### PR TITLE
Fix ai-github-actions workflow references and permissions

### DIFF
--- a/.github/workflows/docs-drift.yml
+++ b/.github/workflows/docs-drift.yml
@@ -11,6 +11,6 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-drift.lock.yml@v0
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@v0
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -4,6 +4,7 @@ on:
     types: [opened]
 
 permissions:
+  actions: read
   contents: read
   discussions: write
   issues: write

--- a/.github/workflows/mention-in-issue.yml
+++ b/.github/workflows/mention-in-issue.yml
@@ -4,6 +4,7 @@ on:
     types: [created]
 
 permissions:
+  actions: read
   contents: write
   discussions: write
   issues: write

--- a/.github/workflows/mention-in-pr.yml
+++ b/.github/workflows/mention-in-pr.yml
@@ -6,6 +6,7 @@ on:
     types: [created]
 
 permissions:
+  actions: read
   contents: write
   discussions: write
   issues: write


### PR DESCRIPTION
## Summary
- Renamed `docs-drift` → `docs-patrol` workflow reference (workflow was renamed upstream)
- Added missing `actions: read` permission to `issue-triage`, `mention-in-issue`, and `mention-in-pr` (required since ai-github-actions v0.2.6)

## Context
Detected by downstream upgrade check: elastic/ai-github-actions-cannon#12

## Test plan
- [ ] Verify docs-patrol workflow runs on schedule
- [ ] Verify issue-triage triggers on new issues
- [ ] Verify mention-in-issue and mention-in-pr respond to `/ai` comments