### PR TITLE
Update unit tests to not assume Linux

### DIFF
--- a/cmd/api_test.go
+++ b/cmd/api_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/elastic/cli/internal/cmdutil"
@@ -17,8 +19,8 @@ func TestRawCmdLookupContextErrors(t *testing.T) {
 	t.Cleanup(func() { rootContext = oldContext })
 
 	t.Run("missing config file returns ErrCodeConfigNotFound", func(t *testing.T) {
-		emptyDir := t.TempDir()
-		t.Setenv("XDG_CONFIG_HOME", emptyDir)
+		configDir := cmdutiltest.InitUserConfigDir(t)
+		os.RemoveAll(filepath.Join(configDir, "elastic"))
 		rootContext = ""
 
 		cmd := newRawCmd("es")

--- a/cmd/es_resources_test.go
+++ b/cmd/es_resources_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"os"
 	"testing"
 
 	"github.com/elastic/cli/internal/cmdutil"
@@ -30,10 +31,12 @@ func TestESListCommandsLookupContextErrors(t *testing.T) {
 		tc := tc
 
 		t.Run(tc.name+"/missing_config_returns_ErrCodeConfigNotFound", func(t *testing.T) {
+			configDir := cmdutiltest.InitUserConfigDir(t)
+			os.RemoveAll(configDir)
+
 			oldCtx := rootContext
 			t.Cleanup(func() { rootContext = oldCtx })
 			rootContext = ""
-			t.Setenv("XDG_CONFIG_HOME", "/nonexistent/xdg/path")
 
 			tc.cmd.SetContext(context.Background())
 			err := tc.cmd.RunE(tc.cmd, nil)


### PR DESCRIPTION
A couple of tests are setting XDG_CONFIG_HOME directly, which is Linux-specific.
We can use cmdutiltest.InitUserConfigDir for portability.