### PR TITLE
Support for JSON output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,88 @@ t.Setenv("ELASTIC_CONFIG", tmpFile)  // auto-restored after the test
 `t.Setenv` sets the variable and restores the original value automatically on cleanup.
 There is no need for a `Env()` / `FakeEnv()` helper or a `getenv func(string) string`
 injection parameter — that is unnecessary indirection in Go.
+
+
+## Go Idioms and Best Practices
+
+### Inject I/O dependencies; never hardcode `os.Stdout` / `os.Stderr` inside logic
+
+Functions that produce output must accept `io.Writer` parameters so callers (and
+tests) can capture or redirect output without mocking the OS. Reserve direct OS
+file references for the thin entry-point wrapper:
+
+```go
+// Good — entry point wires real OS streams
+func Execute() {
+    os.Exit(executeRoot(rootCmd, os.Args[1:], rootCmd.OutOrStdout(), rootCmd.ErrOrStderr()))
+}
+
+// Good — logic is fully testable
+func executeRoot(cmd *cobra.Command, args []string, stdout, stderr io.Writer) int { ... }
+
+// Bad — output is not capturable in tests
+func Execute() {
+    if err := rootCmd.Execute(); err != nil {
+        output.Render(os.Stdout, ...)  // hardcoded; bypasses rootCmd.SetOut
+    }
+}
+```
+
+For Cobra commands, use `cmd.OutOrStdout()` and `cmd.ErrOrStderr()` rather than
+`os.Stdout` / `os.Stderr`. These respect writers configured via `cmd.SetOut` /
+`cmd.SetErr`, which is how tests and embedded use-cases redirect output.
+
+### Use sentinel errors to signal "already handled" across a layer boundary
+
+When a function handles an error itself (e.g. writes a JSON envelope to the user)
+but still needs to signal failure to its caller, returning `nil` is wrong — it
+causes the caller to exit 0. Returning the original error is also wrong — it
+causes the caller to double-print. The right pattern is a package-level sentinel:
+
+```go
+// output package
+var ErrAlreadyRendered = errors.New("error already rendered")
+
+func Render(...) error {
+    // writes JSON envelope ...
+    if cmdErr != nil {
+        return ErrAlreadyRendered  // "I showed the user; you just need to exit non-zero"
+    }
+    return nil
+}
+
+// caller
+if errors.Is(err, output.ErrAlreadyRendered) {
+    return 1  // exit non-zero, print nothing
+}
+```
+
+This pattern keeps the two concerns — user-facing output and process exit code —
+cleanly separated without coupling layers through shared state.
+
+### Keep doc comments accurate as behavior evolves
+
+When implementation changes (e.g. errors are now rendered inside `RunE` rather
+than propagated to Cobra), update the doc comment on the affected function in
+the same commit. A doc comment that contradicts the code is worse than no
+comment: it actively misleads future readers and agents.
+
+Specifically: when a function's error-handling model changes, re-read its doc
+comment and update the description, the enumerated behavior steps, and any
+"not an error" / "error condition" tables.
+
+### Keep spec contracts in sync with code
+
+Contract documents in `specs/*/contracts/` are the authoritative interface
+description for each package. When implementation diverges from a contract
+(different JSON structure, changed error codes, different exit-code behavior),
+update the contract in the same change. Stale contracts cause downstream
+consumers — including other agents — to build against the wrong interface.
+
+### `return nil` after writing an error is an exit-code bug
+
+If a function writes an error response (to a stream, to a log, to a JSON
+envelope) and then returns `nil`, the caller has no signal that anything went
+wrong. In CLI code this manifests as exit code 0 for a failed invocation.
+Always ensure that error paths propagate a non-nil return value — even if the
+error has already been presented to the user.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	apperrors "github.com/elastic/cli/internal/errors"
 	"github.com/elastic/cli/internal/factory"
@@ -53,8 +55,13 @@ func Execute() {
 // routed to the appropriate output channel based on the --format flag.
 func executeRoot(cmd *cobra.Command, args []string, stdout, stderr io.Writer) int {
 	if err := cmd.Execute(); err != nil {
+		if errors.Is(err, output.ErrAlreadyRendered) {
+			// The error was already written as a JSON envelope to stdout by the
+			// factory's RunE; just exit non-zero without printing anything else.
+			return 1
+		}
 		if isJSONFormat(cmd, args) {
-			_ = output.Render(stdout, output.FormatJSON, nil, &apperrors.CommandError{Cause: err})
+			_ = output.Render(stdout, output.FormatJSON, nil, classifyCobraError(err))
 		} else {
 			fmt.Fprintf(stderr, "Error: %s\n", err)
 		}
@@ -84,4 +91,32 @@ func isJSONFormat(cmd *cobra.Command, rawArgs []string) bool {
 		}
 	}
 	return false
+}
+
+// classifyCobraError converts an error from cmd.Execute() into a typed
+// output.OutputError so the JSON envelope carries an accurate error code.
+//
+// Priority:
+//  1. Errors that already implement output.OutputError are passed through as-is.
+//  2. Cobra "unknown command" errors → unknown_command.
+//  3. pflag flag errors (unknown flag, bad syntax, etc.) → invalid_argument.
+//  4. Everything else → command_failed.
+func classifyCobraError(err error) output.OutputError {
+	var outErr output.OutputError
+	if errors.As(err, &outErr) {
+		return outErr
+	}
+	msg := err.Error()
+	if strings.HasPrefix(msg, "unknown command") {
+		return &apperrors.UnknownCommandError{Cause: err}
+	}
+	if strings.HasPrefix(msg, "unknown flag") ||
+		strings.HasPrefix(msg, "unknown shorthand flag") ||
+		strings.HasPrefix(msg, "bad flag syntax") ||
+		strings.HasPrefix(msg, "flag needs an argument") ||
+		strings.HasPrefix(msg, "invalid argument") ||
+		strings.HasPrefix(msg, "required flag") {
+		return &apperrors.InvalidArgumentError{Cause: err}
+	}
+	return &apperrors.CommandError{Cause: err}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	apperrors "github.com/elastic/cli/internal/errors"
 	"github.com/elastic/cli/internal/factory"
+	"github.com/elastic/cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -29,10 +31,27 @@ func init() {
 	}))
 }
 
-// Execute runs the root command and writes any error to stderr.
+// Execute runs the root command. Errors from factory commands are handled
+// inside RunE via output.Render. Cobra-level errors (unknown commands, flag
+// parse failures) are caught here and routed to the appropriate output channel.
+//
+// Output formatting (JSON envelope serialization) currently lives in
+// factory.New's RunE rather than in a PersistentPostRunE hook on rootCmd.
+// PersistentPostRunE would be the more Cobra-idiomatic location, but Cobra
+// provides no first-class mechanism to pass the handler's return value from
+// RunE into PostRunE — doing so would require threading data through
+// cmd.SetContext, which adds complexity with no benefit at the current scale.
+// If per-command middleware (tracing, audit logging) is needed in the future,
+// migrating to a context-passing + PersistentPostRunE pattern is the right move.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		// Cobra-level error (e.g. unknown command). Check --format to decide
+		// whether to write a JSON envelope to stdout or plain text to stderr.
+		if f := rootCmd.PersistentFlags().Lookup("format"); f != nil && f.Value.String() == output.FormatJSON {
+			_ = output.Render(os.Stdout, output.FormatJSON, nil, &apperrors.CommandError{Cause: err})
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		}
 		os.Exit(1)
 	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,7 @@ func init() {
 // If per-command middleware (tracing, audit logging) is needed in the future,
 // migrating to a context-passing + PersistentPostRunE pattern is the right move.
 func Execute() {
-	os.Exit(executeRoot(rootCmd, os.Args[1:], os.Stdout, os.Stderr))
+	os.Exit(executeRoot(rootCmd, os.Args[1:], rootCmd.OutOrStdout(), rootCmd.ErrOrStderr()))
 }
 
 // executeRoot runs the given command and returns an exit code.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,9 +23,9 @@ var rootCmd = &cobra.Command{
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&contextFlag, "context", "", "Context to use for this command")
-	rootCmd.AddCommand(factory.New("version", "Print version info", func(ctx factory.RunContext) error {
-		fmt.Fprintln(os.Stdout, "elastic version dev")
-		return nil
+	rootCmd.PersistentFlags().String("format", "text", "Output format (text|json)")
+	rootCmd.AddCommand(factory.New("version", "Print version info", func(ctx factory.RunContext) (any, error) {
+		return "elastic version dev", nil
 	}))
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 
 	apperrors "github.com/elastic/cli/internal/errors"
@@ -44,14 +45,43 @@ func init() {
 // If per-command middleware (tracing, audit logging) is needed in the future,
 // migrating to a context-passing + PersistentPostRunE pattern is the right move.
 func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		// Cobra-level error (e.g. unknown command). Check --format to decide
-		// whether to write a JSON envelope to stdout or plain text to stderr.
-		if f := rootCmd.PersistentFlags().Lookup("format"); f != nil && f.Value.String() == output.FormatJSON {
-			_ = output.Render(os.Stdout, output.FormatJSON, nil, &apperrors.CommandError{Cause: err})
+	os.Exit(executeRoot(rootCmd, os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// executeRoot runs the given command and returns an exit code.
+// Cobra-level errors (unknown command, flag parse failures) are caught and
+// routed to the appropriate output channel based on the --format flag.
+func executeRoot(cmd *cobra.Command, args []string, stdout, stderr io.Writer) int {
+	if err := cmd.Execute(); err != nil {
+		if isJSONFormat(cmd, args) {
+			_ = output.Render(stdout, output.FormatJSON, nil, &apperrors.CommandError{Cause: err})
 		} else {
-			fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+			fmt.Fprintf(stderr, "Error: %s\n", err)
 		}
-		os.Exit(1)
+		return 1
 	}
+	return 0
+}
+
+// isJSONFormat checks whether --format=json was requested. It first tries the
+// parsed flag value, then falls back to scanning raw args because Cobra skips
+// flag parsing on certain errors (e.g. unknown command).
+func isJSONFormat(cmd *cobra.Command, rawArgs []string) bool {
+	if f := cmd.PersistentFlags().Lookup("format"); f != nil && f.Changed {
+		return f.Value.String() == output.FormatJSON
+	}
+	// Cobra skips flag parsing on certain errors (e.g. unknown command), so
+	// the flag value may still be the default. Scan the raw args as a fallback.
+	for i, arg := range rawArgs {
+		if arg == "--format=json" {
+			return true
+		}
+		if arg == "--format" && i+1 < len(rawArgs) && rawArgs[i+1] == "json" {
+			return true
+		}
+		if arg == "--" {
+			break
+		}
+	}
+	return false
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -79,8 +79,9 @@ func TestRootCmd_FormatFlag(t *testing.T) {
 	}
 }
 
-// Execute() with --format=json and a failing command writes JSON error
-// envelope to stdout instead of plain text to stderr.
+// Factory-level error with --format=json renders a JSON error envelope via
+// output.Render inside RunE (the factory swallows the error, returning nil to
+// Cobra). This does NOT exercise the cmd.Execute() wrapper's error path.
 func TestRootCmd_FormatJSON_FailingCommand_WritesJSONToStdout(t *testing.T) {
 	yaml := `
 current_context: prod
@@ -107,7 +108,7 @@ contexts:
 
 	err := rootCmd.Execute()
 	if err != nil {
-		t.Fatalf("expected nil error (handled by Render), got: %v", err)
+		t.Fatalf("expected nil error (factory handles JSON rendering), got: %v", err)
 	}
 
 	out := outBuf.String()
@@ -141,5 +142,80 @@ func TestRootCmd_VersionHelp_ContainsFormatFlag(t *testing.T) {
 
 	if !strings.Contains(buf.String(), "--format") {
 		t.Errorf("help output missing --format; got:\n%s", buf.String())
+	}
+}
+
+// executeRoot with --format=json and a Cobra-level error (unknown command)
+// writes a JSON error envelope to stdout and returns exit code 1.
+func TestExecuteRoot_CobraError_FormatJSON_WritesJSONToStdout(t *testing.T) {
+	args := []string{"--format=json", "nonexistent-command"}
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+
+	var stdout, stderr strings.Builder
+	code := executeRoot(rootCmd, args, &stdout, &stderr)
+
+	if code != 1 {
+		t.Errorf("exit code = %d; want 1", code)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, `"error"`) {
+		t.Errorf("stdout missing 'error' key: %q", out)
+	}
+	if !strings.Contains(out, "command_failed") {
+		t.Errorf("stdout missing 'command_failed' code: %q", out)
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("stderr should be empty in JSON mode, got: %q", stderr.String())
+	}
+}
+
+// executeRoot with text format and a Cobra-level error writes plain text to
+// stderr and returns exit code 1.
+func TestExecuteRoot_CobraError_FormatText_WritesToStderr(t *testing.T) {
+	args := []string{"nonexistent-command"}
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+
+	var stdout, stderr strings.Builder
+	code := executeRoot(rootCmd, args, &stdout, &stderr)
+
+	if code != 1 {
+		t.Errorf("exit code = %d; want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "Error:") {
+		t.Errorf("stderr missing 'Error:' prefix: %q", stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("stdout should be empty in text mode, got: %q", stdout.String())
+	}
+}
+
+// executeRoot returns 0 when the command succeeds.
+func TestExecuteRoot_Success_ReturnsZero(t *testing.T) {
+	yaml := `
+current_context: prod
+contexts:
+  prod:
+    elasticsearch:
+      url: https://prod.es.io
+`
+	configPath := cmdtest.TempConfigFile(t, []byte(yaml))
+	t.Setenv("ELASTIC_CONFIG", configPath)
+
+	args := []string{"version"}
+	rootCmd.SetArgs(args)
+	var stdout strings.Builder
+	rootCmd.SetOut(&stdout)
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+	})
+
+	var devnull strings.Builder
+	code := executeRoot(rootCmd, args, &devnull, &devnull)
+
+	if code != 0 {
+		t.Errorf("exit code = %d; want 0", code)
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -72,3 +72,9 @@ contexts:
 		t.Errorf("error %q should contain 'not found'", err.Error())
 	}
 }
+
+func TestRootCmd_FormatFlag(t *testing.T) {
+	if rootCmd.PersistentFlags().Lookup("format") == nil {
+		t.Error("--format persistent flag not registered on rootCmd")
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/elastic/cli/cmd/cmdtest"
+	apperrors "github.com/elastic/cli/internal/errors"
+	"github.com/elastic/cli/internal/output"
 )
 
 func TestRootCmd_UseAndShort(t *testing.T) {
@@ -107,8 +111,8 @@ contexts:
 	rootCmd.SetOut(&outBuf)
 
 	err := rootCmd.Execute()
-	if err != nil {
-		t.Fatalf("expected nil error (factory handles JSON rendering), got: %v", err)
+	if !errors.Is(err, output.ErrAlreadyRendered) {
+		t.Fatalf("expected ErrAlreadyRendered, got: %v", err)
 	}
 
 	out := outBuf.String()
@@ -162,8 +166,8 @@ func TestExecuteRoot_CobraError_FormatJSON_WritesJSONToStdout(t *testing.T) {
 	if !strings.Contains(out, `"error"`) {
 		t.Errorf("stdout missing 'error' key: %q", out)
 	}
-	if !strings.Contains(out, "command_failed") {
-		t.Errorf("stdout missing 'command_failed' code: %q", out)
+	if !strings.Contains(out, "unknown_command") {
+		t.Errorf("stdout missing 'unknown_command' code: %q", out)
 	}
 	if stderr.Len() != 0 {
 		t.Errorf("stderr should be empty in JSON mode, got: %q", stderr.String())
@@ -217,5 +221,45 @@ contexts:
 
 	if code != 0 {
 		t.Errorf("exit code = %d; want 0", code)
+	}
+}
+
+// classifyCobraError passes through errors that already implement
+// output.OutputError instead of re-wrapping them.
+func TestClassifyCobraError_OutputError_PassesThrough(t *testing.T) {
+	original := &apperrors.ContextNotFoundError{Name: "prod", Available: []string{"dev"}}
+	got := classifyCobraError(original)
+	if got != original {
+		t.Errorf("expected same pointer; got %T %v", got, got)
+	}
+	if got.ErrorCode() != "context_not_found" {
+		t.Errorf("ErrorCode() = %q; want %q", got.ErrorCode(), "context_not_found")
+	}
+}
+
+// classifyCobraError maps Cobra "unknown command" errors to unknown_command.
+func TestClassifyCobraError_UnknownCommand(t *testing.T) {
+	err := fmt.Errorf(`unknown command "bogus" for "elastic"`)
+	got := classifyCobraError(err)
+	if got.ErrorCode() != "unknown_command" {
+		t.Errorf("ErrorCode() = %q; want %q", got.ErrorCode(), "unknown_command")
+	}
+}
+
+// classifyCobraError maps pflag "unknown flag" errors to invalid_argument.
+func TestClassifyCobraError_UnknownFlag(t *testing.T) {
+	err := fmt.Errorf("unknown flag: --bogus")
+	got := classifyCobraError(err)
+	if got.ErrorCode() != "invalid_argument" {
+		t.Errorf("ErrorCode() = %q; want %q", got.ErrorCode(), "invalid_argument")
+	}
+}
+
+// classifyCobraError maps unrecognised errors to command_failed.
+func TestClassifyCobraError_FallbackCommandFailed(t *testing.T) {
+	err := fmt.Errorf("some internal cobra error")
+	got := classifyCobraError(err)
+	if got.ErrorCode() != "command_failed" {
+		t.Errorf("ErrorCode() = %q; want %q", got.ErrorCode(), "command_failed")
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -118,3 +118,28 @@ contexts:
 		t.Errorf("stdout missing 'context_not_found': %q", out)
 	}
 }
+
+// every registered subcommand inherits --format persistent flag via root.
+func TestRootCmd_AllSubcommands_InheritFormatFlag(t *testing.T) {
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Root().PersistentFlags().Lookup("format") == nil {
+			t.Errorf("subcommand %q: --format persistent flag not found on root", cmd.Use)
+		}
+	}
+}
+
+// --help output contains --format.
+func TestRootCmd_VersionHelp_ContainsFormatFlag(t *testing.T) {
+	var buf strings.Builder
+	rootCmd.SetOut(&buf)
+	t.Cleanup(func() { rootCmd.SetOut(nil) })
+
+	rootCmd.SetArgs([]string{"version", "--help"})
+	t.Cleanup(func() { rootCmd.SetArgs(nil) })
+
+	_ = rootCmd.Execute()
+
+	if !strings.Contains(buf.String(), "--format") {
+		t.Errorf("help output missing --format; got:\n%s", buf.String())
+	}
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -78,3 +78,43 @@ func TestRootCmd_FormatFlag(t *testing.T) {
 		t.Error("--format persistent flag not registered on rootCmd")
 	}
 }
+
+// Execute() with --format=json and a failing command writes JSON error
+// envelope to stdout instead of plain text to stderr.
+func TestRootCmd_FormatJSON_FailingCommand_WritesJSONToStdout(t *testing.T) {
+	yaml := `
+current_context: prod
+contexts:
+  prod:
+    elasticsearch:
+      url: https://prod.es.io
+`
+	configPath := cmdtest.TempConfigFile(t, []byte(yaml))
+	t.Setenv("ELASTIC_CONFIG", configPath)
+
+	rootCmd.SetArgs([]string{"version", "--format=json", "--context=bogus"})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.ResetFlags()
+		// Re-register flags after reset.
+		rootCmd.PersistentFlags().StringVar(&contextFlag, "context", "", "Context to use for this command")
+		rootCmd.PersistentFlags().String("format", "text", "Output format (text|json)")
+	})
+
+	var outBuf strings.Builder
+	rootCmd.SetOut(&outBuf)
+
+	err := rootCmd.Execute()
+	if err != nil {
+		t.Fatalf("expected nil error (handled by Render), got: %v", err)
+	}
+
+	out := outBuf.String()
+	if !strings.Contains(out, `"error"`) {
+		t.Errorf("stdout missing 'error' key: %q", out)
+	}
+	if !strings.Contains(out, "context_not_found") {
+		t.Errorf("stdout missing 'context_not_found': %q", out)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@ module github.com/elastic/cli
 go 1.25.3
 
 require (
+	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.10.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,7 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -59,6 +59,16 @@ type CommandError struct {
 	Cause error
 }
 
+// UnknownCommandError is returned when a Cobra-level unknown-command error
+// occurs (e.g. the user typed a subcommand that does not exist).
+type UnknownCommandError struct {
+	Cause error
+}
+
+func (e *UnknownCommandError) Error() string     { return e.Cause.Error() }
+func (e *UnknownCommandError) ErrorCode() string { return "unknown_command" }
+func (e *UnknownCommandError) Unwrap() error     { return e.Cause }
+
 func (e *CommandError) Error() string     { return e.Cause.Error() }
 func (e *CommandError) ErrorCode() string { return "command_failed" }
 func (e *CommandError) Unwrap() error     { return e.Cause }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,64 @@
+// Package errors defines the typed error values used throughout the CLI.
+// Each type implements output.OutputError, carrying a static machine-readable
+// code alongside any domain-specific fields. Use errors.As to inspect errors
+// returned from CLI commands.
+package errors
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ConfigError is returned when the config file cannot be read or parsed.
+type ConfigError struct {
+	Cause error
+}
+
+func (e *ConfigError) Error() string     { return e.Cause.Error() }
+func (e *ConfigError) ErrorCode() string { return "config_error" }
+func (e *ConfigError) Unwrap() error     { return e.Cause }
+
+// ContextNotFoundError is returned when --context names an unknown context.
+type ContextNotFoundError struct {
+	Name      string
+	Available []string // sorted list of configured context names
+}
+
+func (e *ContextNotFoundError) Error() string {
+	if len(e.Available) == 0 {
+		return fmt.Sprintf("context %q not found; no contexts are configured", e.Name)
+	}
+	return fmt.Sprintf("context %q not found; available: %s", e.Name, strings.Join(e.Available, ", "))
+}
+
+func (e *ContextNotFoundError) ErrorCode() string { return "context_not_found" }
+
+// InputError is returned when a --file or stdin read fails, or both are
+// provided simultaneously.
+type InputError struct {
+	Cause error
+}
+
+func (e *InputError) Error() string     { return e.Cause.Error() }
+func (e *InputError) ErrorCode() string { return "input_error" }
+func (e *InputError) Unwrap() error     { return e.Cause }
+
+// InvalidArgumentError is returned when a flag value is not supported (e.g.
+// an unrecognised --format value).
+type InvalidArgumentError struct {
+	Cause error
+}
+
+func (e *InvalidArgumentError) Error() string     { return e.Cause.Error() }
+func (e *InvalidArgumentError) ErrorCode() string { return "invalid_argument" }
+func (e *InvalidArgumentError) Unwrap() error     { return e.Cause }
+
+// CommandError wraps a generic handler error when no more specific type
+// applies.
+type CommandError struct {
+	Cause error
+}
+
+func (e *CommandError) Error() string     { return e.Cause.Error() }
+func (e *CommandError) ErrorCode() string { return "command_failed" }
+func (e *CommandError) Unwrap() error     { return e.Cause }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -80,6 +80,21 @@ func TestCommandError(t *testing.T) {
 	}
 }
 
+func TestUnknownCommandError(t *testing.T) {
+	cause := fmt.Errorf(`unknown command "bogus" for "elastic"`)
+	err := &apperrors.UnknownCommandError{Cause: cause}
+
+	if err.ErrorCode() != "unknown_command" {
+		t.Errorf("ErrorCode(): got %q, want %q", err.ErrorCode(), "unknown_command")
+	}
+	if err.Error() != cause.Error() {
+		t.Errorf("Error(): got %q, want %q", err.Error(), cause.Error())
+	}
+	if !errors.Is(err, cause) {
+		t.Error("errors.Is: cause should be reachable via Unwrap")
+	}
+}
+
 // ErrorCode() is defined on all types, satisfying output.OutputError implicitly.
 // This compile-time assertion verifies each type satisfies the interface without
 // importing the output package (interfaces are satisfied implicitly in Go).
@@ -94,4 +109,5 @@ func TestAllTypesImplementOutputError(t *testing.T) {
 	var _ outputError = &apperrors.InputError{}
 	var _ outputError = &apperrors.InvalidArgumentError{}
 	var _ outputError = &apperrors.CommandError{}
+	var _ outputError = &apperrors.UnknownCommandError{}
 }

--- a/internal/errors/errors_test.go
+++ b/internal/errors/errors_test.go
@@ -1,0 +1,97 @@
+package errors_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	apperrors "github.com/elastic/cli/internal/errors"
+)
+
+func TestConfigError(t *testing.T) {
+	cause := fmt.Errorf("open /etc/config.yml: permission denied")
+	err := &apperrors.ConfigError{Cause: cause}
+
+	if err.ErrorCode() != "config_error" {
+		t.Errorf("ErrorCode: got %q, want %q", err.ErrorCode(), "config_error")
+	}
+	if err.Error() != cause.Error() {
+		t.Errorf("Error(): got %q, want %q", err.Error(), cause.Error())
+	}
+	if !errors.Is(err, cause) {
+		t.Error("errors.Is: cause should be reachable via Unwrap")
+	}
+}
+
+func TestContextNotFoundError_WithAvailable(t *testing.T) {
+	err := &apperrors.ContextNotFoundError{Name: "bogus", Available: []string{"prod", "staging"}}
+
+	if err.ErrorCode() != "context_not_found" {
+		t.Errorf("ErrorCode: got %q, want %q", err.ErrorCode(), "context_not_found")
+	}
+	msg := err.Error()
+	if msg != `context "bogus" not found; available: prod, staging` {
+		t.Errorf("Error(): got %q", msg)
+	}
+}
+
+func TestContextNotFoundError_NoAvailable(t *testing.T) {
+	err := &apperrors.ContextNotFoundError{Name: "bogus"}
+
+	msg := err.Error()
+	if msg != `context "bogus" not found; no contexts are configured` {
+		t.Errorf("Error(): got %q", msg)
+	}
+}
+
+func TestInputError(t *testing.T) {
+	cause := fmt.Errorf("read stdin: unexpected EOF")
+	err := &apperrors.InputError{Cause: cause}
+
+	if err.ErrorCode() != "input_error" {
+		t.Errorf("ErrorCode: got %q, want %q", err.ErrorCode(), "input_error")
+	}
+	if !errors.Is(err, cause) {
+		t.Error("errors.Is: cause should be reachable via Unwrap")
+	}
+}
+
+func TestInvalidArgumentError(t *testing.T) {
+	cause := fmt.Errorf(`unsupported format "xml"`)
+	err := &apperrors.InvalidArgumentError{Cause: cause}
+
+	if err.ErrorCode() != "invalid_argument" {
+		t.Errorf("ErrorCode: got %q, want %q", err.ErrorCode(), "invalid_argument")
+	}
+	if !errors.Is(err, cause) {
+		t.Error("errors.Is: cause should be reachable via Unwrap")
+	}
+}
+
+func TestCommandError(t *testing.T) {
+	cause := fmt.Errorf("something went wrong")
+	err := &apperrors.CommandError{Cause: cause}
+
+	if err.ErrorCode() != "command_failed" {
+		t.Errorf("ErrorCode: got %q, want %q", err.ErrorCode(), "command_failed")
+	}
+	if !errors.Is(err, cause) {
+		t.Error("errors.Is: cause should be reachable via Unwrap")
+	}
+}
+
+// ErrorCode() is defined on all types, satisfying output.OutputError implicitly.
+// This compile-time assertion verifies each type satisfies the interface without
+// importing the output package (interfaces are satisfied implicitly in Go).
+type outputError interface {
+	error
+	ErrorCode() string
+}
+
+func TestAllTypesImplementOutputError(t *testing.T) {
+	var _ outputError = &apperrors.ConfigError{}
+	var _ outputError = &apperrors.ContextNotFoundError{}
+	var _ outputError = &apperrors.InputError{}
+	var _ outputError = &apperrors.InvalidArgumentError{}
+	var _ outputError = &apperrors.CommandError{}
+}

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -7,13 +7,15 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/elastic/cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
 // RunFunc is the handler type that every subcommand implements.
 // The factory calls it after fully populating RunContext.
-// A non-nil return value propagates to Cobra as a command error.
-type RunFunc func(ctx RunContext) error
+// The first return value is the data payload written to output; the second is
+// any error that occurred. Both nil is valid (produces a null data envelope).
+type RunFunc func(ctx RunContext) (any, error)
 
 // RunContext is the per-invocation execution context passed to every handler.
 type RunContext struct {
@@ -95,7 +97,20 @@ func New(name, description string, run RunFunc) *cobra.Command {
 				ActiveContext: activeContext,
 				Body:          body,
 			}
-			return run(ctx)
+
+			// Resolve output format from root persistent flags.
+			format := output.FormatText
+			if f := cmd.Root().PersistentFlags().Lookup("format"); f != nil {
+				if v := f.Value.String(); v != "" {
+					if err := output.ValidateFormat(v); err != nil {
+						return output.Render(cmd.OutOrStdout(), output.FormatJSON, nil, fmt.Errorf("unsupported format %q: supported values are %q and %q", v, output.FormatText, output.FormatJSON))
+					}
+					format = v
+				}
+			}
+
+			data, runErr := run(ctx)
+			return output.Render(cmd.OutOrStdout(), format, data, runErr)
 		},
 	}
 	cmd.Flags().String("file", "", "Path to an input JSON file")

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -45,13 +45,16 @@ type RunContext struct {
 //     A missing file is not an error — a zero-value Config is used instead.
 //  3. Resolves ActiveContext from the --context persistent flag (if set and
 //     non-empty) or falls back to Config.CurrentContext.
-//  4. Returns an error if --context names a context that does not exist.
+//  4. Renders a context_not_found error envelope if --context names an unknown context.
 //  5. Reads the request body from --file or piped stdin (see readBody).
-//  6. Returns an error if both --file and piped stdin provide data simultaneously.
+//  6. Renders an input_error envelope if both --file and piped stdin provide data.
 //  7. Calls run with the fully populated RunContext.
 //
-// All errors are returned to Cobra and written to stderr by the root command;
-// no os.Exit is called inside this package.
+// All errors (config, context, input, and RunFunc errors) are handled inside
+// RunE via output.Render and written to cmd.OutOrStdout(). In JSON mode Render
+// writes the error envelope and returns nil, so Cobra never sees the error. In
+// text mode Render returns the error so that executeRoot can write it to stderr.
+// No os.Exit calls appear inside this package.
 func New(name, description string, run RunFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   name,

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"os"
 	"sort"
-	"strings"
 
+	apperrors "github.com/elastic/cli/internal/errors"
 	"github.com/elastic/cli/internal/output"
 	"github.com/spf13/cobra"
 )
@@ -57,14 +57,26 @@ func New(name, description string, run RunFunc) *cobra.Command {
 		Use:   name,
 		Short: description,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Resolve output format first so ALL errors can be routed through Render.
+			format := output.FormatText
+			if f := cmd.Root().PersistentFlags().Lookup("format"); f != nil {
+				if v := f.Value.String(); v != "" {
+					if err := output.ValidateFormat(v); err != nil {
+						return output.Render(cmd.OutOrStdout(), output.FormatJSON, nil,
+							&apperrors.InvalidArgumentError{Cause: fmt.Errorf("unsupported format %q: supported values are %q and %q", v, output.FormatText, output.FormatJSON)})
+					}
+					format = v
+				}
+			}
+
 			path, err := resolveConfigPath()
 			if err != nil {
-				return err
+				return output.Render(cmd.OutOrStdout(), format, nil, &apperrors.ConfigError{Cause: err})
 			}
 
 			cfg, err := Load(path)
 			if err != nil {
-				return err
+				return output.Render(cmd.OutOrStdout(), format, nil, &apperrors.ConfigError{Cause: err})
 			}
 
 			// ConfigPath is empty when the file was not found (defaults in use).
@@ -80,7 +92,12 @@ func New(name, description string, run RunFunc) *cobra.Command {
 			if f := cmd.Root().PersistentFlags().Lookup("context"); f != nil {
 				if contextName := f.Value.String(); contextName != "" {
 					if _, ok := cfg.Contexts[contextName]; !ok {
-						return contextNotFoundError(contextName, cfg.Contexts)
+						keys := make([]string, 0, len(cfg.Contexts))
+						for k := range cfg.Contexts {
+							keys = append(keys, k)
+						}
+						sort.Strings(keys)
+						return output.Render(cmd.OutOrStdout(), format, nil, &apperrors.ContextNotFoundError{Name: contextName, Available: keys})
 					}
 					activeContext = contextName
 				}
@@ -88,7 +105,7 @@ func New(name, description string, run RunFunc) *cobra.Command {
 
 			body, err := readBody(cmd)
 			if err != nil {
-				return err
+				return output.Render(cmd.OutOrStdout(), format, nil, &apperrors.InputError{Cause: err})
 			}
 
 			ctx := RunContext{
@@ -98,19 +115,12 @@ func New(name, description string, run RunFunc) *cobra.Command {
 				Body:          body,
 			}
 
-			// Resolve output format from root persistent flags.
-			format := output.FormatText
-			if f := cmd.Root().PersistentFlags().Lookup("format"); f != nil {
-				if v := f.Value.String(); v != "" {
-					if err := output.ValidateFormat(v); err != nil {
-						return output.Render(cmd.OutOrStdout(), output.FormatJSON, nil, fmt.Errorf("unsupported format %q: supported values are %q and %q", v, output.FormatText, output.FormatJSON))
-					}
-					format = v
-				}
-			}
-
 			data, runErr := run(ctx)
-			return output.Render(cmd.OutOrStdout(), format, data, runErr)
+			var outErr output.OutputError
+			if runErr != nil {
+				outErr = &apperrors.CommandError{Cause: runErr}
+			}
+			return output.Render(cmd.OutOrStdout(), format, data, outErr)
 		},
 	}
 	cmd.Flags().String("file", "", "Path to an input JSON file")
@@ -182,15 +192,3 @@ func isReaderTTY(r io.Reader) bool {
 	return (info.Mode() & os.ModeCharDevice) != 0
 }
 
-// contextNotFoundError builds a descriptive error for an unknown context name.
-func contextNotFoundError(name string, contexts map[string]Context) error {
-	if len(contexts) == 0 {
-		return fmt.Errorf("context %q not found; no contexts are configured", name)
-	}
-	keys := make([]string, 0, len(contexts))
-	for k := range contexts {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return fmt.Errorf("context %q not found; available: %s", name, strings.Join(keys, ", "))
-}

--- a/internal/factory/factory.go
+++ b/internal/factory/factory.go
@@ -194,4 +194,3 @@ func isReaderTTY(r io.Reader) bool {
 	}
 	return (info.Mode() & os.ModeCharDevice) != 0
 }
-

--- a/internal/factory/factory_test.go
+++ b/internal/factory/factory_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/elastic/cli/internal/factory/factorytest"
+	"github.com/elastic/cli/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -779,8 +780,8 @@ func TestNew_FormatJSON_HandlerError_ProducesErrorEnvelope(t *testing.T) {
 	})
 
 	stdout, _, err := executeCmdCaptureWithStderr(t, cmd, "--format=json")
-	if err != nil {
-		t.Fatalf("unexpected RunE error: %v", err)
+	if !errors.Is(err, output.ErrAlreadyRendered) {
+		t.Fatalf("expected ErrAlreadyRendered, got: %v", err)
 	}
 	var env map[string]any
 	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); jsonErr != nil {
@@ -810,8 +811,8 @@ func TestNew_FormatJSON_HandlerError_NoStderr(t *testing.T) {
 	})
 
 	_, stderr, err := executeCmdCaptureWithStderr(t, cmd, "--format=json")
-	if err != nil {
-		t.Fatalf("unexpected RunE error: %v", err)
+	if !errors.Is(err, output.ErrAlreadyRendered) {
+		t.Fatalf("expected ErrAlreadyRendered, got: %v", err)
 	}
 	if stderr != "" {
 		t.Errorf("stderr: got %q, want empty", stderr)
@@ -851,8 +852,8 @@ func TestNew_FormatJSON_ConfigError_ProducesConfigErrorCode(t *testing.T) {
 	})
 
 	stdout, _, err := executeCmdCaptureWithStderr(t, cmd, "--format=json")
-	if err != nil {
-		t.Fatalf("unexpected RunE error: %v", err)
+	if !errors.Is(err, output.ErrAlreadyRendered) {
+		t.Fatalf("expected ErrAlreadyRendered, got: %v", err)
 	}
 	var env map[string]any
 	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); jsonErr != nil {
@@ -885,8 +886,8 @@ contexts:
 	})
 
 	stdout, _, err := executeCmdCaptureWithStderr(t, cmd, "--format=json", "--context=bogus")
-	if err != nil {
-		t.Fatalf("unexpected RunE error: %v", err)
+	if !errors.Is(err, output.ErrAlreadyRendered) {
+		t.Fatalf("expected ErrAlreadyRendered, got: %v", err)
 	}
 	var env map[string]any
 	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); jsonErr != nil {
@@ -910,8 +911,8 @@ func TestNew_FormatXML_ProducesInvalidArgumentCode(t *testing.T) {
 	})
 
 	stdout, _, err := executeCmdCaptureWithStderr(t, cmd, "--format=xml")
-	if err != nil {
-		t.Fatalf("unexpected RunE error: %v", err)
+	if !errors.Is(err, output.ErrAlreadyRendered) {
+		t.Fatalf("expected ErrAlreadyRendered, got: %v", err)
 	}
 	var env map[string]any
 	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); jsonErr != nil {

--- a/internal/factory/factory_test.go
+++ b/internal/factory/factory_test.go
@@ -928,3 +928,88 @@ func TestNew_FormatXML_ProducesInvalidArgumentCode(t *testing.T) {
 		t.Errorf("error.message: got %v, want to mention supported values", errObj["message"])
 	}
 }
+
+// command with --format=json returning nil data produces
+// {"data":null,"error":null,"warnings":[]}.
+func TestNew_FormatJSON_NilData_ProducesValidEnvelope(t *testing.T) {
+	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte(`
+current_context: test
+contexts:
+  test:
+    elasticsearch:
+      url: http://localhost:9200
+`)))
+
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
+		return nil, nil
+	})
+
+	stdout, _, err := executeCmdCaptureWithStderr(t, cmd, "--format=json")
+	if err != nil {
+		t.Fatalf("unexpected RunE error: %v", err)
+	}
+	var env map[string]any
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); jsonErr != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", jsonErr, stdout)
+	}
+	if env["data"] != nil {
+		t.Errorf("data: got %v, want nil/null", env["data"])
+	}
+	if env["error"] != nil {
+		t.Errorf("error: got %v, want nil/null", env["error"])
+	}
+	warnings, ok := env["warnings"]
+	if !ok {
+		t.Fatal("warnings key missing from envelope")
+	}
+	warningSlice, ok := warnings.([]any)
+	if !ok {
+		t.Fatalf("warnings: got %T, want []", warnings)
+	}
+	if len(warningSlice) != 0 {
+		t.Errorf("warnings: got %v, want []", warningSlice)
+	}
+}
+
+// command returning a map as data with no error produces a correct
+// JSON envelope (FR-007 — no-output commands still emit valid envelopes).
+func TestNew_FormatJSON_MapData_ProducesCorrectEnvelope(t *testing.T) {
+	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte(`
+current_context: test
+contexts:
+  test:
+    elasticsearch:
+      url: http://localhost:9200
+`)))
+
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
+		return map[string]string{"status": "ok"}, nil
+	})
+
+	stdout, _, err := executeCmdCaptureWithStderr(t, cmd, "--format=json")
+	if err != nil {
+		t.Fatalf("unexpected RunE error: %v", err)
+	}
+
+	var env map[string]any
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); jsonErr != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", jsonErr, stdout)
+	}
+	if env["error"] != nil {
+		t.Errorf("error: got %v, want nil", env["error"])
+	}
+	data, ok := env["data"].(map[string]any)
+	if !ok {
+		t.Fatalf("data: got %T (%v), want map", env["data"], env["data"])
+	}
+	if data["status"] != "ok" {
+		t.Errorf("data.status: got %v, want %q", data["status"], "ok")
+	}
+	warnings, ok := env["warnings"].([]any)
+	if !ok {
+		t.Fatalf("warnings should be [] not null; got %v", env["warnings"])
+	}
+	if len(warnings) != 0 {
+		t.Errorf("warnings: got %v, want []", warnings)
+	}
+}

--- a/internal/factory/factory_test.go
+++ b/internal/factory/factory_test.go
@@ -28,14 +28,14 @@ func executeCmd(t *testing.T, sub *cobra.Command, args ...string) error {
 // ---- New() command fields ---------------------------------------------------
 
 func TestNew_Use(t *testing.T) {
-	cmd := New("my-cmd", "short desc", func(ctx RunContext) error { return nil })
+	cmd := New("my-cmd", "short desc", func(ctx RunContext) (any, error) { return nil, nil })
 	if cmd.Use != "my-cmd" {
 		t.Errorf("Use: got %q, want %q", cmd.Use, "my-cmd")
 	}
 }
 
 func TestNew_Short(t *testing.T) {
-	cmd := New("my-cmd", "short desc", func(ctx RunContext) error { return nil })
+	cmd := New("my-cmd", "short desc", func(ctx RunContext) (any, error) { return nil, nil })
 	if cmd.Short != "short desc" {
 		t.Errorf("Short: got %q, want %q", cmd.Short, "short desc")
 	}
@@ -55,9 +55,9 @@ contexts:
 	t.Setenv("ELASTIC_CONFIG", configPath)
 
 	callCount := 0
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		callCount++
-		return nil
+		return nil, nil
 	})
 
 	if err := executeCmd(t, cmd); err != nil {
@@ -84,9 +84,9 @@ contexts:
 	t.Setenv("ELASTIC_CONFIG", configPath)
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		received = ctx
-		return nil
+		return nil, nil
 	})
 
 	if err := executeCmd(t, cmd); err != nil {
@@ -112,9 +112,9 @@ func TestNew_RunContextConfigPath(t *testing.T) {
 	t.Setenv("ELASTIC_CONFIG", configPath)
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		received = ctx
-		return nil
+		return nil, nil
 	})
 
 	if err := executeCmd(t, cmd); err != nil {
@@ -131,7 +131,7 @@ func TestNew_HandlerErrorPropagates(t *testing.T) {
 	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte("")))
 
 	want := errors.New("handler failure")
-	cmd := New("sub", "desc", func(ctx RunContext) error { return want })
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) { return nil, want })
 
 	err := executeCmd(t, cmd)
 	if err == nil {
@@ -156,8 +156,8 @@ contexts:
 	t.Setenv("ELASTIC_CONFIG", configPath)
 
 	var ctx1, ctx2 RunContext
-	cmd1 := New("cmd-one", "first", func(ctx RunContext) error { ctx1 = ctx; return nil })
-	cmd2 := New("cmd-two", "second", func(ctx RunContext) error { ctx2 = ctx; return nil })
+	cmd1 := New("cmd-one", "first", func(ctx RunContext) (any, error) { ctx1 = ctx; return nil, nil })
+	cmd2 := New("cmd-two", "second", func(ctx RunContext) (any, error) { ctx2 = ctx; return nil, nil })
 
 	if err := executeCmd(t, cmd1); err != nil {
 		t.Fatalf("cmd1: %v", err)
@@ -189,9 +189,9 @@ func TestNew_NoConfigFile_XDGEmpty(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		received = ctx
-		return nil
+		return nil, nil
 	})
 
 	if err := executeCmd(t, cmd); err != nil {
@@ -219,9 +219,9 @@ func TestNew_NoConfigFile_HomeEmpty(t *testing.T) {
 	t.Setenv("HOME", tmpDir)
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		received = ctx
-		return nil
+		return nil, nil
 	})
 
 	if err := executeCmd(t, cmd); err != nil {
@@ -256,9 +256,9 @@ contexts:
 	t.Setenv("ELASTIC_CONFIG", configPath)
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		received = ctx
-		return nil
+		return nil, nil
 	})
 	if err := executeCmd(t, cmd); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -288,9 +288,9 @@ contexts:
 	t.Setenv("ELASTIC_CONFIG", configPath)
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		received = ctx
-		return nil
+		return nil, nil
 	})
 	if err := executeCmd(t, cmd); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -326,9 +326,9 @@ contexts:
 	t.Setenv("ELASTIC_CONFIG", configPath)
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		received = ctx
-		return nil
+		return nil, nil
 	})
 	if err := executeCmd(t, cmd); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -370,7 +370,7 @@ func TestNew_Context_FlagOverridesCurrentContext(t *testing.T) {
 	t.Setenv("ELASTIC_CONFIG", configPath)
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error { received = ctx; return nil })
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) { received = ctx; return nil, nil })
 	if err := executeCmd(t, cmd, "--context=dev"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -384,7 +384,7 @@ func TestNew_Context_DefaultsToCurrentContext(t *testing.T) {
 	t.Setenv("ELASTIC_CONFIG", configPath)
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error { received = ctx; return nil })
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) { received = ctx; return nil, nil })
 	if err := executeCmd(t, cmd); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -397,7 +397,7 @@ func TestNew_Context_UnknownName_ErrorListsAvailable(t *testing.T) {
 	configPath := factorytest.TempConfigFile(t, []byte(twoContextConfig))
 	t.Setenv("ELASTIC_CONFIG", configPath)
 
-	cmd := New("sub", "desc", func(ctx RunContext) error { return nil })
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) { return nil, nil })
 	err := executeCmd(t, cmd, "--context=missing")
 	if err == nil {
 		t.Fatal("expected error for unknown context, got nil")
@@ -418,7 +418,7 @@ func TestNew_Context_NoConfigFile_NoFlag_EmptyActiveContext(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error { received = ctx; return nil })
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) { received = ctx; return nil, nil })
 	if err := executeCmd(t, cmd); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -431,7 +431,7 @@ func TestNew_Context_NoConfigFile_WithFlag_Errors(t *testing.T) {
 	t.Setenv("ELASTIC_CONFIG", "")
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 
-	cmd := New("sub", "desc", func(ctx RunContext) error { return nil })
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) { return nil, nil })
 	err := executeCmd(t, cmd, "--context=anything")
 	if err == nil {
 		t.Fatal("expected error when --context set but no contexts configured, got nil")
@@ -450,9 +450,9 @@ func TestNew_Body_NilWhenNoInputConfigured(t *testing.T) {
 	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte("")))
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		received = ctx
-		return nil
+		return nil, nil
 	})
 
 	if err := executeCmd(t, cmd); err != nil {
@@ -481,9 +481,9 @@ func TestNew_Body_PopulatedFromStdin(t *testing.T) {
 
 	payload := []byte(`{"x":1}`)
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		received = ctx
-		return nil
+		return nil, nil
 	})
 
 	if err := executeCmdWithStdin(t, cmd, bytes.NewReader(payload)); err != nil {
@@ -500,9 +500,9 @@ func TestNew_Body_NilWhenStdinEmpty(t *testing.T) {
 	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte("")))
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		received = ctx
-		return nil
+		return nil, nil
 	})
 
 	if err := executeCmdWithStdin(t, cmd, bytes.NewReader(nil)); err != nil {
@@ -524,9 +524,9 @@ func TestNew_Body_PopulatedFromFile(t *testing.T) {
 	filePath := factorytest.TempDataFile(t, payload)
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		received = ctx
-		return nil
+		return nil, nil
 	})
 
 	if err := executeCmd(t, cmd, "--file", filePath); err != nil {
@@ -543,9 +543,9 @@ func TestNew_Body_ErrorWhenFileNotFound(t *testing.T) {
 	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte("")))
 
 	handlerCalled := false
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		handlerCalled = true
-		return nil
+		return nil, nil
 	})
 
 	err := executeCmd(t, cmd, "--file", "/nonexistent/path/payload.json")
@@ -568,9 +568,9 @@ func TestNew_Body_ErrorWhenFileUnreadable(t *testing.T) {
 	filePath := factorytest.TempConfigFileUnreadable(t, []byte(`{}`))
 
 	handlerCalled := false
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		handlerCalled = true
-		return nil
+		return nil, nil
 	})
 
 	err := executeCmd(t, cmd, "--file", filePath)
@@ -590,9 +590,9 @@ func TestNew_Body_NilWhenFileEmpty(t *testing.T) {
 	filePath := factorytest.TempDataFile(t, []byte{})
 
 	var received RunContext
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		received = ctx
-		return nil
+		return nil, nil
 	})
 
 	if err := executeCmd(t, cmd, "--file", filePath); err != nil {
@@ -614,9 +614,9 @@ func TestNew_Body_ErrorWhenBothStdinAndFile(t *testing.T) {
 	stdinData := bytes.NewReader([]byte(`{"source":"stdin"}`))
 
 	handlerCalled := false
-	cmd := New("sub", "desc", func(ctx RunContext) error {
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
 		handlerCalled = true
-		return nil
+		return nil, nil
 	})
 
 	err := executeCmdWithStdin(t, cmd, stdinData, "--file", filePath)

--- a/internal/factory/factory_test.go
+++ b/internal/factory/factory_test.go
@@ -696,6 +696,10 @@ func TestNew_FormatJSON_OutputIsValidJSON(t *testing.T) {
 }
 
 // jsonValid reports whether b is a single valid JSON value with no trailing content.
+// jsonValid reports whether b is a single valid JSON value with no trailing
+// content (whitespace excepted). dec.More() is not used because it peeks the
+// next byte and returns false for trailing } or ], silently accepting malformed
+// input. Instead, a second Decode is attempted: io.EOF means nothing follows.
 func jsonValid(b []byte) bool {
 	if len(b) == 0 {
 		return false
@@ -705,7 +709,38 @@ func jsonValid(b []byte) bool {
 	if err := dec.Decode(&v); err != nil {
 		return false
 	}
-	return !dec.More()
+	var extra any
+	return errors.Is(dec.Decode(&extra), io.EOF)
+}
+
+func TestJsonValid(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{`{"data":"ok","error":null,"warnings":[]}`, true},
+		{`"just a string"`, true},
+		{`42`, true},
+		{`{}`, true},
+		{``, false},
+		{`not json`, false},
+		// trailing non-whitespace must be rejected
+		{`{} trailing`, false},
+		{`{"a":1} {"b":2}`, false},
+		// trailing } or ] fools dec.More() (it peeks and treats them as
+		// container-end markers, returning false); second-decode catches them
+		{`{"a":1}}`, false},
+		{`[1,2]]`, false},
+		{`{"a":1} ]`, false},
+		// whitespace-only trailing is acceptable
+		{`{"a":1}   `, true},
+	}
+	for _, tt := range tests {
+		got := jsonValid([]byte(tt.input))
+		if got != tt.want {
+			t.Errorf("jsonValid(%q) = %v; want %v", tt.input, got, tt.want)
+		}
+	}
 }
 
 // no --format flag produces unchanged plain-text output (backward compatibility).

--- a/internal/factory/factory_test.go
+++ b/internal/factory/factory_test.go
@@ -2,7 +2,9 @@ package factory
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"strings"
@@ -628,5 +630,301 @@ func TestNew_Body_ErrorWhenBothStdinAndFile(t *testing.T) {
 	}
 	if handlerCalled {
 		t.Error("handler must not be called when input source is ambiguous")
+	}
+}
+
+// ---- JSON output format -----------------------------------------------
+
+// executeCmdCapture runs the subcommand under a fresh root with --format
+// registered as a persistent flag, captures stdout, and returns it along with
+// any error. Extra args follow the subcommand name.
+func executeCmdCapture(t *testing.T, sub *cobra.Command, args ...string) (string, error) {
+	t.Helper()
+	var contextFlag, formatFlag string
+	root := &cobra.Command{Use: "root", SilenceErrors: true, SilenceUsage: true}
+	root.PersistentFlags().StringVar(&contextFlag, "context", "", "")
+	root.PersistentFlags().StringVar(&formatFlag, "format", "text", "")
+	root.AddCommand(sub)
+	root.SetArgs(append([]string{sub.Use}, args...))
+	var buf bytes.Buffer
+	root.SetOut(&buf)
+	sub.SetOut(&buf)
+	err := root.Execute()
+	return buf.String(), err
+}
+
+// --format=json produces valid JSON envelope with "data" field matching handler return.
+func TestNew_FormatJSON_ProducesEnvelopeWithData(t *testing.T) {
+	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte("")))
+
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
+		return "elastic version dev", nil
+	})
+
+	out, err := executeCmdCapture(t, cmd, "--format=json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, `"data"`) {
+		t.Errorf("output missing 'data' key: %q", out)
+	}
+	if !strings.Contains(out, "elastic version dev") {
+		t.Errorf("output missing data value: %q", out)
+	}
+	if !strings.Contains(out, `"error":null`) {
+		t.Errorf("output missing null error: %q", out)
+	}
+}
+
+// --format=json stdout output is valid JSON with no preamble or trailing text.
+func TestNew_FormatJSON_OutputIsValidJSON(t *testing.T) {
+	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte("")))
+
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
+		return "hello", nil
+	})
+
+	out, err := executeCmdCapture(t, cmd, "--format=json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	trimmed := strings.TrimSpace(out)
+	if !jsonValid([]byte(trimmed)) {
+		t.Errorf("output is not valid JSON: %q", out)
+	}
+}
+
+// jsonValid reports whether b is a single valid JSON value with no trailing content.
+func jsonValid(b []byte) bool {
+	if len(b) == 0 {
+		return false
+	}
+	dec := json.NewDecoder(bytes.NewReader(b))
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return false
+	}
+	return !dec.More()
+}
+
+// no --format flag produces unchanged plain-text output (backward compatibility).
+func TestNew_NoFormat_ProducesTextOutput(t *testing.T) {
+	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte("")))
+
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
+		return "plain output", nil
+	})
+
+	out, err := executeCmdCapture(t, cmd)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.TrimSpace(out) != "plain output" {
+		t.Errorf("text output: got %q, want %q", strings.TrimSpace(out), "plain output")
+	}
+}
+
+// --format=text produces identical output to no flag.
+func TestNew_FormatText_IdenticalToNoFlag(t *testing.T) {
+	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte("")))
+
+	makeCmd := func() *cobra.Command {
+		return New("sub", "desc", func(ctx RunContext) (any, error) {
+			return "plain output", nil
+		})
+	}
+
+	outNoFlag, err := executeCmdCapture(t, makeCmd())
+	if err != nil {
+		t.Fatalf("no-flag: unexpected error: %v", err)
+	}
+	outText, err := executeCmdCapture(t, makeCmd(), "--format=text")
+	if err != nil {
+		t.Fatalf("--format=text: unexpected error: %v", err)
+	}
+	if outNoFlag != outText {
+		t.Errorf("--format=text output differs from no-flag output:\n  no-flag: %q\n  text:    %q", outNoFlag, outText)
+	}
+}
+
+// ---- Error output in JSON mode ----------------------------------------
+
+// executeCmdCaptureWithStderr runs the subcommand under a fresh root with
+// --format and --context registered, captures both stdout and stderr, and
+// returns them along with any error.
+func executeCmdCaptureWithStderr(t *testing.T, sub *cobra.Command, args ...string) (stdout, stderr string, err error) {
+	t.Helper()
+	var contextFlag, formatFlag string
+	root := &cobra.Command{Use: "root", SilenceErrors: true, SilenceUsage: true}
+	root.PersistentFlags().StringVar(&contextFlag, "context", "", "")
+	root.PersistentFlags().StringVar(&formatFlag, "format", "text", "")
+	root.AddCommand(sub)
+	root.SetArgs(append([]string{sub.Use}, args...))
+	var outBuf, errBuf bytes.Buffer
+	root.SetOut(&outBuf)
+	root.SetErr(&errBuf)
+	sub.SetOut(&outBuf)
+	sub.SetErr(&errBuf)
+	err = root.Execute()
+	return outBuf.String(), errBuf.String(), err
+}
+
+// handler returning error with --format=json produces JSON envelope with
+// error field and null data on stdout.
+func TestNew_FormatJSON_HandlerError_ProducesErrorEnvelope(t *testing.T) {
+	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte("")))
+
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
+		return nil, errors.New("something went wrong")
+	})
+
+	stdout, _, err := executeCmdCaptureWithStderr(t, cmd, "--format=json")
+	if err != nil {
+		t.Fatalf("unexpected RunE error: %v", err)
+	}
+	var env map[string]any
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); jsonErr != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", jsonErr, stdout)
+	}
+	if env["data"] != nil {
+		t.Errorf("data: got %v, want null", env["data"])
+	}
+	errObj, ok := env["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error field is not an object: %v", env["error"])
+	}
+	if errObj["code"] != "command_failed" {
+		t.Errorf("error.code: got %v, want %q", errObj["code"], "command_failed")
+	}
+	if !strings.Contains(fmt.Sprintf("%v", errObj["message"]), "something went wrong") {
+		t.Errorf("error.message: got %v, want to contain 'something went wrong'", errObj["message"])
+	}
+}
+
+// handler returning error with --format=json writes nothing to stderr.
+func TestNew_FormatJSON_HandlerError_NoStderr(t *testing.T) {
+	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte("")))
+
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
+		return nil, errors.New("oops")
+	})
+
+	_, stderr, err := executeCmdCaptureWithStderr(t, cmd, "--format=json")
+	if err != nil {
+		t.Fatalf("unexpected RunE error: %v", err)
+	}
+	if stderr != "" {
+		t.Errorf("stderr: got %q, want empty", stderr)
+	}
+}
+
+// handler returning error without --format=json propagates error to caller
+// (which writes "Error: <msg>" to stderr in the real Execute() path).
+func TestNew_TextMode_HandlerError_PropagatesError(t *testing.T) {
+	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte("")))
+
+	want := errors.New("handler failure text mode")
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
+		return nil, want
+	})
+
+	err := executeCmd(t, cmd)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, want) {
+		t.Errorf("got %v, want %v", err, want)
+	}
+}
+
+// config error (unreadable file) with --format=json produces JSON envelope
+// with "code": "config_error".
+func TestNew_FormatJSON_ConfigError_ProducesConfigErrorCode(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("permission check meaningless as root")
+	}
+	configPath := factorytest.TempConfigFileUnreadable(t, []byte("current_context: prod\n"))
+	t.Setenv("ELASTIC_CONFIG", configPath)
+
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
+		return "ok", nil
+	})
+
+	stdout, _, err := executeCmdCaptureWithStderr(t, cmd, "--format=json")
+	if err != nil {
+		t.Fatalf("unexpected RunE error: %v", err)
+	}
+	var env map[string]any
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); jsonErr != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", jsonErr, stdout)
+	}
+	errObj, ok := env["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error field is not an object: %v", env["error"])
+	}
+	if errObj["code"] != "config_error" {
+		t.Errorf("error.code: got %v, want %q", errObj["code"], "config_error")
+	}
+}
+
+// --context=bogus with --format=json produces JSON envelope with
+// "code": "context_not_found".
+func TestNew_FormatJSON_ContextNotFound_ProducesContextNotFoundCode(t *testing.T) {
+	yaml := `
+current_context: prod
+contexts:
+  prod:
+    elasticsearch:
+      url: https://prod.es.io
+`
+	configPath := factorytest.TempConfigFile(t, []byte(yaml))
+	t.Setenv("ELASTIC_CONFIG", configPath)
+
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
+		return "ok", nil
+	})
+
+	stdout, _, err := executeCmdCaptureWithStderr(t, cmd, "--format=json", "--context=bogus")
+	if err != nil {
+		t.Fatalf("unexpected RunE error: %v", err)
+	}
+	var env map[string]any
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); jsonErr != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", jsonErr, stdout)
+	}
+	errObj, ok := env["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error field is not an object: %v", env["error"])
+	}
+	if errObj["code"] != "context_not_found" {
+		t.Errorf("error.code: got %v, want %q", errObj["code"], "context_not_found")
+	}
+}
+
+// --format=xml produces JSON envelope with "code": "invalid_argument".
+func TestNew_FormatXML_ProducesInvalidArgumentCode(t *testing.T) {
+	t.Setenv("ELASTIC_CONFIG", factorytest.TempConfigFile(t, []byte("")))
+
+	cmd := New("sub", "desc", func(ctx RunContext) (any, error) {
+		return "ok", nil
+	})
+
+	stdout, _, err := executeCmdCaptureWithStderr(t, cmd, "--format=xml")
+	if err != nil {
+		t.Fatalf("unexpected RunE error: %v", err)
+	}
+	var env map[string]any
+	if jsonErr := json.Unmarshal([]byte(strings.TrimSpace(stdout)), &env); jsonErr != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", jsonErr, stdout)
+	}
+	errObj, ok := env["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error field is not an object: %v", env["error"])
+	}
+	if errObj["code"] != "invalid_argument" {
+		t.Errorf("error.code: got %v, want %q", errObj["code"], "invalid_argument")
+	}
+	if !strings.Contains(fmt.Sprintf("%v", errObj["message"]), "text") {
+		t.Errorf("error.message: got %v, want to mention supported values", errObj["message"])
 	}
 }

--- a/internal/factory/path_test.go
+++ b/internal/factory/path_test.go
@@ -3,8 +3,8 @@ package factory
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/elastic/cli/internal/factory/factorytest"

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -14,6 +14,29 @@ const FormatText = "text"
 // FormatJSON is the machine-readable JSON envelope output format.
 const FormatJSON = "json"
 
+// OutputError is the error interface required by Render. All errors passed to
+// Render must carry a machine-readable code via ErrorCode(), ensuring the JSON
+// envelope always has a well-defined, non-guessed code field.
+type OutputError interface {
+	error
+	ErrorCode() string
+}
+
+// Error is the structured error type used in the JSON envelope. It implements
+// OutputError, so it can be passed directly to Render and also marshaled into
+// the envelope's "error" field.
+type Error struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	cause   error  // preserved for errors.Is/As traversal; not marshaled
+}
+
+func (e *Error) Error() string     { return e.Message }
+func (e *Error) ErrorCode() string { return e.Code }
+
+// Unwrap preserves the error chain so errors.Is/As work on the wrapped cause.
+func (e *Error) Unwrap() error { return e.cause }
+
 // Envelope is the top-level JSON response structure emitted on stdout when
 // --format=json is active. Exactly one of Data or Error should be non-nil.
 // Warnings is always initialized to an empty slice so JSON output is [] not null.
@@ -21,12 +44,6 @@ type Envelope struct {
 	Data     any      `json:"data"`
 	Error    *Error   `json:"error"`
 	Warnings []string `json:"warnings"`
-}
-
-// Error is a structured error value embedded in an Envelope.
-type Error struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
 }
 
 // ValidateFormat returns nil if s is a supported format value, or an error
@@ -40,12 +57,15 @@ func ValidateFormat(s string) error {
 	}
 }
 
-// Render builds an Envelope from data and err, then writes it to w.
+// Render builds an Envelope from data and cmdErr, then writes it to w.
+// cmdErr must implement OutputError, ensuring the JSON envelope always carries
+// a well-typed error code set explicitly at the call site.
+//
 // When format is FormatJSON, the envelope is written as a single JSON line.
 // When format is FormatText, data is written as plain text (string via
-// fmt.Fprintln, other types via fmt.Fprintf("%v")), and err is returned
+// fmt.Fprintln, other types via fmt.Fprintf("%v")), and cmdErr is returned
 // directly for Cobra to handle.
-func Render(w io.Writer, format string, data any, cmdErr error) error {
+func Render(w io.Writer, format string, data any, cmdErr OutputError) error {
 	if format == FormatJSON {
 		env := Envelope{
 			Data:     data,
@@ -53,7 +73,7 @@ func Render(w io.Writer, format string, data any, cmdErr error) error {
 		}
 		if cmdErr != nil {
 			env.Data = nil
-			env.Error = errorToStructured(cmdErr)
+			env.Error = &Error{Code: cmdErr.ErrorCode(), Message: cmdErr.Error()}
 		}
 		b, err := json.Marshal(env)
 		if err != nil {
@@ -75,48 +95,4 @@ func Render(w io.Writer, format string, data any, cmdErr error) error {
 		}
 	}
 	return nil
-}
-
-// errorToStructured maps a Go error to a structured Error with a machine-readable code.
-func errorToStructured(err error) *Error {
-	return &Error{
-		Code:    classifyError(err),
-		Message: err.Error(),
-	}
-}
-
-// classifyError returns a snake_case error code for the given error.
-// It inspects the error message heuristically; richer typed errors can be
-// added later once more error types are defined.
-func classifyError(err error) string {
-	msg := err.Error()
-	switch {
-	case containsAny(msg, "context", "not found"):
-		return "context_not_found"
-	case containsAny(msg, "config"):
-		return "config_error"
-	case containsAny(msg, "stdin", "--file", "input"):
-		return "input_error"
-	case containsAny(msg, "unsupported format", "invalid_argument"):
-		return "invalid_argument"
-	default:
-		return "command_failed"
-	}
-}
-
-// containsAny reports whether s contains all of the given substrings.
-func containsAny(s string, subs ...string) bool {
-	for _, sub := range subs {
-		found := false
-		for i := 0; i <= len(s)-len(sub); i++ {
-			if s[i:i+len(sub)] == sub {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -4,6 +4,7 @@ package output
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 )
@@ -11,6 +12,12 @@ import (
 // FormatText is the default human-readable output format.
 const FormatText = "text"
 
+
+// ErrAlreadyRendered is returned by Render when it successfully writes a JSON
+// error envelope to the output stream. It signals that the error has already
+// been presented to the user and the caller should exit non-zero without
+// printing anything further. Use errors.Is to detect it.
+var ErrAlreadyRendered = errors.New("error already rendered")
 // FormatJSON is the machine-readable JSON envelope output format.
 const FormatJSON = "json"
 
@@ -79,8 +86,13 @@ func Render(w io.Writer, format string, data any, cmdErr OutputError) error {
 		if err != nil {
 			return fmt.Errorf("marshal envelope: %w", err)
 		}
-		_, err = fmt.Fprintf(w, "%s\n", b)
-		return err
+		if _, err = fmt.Fprintf(w, "%s\n", b); err != nil {
+			return err
+		}
+		if cmdErr != nil {
+			return ErrAlreadyRendered
+		}
+		return nil
 	}
 
 	// text mode: surface the original error so Cobra/Execute() can handle it.

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -12,12 +12,12 @@ import (
 // FormatText is the default human-readable output format.
 const FormatText = "text"
 
-
 // ErrAlreadyRendered is returned by Render when it successfully writes a JSON
 // error envelope to the output stream. It signals that the error has already
 // been presented to the user and the caller should exit non-zero without
 // printing anything further. Use errors.Is to detect it.
 var ErrAlreadyRendered = errors.New("error already rendered")
+
 // FormatJSON is the machine-readable JSON envelope output format.
 const FormatJSON = "json"
 

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -1,0 +1,122 @@
+// Package output provides the JSON envelope type, format constants, and
+// rendering logic for structured CLI output.
+package output
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// FormatText is the default human-readable output format.
+const FormatText = "text"
+
+// FormatJSON is the machine-readable JSON envelope output format.
+const FormatJSON = "json"
+
+// Envelope is the top-level JSON response structure emitted on stdout when
+// --format=json is active. Exactly one of Data or Error should be non-nil.
+// Warnings is always initialized to an empty slice so JSON output is [] not null.
+type Envelope struct {
+	Data     any      `json:"data"`
+	Error    *Error   `json:"error"`
+	Warnings []string `json:"warnings"`
+}
+
+// Error is a structured error value embedded in an Envelope.
+type Error struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// ValidateFormat returns nil if s is a supported format value, or an error
+// listing the supported values otherwise.
+func ValidateFormat(s string) error {
+	switch s {
+	case FormatText, FormatJSON:
+		return nil
+	default:
+		return fmt.Errorf("unsupported format %q: supported values are %q and %q", s, FormatText, FormatJSON)
+	}
+}
+
+// Render builds an Envelope from data and err, then writes it to w.
+// When format is FormatJSON, the envelope is written as a single JSON line.
+// When format is FormatText, data is written as plain text (string via
+// fmt.Fprintln, other types via fmt.Fprintf("%v")), and err is returned
+// directly for Cobra to handle.
+func Render(w io.Writer, format string, data any, cmdErr error) error {
+	if format == FormatJSON {
+		env := Envelope{
+			Data:     data,
+			Warnings: []string{},
+		}
+		if cmdErr != nil {
+			env.Data = nil
+			env.Error = errorToStructured(cmdErr)
+		}
+		b, err := json.Marshal(env)
+		if err != nil {
+			return fmt.Errorf("marshal envelope: %w", err)
+		}
+		_, err = fmt.Fprintf(w, "%s\n", b)
+		return err
+	}
+
+	// text mode: surface the original error so Cobra/Execute() can handle it.
+	if cmdErr != nil {
+		return cmdErr
+	}
+	if data != nil {
+		if s, ok := data.(string); ok {
+			fmt.Fprintln(w, s)
+		} else {
+			fmt.Fprintf(w, "%v\n", data)
+		}
+	}
+	return nil
+}
+
+// errorToStructured maps a Go error to a structured Error with a machine-readable code.
+func errorToStructured(err error) *Error {
+	return &Error{
+		Code:    classifyError(err),
+		Message: err.Error(),
+	}
+}
+
+// classifyError returns a snake_case error code for the given error.
+// It inspects the error message heuristically; richer typed errors can be
+// added later once more error types are defined.
+func classifyError(err error) string {
+	msg := err.Error()
+	switch {
+	case containsAny(msg, "context", "not found"):
+		return "context_not_found"
+	case containsAny(msg, "config"):
+		return "config_error"
+	case containsAny(msg, "stdin", "--file", "input"):
+		return "input_error"
+	case containsAny(msg, "unsupported format", "invalid_argument"):
+		return "invalid_argument"
+	default:
+		return "command_failed"
+	}
+}
+
+// containsAny reports whether s contains all of the given substrings.
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		found := false
+		for i := 0; i <= len(s)-len(sub); i++ {
+			if s[i:i+len(sub)] == sub {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -257,6 +257,7 @@ func TestValidateFormat_CaseSensitive(t *testing.T) {
 		t.Error("ValidateFormat(\"Text\"): expected error (case sensitive), got nil")
 	}
 }
+
 // ---- typed errors satisfy OutputError -------------------------------------
 
 // Verify that the apperrors types satisfy output.OutputError at compile time.

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,0 +1,255 @@
+package output_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/elastic/cli/internal/output"
+)
+
+// ---- Envelope JSON marshaling -----------------------------------------------
+
+func TestEnvelope_SuccessMarshaling(t *testing.T) {
+	env := output.Envelope{
+		Data:     "elastic version dev",
+		Error:    nil,
+		Warnings: []string{},
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if got["data"] != "elastic version dev" {
+		t.Errorf("data: got %v, want %q", got["data"], "elastic version dev")
+	}
+	if got["error"] != nil {
+		t.Errorf("error: got %v, want nil", got["error"])
+	}
+}
+
+func TestEnvelope_ErrorMarshaling(t *testing.T) {
+	env := output.Envelope{
+		Data:     nil,
+		Error:    &output.Error{Code: "command_failed", Message: "something went wrong"},
+		Warnings: []string{},
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if got["data"] != nil {
+		t.Errorf("data: got %v, want nil", got["data"])
+	}
+	errObj, ok := got["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error field is not an object: %v", got["error"])
+	}
+	if errObj["code"] != "command_failed" {
+		t.Errorf("error.code: got %v, want %q", errObj["code"], "command_failed")
+	}
+	if errObj["message"] != "something went wrong" {
+		t.Errorf("error.message: got %v", errObj["message"])
+	}
+}
+
+func TestEnvelope_WarningsMarshaling(t *testing.T) {
+	env := output.Envelope{
+		Data:     "ok",
+		Error:    nil,
+		Warnings: []string{"msg1", "msg2"},
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	warnings, ok := got["warnings"].([]any)
+	if !ok {
+		t.Fatalf("warnings field is not an array: %v", got["warnings"])
+	}
+	if len(warnings) != 2 {
+		t.Errorf("warnings len: got %d, want 2", len(warnings))
+	}
+}
+
+func TestEnvelope_NullFields(t *testing.T) {
+	env := output.Envelope{
+		Data:     nil,
+		Error:    nil,
+		Warnings: []string{},
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	if !json.Valid(b) {
+		t.Error("marshaled output is not valid JSON")
+	}
+}
+
+func TestEnvelope_EmptyWarningsAsArray(t *testing.T) {
+	env := output.Envelope{
+		Data:     "x",
+		Error:    nil,
+		Warnings: []string{},
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal error: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	warnings, ok := got["warnings"].([]any)
+	if !ok {
+		t.Fatalf("warnings should be [] not null; got %v", got["warnings"])
+	}
+	if len(warnings) != 0 {
+		t.Errorf("warnings should be empty, got %v", warnings)
+	}
+}
+
+// ---- ValidateFormat ---------------------------------------------------------
+
+func TestValidateFormat_ValidValues(t *testing.T) {
+	for _, v := range []string{output.FormatText, output.FormatJSON} {
+		if err := output.ValidateFormat(v); err != nil {
+			t.Errorf("ValidateFormat(%q): unexpected error: %v", v, err)
+		}
+	}
+}
+
+func TestValidateFormat_InvalidValue(t *testing.T) {
+	if err := output.ValidateFormat("xml"); err == nil {
+		t.Error("ValidateFormat(\"xml\"): expected error, got nil")
+	}
+}
+
+func TestValidateFormat_EmptyString(t *testing.T) {
+	if err := output.ValidateFormat(""); err == nil {
+		t.Error("ValidateFormat(\"\"): expected error, got nil")
+	}
+}
+
+// ---- Render -----------------------------------------------------------------
+
+func TestRender_JSONSuccess(t *testing.T) {
+	var buf strings.Builder
+	if err := output.Render(&buf, output.FormatJSON, "elastic version dev", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := buf.String()
+	if !json.Valid([]byte(strings.TrimSpace(got))) {
+		t.Errorf("output is not valid JSON: %q", got)
+	}
+	var env map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(got)), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env["data"] != "elastic version dev" {
+		t.Errorf("data: got %v, want %q", env["data"], "elastic version dev")
+	}
+	if env["error"] != nil {
+		t.Errorf("error: got %v, want nil", env["error"])
+	}
+}
+
+func TestRender_JSONError(t *testing.T) {
+	var buf strings.Builder
+	if err := output.Render(&buf, output.FormatJSON, nil, fmt.Errorf("oops")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got := buf.String()
+	var env map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(got)), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env["data"] != nil {
+		t.Errorf("data: got %v, want nil", env["data"])
+	}
+	errObj, ok := env["error"].(map[string]any)
+	if !ok {
+		t.Fatalf("error field is not an object: %v", env["error"])
+	}
+	if errObj["code"] == "" {
+		t.Error("error.code is empty")
+	}
+	if errObj["message"] != "oops" {
+		t.Errorf("error.message: got %v, want %q", errObj["message"], "oops")
+	}
+}
+
+func TestRender_TextSuccess(t *testing.T) {
+	var buf strings.Builder
+	if err := output.Render(&buf, output.FormatText, "hello world", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(buf.String()); got != "hello world" {
+		t.Errorf("output: got %q, want %q", got, "hello world")
+	}
+}
+
+func TestRender_TextErrorPassthrough(t *testing.T) {
+	var buf strings.Builder
+	origErr := fmt.Errorf("text error")
+	err := output.Render(&buf, output.FormatText, nil, origErr)
+	if err != origErr {
+		t.Errorf("expected original error returned, got %v", err)
+	}
+}
+
+func TestRender_JSONWarningsEmbedded(t *testing.T) {
+	var buf strings.Builder
+	if err := output.Render(&buf, output.FormatJSON, "data", nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var env map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	warnings, ok := env["warnings"].([]any)
+	if !ok {
+		t.Fatalf("warnings should be [] not null; got %v", env["warnings"])
+	}
+	_ = warnings
+}
+
+func TestRender_JSONNilDataProducesNull(t *testing.T) {
+	var buf strings.Builder
+	if err := output.Render(&buf, output.FormatJSON, nil, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var env map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, ok := env["data"]; !ok {
+		t.Error("data key missing from envelope")
+	}
+	if env["data"] != nil {
+		t.Errorf("data: got %v, want nil", env["data"])
+	}
+}
+
+func TestValidateFormat_CaseSensitive(t *testing.T) {
+	if err := output.ValidateFormat("JSON"); err == nil {
+		t.Error("ValidateFormat(\"JSON\"): expected error (case sensitive), got nil")
+	}
+	if err := output.ValidateFormat("Text"); err == nil {
+		t.Error("ValidateFormat(\"Text\"): expected error (case sensitive), got nil")
+	}
+}

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -2,10 +2,12 @@ package output_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
 
+	apperrors "github.com/elastic/cli/internal/errors"
 	"github.com/elastic/cli/internal/output"
 )
 
@@ -170,7 +172,7 @@ func TestRender_JSONSuccess(t *testing.T) {
 
 func TestRender_JSONError(t *testing.T) {
 	var buf strings.Builder
-	if err := output.Render(&buf, output.FormatJSON, nil, fmt.Errorf("oops")); err != nil {
+	if err := output.Render(&buf, output.FormatJSON, nil, &apperrors.CommandError{Cause: fmt.Errorf("oops")}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	got := buf.String()
@@ -205,10 +207,11 @@ func TestRender_TextSuccess(t *testing.T) {
 
 func TestRender_TextErrorPassthrough(t *testing.T) {
 	var buf strings.Builder
-	origErr := fmt.Errorf("text error")
-	err := output.Render(&buf, output.FormatText, nil, origErr)
-	if err != origErr {
-		t.Errorf("expected original error returned, got %v", err)
+	cause := fmt.Errorf("text error")
+	outErr := &apperrors.CommandError{Cause: cause}
+	err := output.Render(&buf, output.FormatText, nil, outErr)
+	if !errors.Is(err, cause) {
+		t.Errorf("expected cause in error chain, got %v", err)
 	}
 }
 
@@ -251,5 +254,47 @@ func TestValidateFormat_CaseSensitive(t *testing.T) {
 	}
 	if err := output.ValidateFormat("Text"); err == nil {
 		t.Error("ValidateFormat(\"Text\"): expected error (case sensitive), got nil")
+	}
+}
+// ---- typed errors satisfy OutputError -------------------------------------
+
+// Verify that the apperrors types satisfy output.OutputError at compile time.
+// No imports of internal/errors are needed in output itself; the interface is
+// satisfied implicitly.
+func TestTypedErrors_SatisfyOutputError(t *testing.T) {
+	var _ output.OutputError = &apperrors.ConfigError{Cause: fmt.Errorf("x")}
+	var _ output.OutputError = &apperrors.ContextNotFoundError{Name: "x"}
+	var _ output.OutputError = &apperrors.InputError{Cause: fmt.Errorf("x")}
+	var _ output.OutputError = &apperrors.InvalidArgumentError{Cause: fmt.Errorf("x")}
+	var _ output.OutputError = &apperrors.CommandError{Cause: fmt.Errorf("x")}
+}
+
+func TestTypedErrors_RenderUsesCode(t *testing.T) {
+	cases := []struct {
+		name string
+		err  output.OutputError
+		code string
+	}{
+		{"config", &apperrors.ConfigError{Cause: fmt.Errorf("e")}, "config_error"},
+		{"context", &apperrors.ContextNotFoundError{Name: "x"}, "context_not_found"},
+		{"input", &apperrors.InputError{Cause: fmt.Errorf("e")}, "input_error"},
+		{"invalid_arg", &apperrors.InvalidArgumentError{Cause: fmt.Errorf("e")}, "invalid_argument"},
+		{"command", &apperrors.CommandError{Cause: fmt.Errorf("e")}, "command_failed"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf strings.Builder
+			if err := output.Render(&buf, output.FormatJSON, nil, tc.err); err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			var env map[string]any
+			if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &env); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			errObj := env["error"].(map[string]any)
+			if errObj["code"] != tc.code {
+				t.Errorf("code: got %v, want %q", errObj["code"], tc.code)
+			}
+		})
 	}
 }

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -172,8 +172,9 @@ func TestRender_JSONSuccess(t *testing.T) {
 
 func TestRender_JSONError(t *testing.T) {
 	var buf strings.Builder
-	if err := output.Render(&buf, output.FormatJSON, nil, &apperrors.CommandError{Cause: fmt.Errorf("oops")}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	err := output.Render(&buf, output.FormatJSON, nil, &apperrors.CommandError{Cause: fmt.Errorf("oops")})
+	if !errors.Is(err, output.ErrAlreadyRendered) {
+		t.Fatalf("expected ErrAlreadyRendered, got: %v", err)
 	}
 	got := buf.String()
 	var env map[string]any
@@ -284,8 +285,8 @@ func TestTypedErrors_RenderUsesCode(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var buf strings.Builder
-			if err := output.Render(&buf, output.FormatJSON, nil, tc.err); err != nil {
-				t.Fatalf("Render: %v", err)
+			if err := output.Render(&buf, output.FormatJSON, nil, tc.err); !errors.Is(err, output.ErrAlreadyRendered) {
+				t.Fatalf("expected ErrAlreadyRendered, got: %v", err)
 			}
 			var env map[string]any
 			if err := json.Unmarshal([]byte(strings.TrimSpace(buf.String())), &env); err != nil {

--- a/justfile
+++ b/justfile
@@ -12,3 +12,4 @@ lint:
 
 lint-fix:
   gofmt -w .
+  go mod tidy

--- a/justfile
+++ b/justfile
@@ -4,6 +4,9 @@ build:
 test:
   go test ./...
 
+test-race:
+  go test -race ./...
+
 lint:
   go vet ./...
 

--- a/specs/001-command-factory/contracts/go-api.md
+++ b/specs/001-command-factory/contracts/go-api.md
@@ -14,12 +14,14 @@ requires updating all call sites.
 ### `RunFunc`
 
 ```go
-type RunFunc func(ctx RunContext) error
+type RunFunc func(ctx RunContext) (any, error)
 ```
 
 The handler function type that every subcommand implements. The factory calls the
-`RunFunc` after fully populating `RunContext`. A non-nil return value is propagated
-to Cobra as a command error (root command writes to stderr, exits non-zero).
+`RunFunc` after fully populating `RunContext`. The first return value is the data
+payload written to the output envelope; `nil` is valid and produces a null `data`
+field. A non-nil error is wrapped in a `CommandError` and rendered as a JSON error
+envelope (or returned to Cobra in text mode).
 
 ---
 
@@ -37,6 +39,10 @@ type RunContext struct {
     // ActiveContext is the resolved context name for this invocation.
     // Set from the --context flag if provided; otherwise from Config.CurrentContext.
     ActiveContext string
+
+    // Body is the raw request body supplied by the caller, either piped via
+    // stdin or read from the path given to --file. Nil when no input was provided.
+    Body []byte
 }
 ```
 
@@ -87,16 +93,6 @@ Connection parameters for Elasticsearch. Supports two mutually exclusive auth mo
 - **API key**: `url` + `api_key`
 - **None**: `url` only (open/anonymous cluster)
 
-#### Method: `AuthMode() (string, error)`
-
-```go
-func (e ElasticsearchConfig) AuthMode() (string, error)
-```
-
-Returns `"basic"`, `"api_key"`, or `"none"`. Returns a non-nil error if:
-- Both basic credentials and `api_key` are set (conflict)
-- Only one of `username`/`password` is set (incomplete basic auth)
-
 ---
 
 ## Functions
@@ -117,17 +113,23 @@ Creates a fully wired `*cobra.Command` from a minimal command definition.
    Missing file → zero-value `Config`, empty `ConfigPath`.
 3. Resolves `ActiveContext` from `--context` flag (if set) or `Config.CurrentContext`.
 4. Validates that `ActiveContext` exists in `Config.Contexts` when non-empty.
-5. Calls `run(RunContext{...})` with the fully populated context.
-6. Returns any error from `run` to Cobra.
+5. Reads the request body from `--file` or piped stdin (mutually exclusive).
+6. Calls `run(RunContext{...})` with the fully populated context.
+7. Renders the result via `output.Render` — errors are written as a JSON envelope
+   (or returned to Cobra in text mode). **Errors are never propagated raw to Cobra
+   from inside this package.**
 
-**Error conditions** (all returned as Go `error`, not written directly to stderr):
+**Error conditions** (all routed through `output.Render`, not returned raw to Cobra):
 
-| Condition | Error message pattern |
-|---|---|
-| `$ELASTIC_CONFIG` set, file not found | `$ELASTIC_CONFIG path not found: <path>` |
-| Config file exists, unreadable | `read config <path>: <os error>` |
-| Config file exists, malformed YAML | `parse config <path>: <yaml error>` |
-| `--context` names unknown context | `context "<name>" not found; available: [a, b, c]` |
+| Condition | Error code | Error message pattern |
+|---|---|---|
+| `$ELASTIC_CONFIG` set, file not found | `config_error` | `$ELASTIC_CONFIG path not found: <os error>` |
+| Config file exists, unreadable | `config_error` | `read config <path>: <os error>` |
+| Config file exists, malformed YAML | `config_error` | `parse config <path>: <yaml error>` |
+| `--context` names unknown context | `context_not_found` | `context "<name>" not found; available: [a, b, c]` |
+| Both `--file` and piped stdin provided | `input_error` | `cannot use both stdin and --file as input; provide only one` |
+| `--file` path unreadable | `input_error` | `read --file "<path>": <os error>` |
+| Unsupported `--format` value | `invalid_argument` | `unsupported format "<v>": supported values are "text" and "json"` |
 
 **Not an error**: config file absent or config directory absent → zero-value
 `Config` used silently.
@@ -139,12 +141,12 @@ Creates a fully wired `*cobra.Command` from a minimal command definition.
 Registered on `rootCmd` via `PersistentFlags()` in `cmd/root.go`:
 
 ```go
-var contextOverride string
+var contextFlag string
 
 rootCmd.PersistentFlags().StringVar(
-    &contextOverride,
+    &contextFlag,
     "context", "",
-    "override the active context for this invocation",
+    "Context to use for this command",
 )
 ```
 
@@ -155,10 +157,12 @@ The flag value is passed into the factory's context resolution step. When empty,
 
 ## Error propagation model
 
-All errors from config loading and context resolution are returned as Go `error`
-values from the Cobra `RunE` function. The Cobra root command (already configured
-with `SilenceUsage: true` for error cases) writes the error to stderr and exits
-with code 1. No `os.Exit` calls appear inside `internal/factory`.
+All errors from format validation, config loading, context resolution, input
+reading, and the `RunFunc` itself are handled **inside `RunE`** by calling
+`output.Render`. In JSON mode, a JSON error envelope is written to stdout and
+`RunE` returns `nil` (Cobra sees no error). In text mode, the error is returned
+from `RunE` so that Cobra/`executeRoot` can write it to stderr and exit non-zero.
+No `os.Exit` calls appear inside `internal/factory`.
 
 ---
 
@@ -174,10 +178,9 @@ import (
 )
 
 func newPingCmd() *cobra.Command {
-    return factory.New("ping", "Check Elasticsearch connectivity", func(ctx factory.RunContext) error {
+    return factory.New("ping", "Check Elasticsearch connectivity", func(ctx factory.RunContext) (any, error) {
         es := ctx.Config.Contexts[ctx.ActiveContext].Elasticsearch
-        fmt.Printf("pinging %s (context: %s)\n", es.URL, ctx.ActiveContext)
-        return nil
+        return fmt.Sprintf("pinging %s (context: %s)", es.URL, ctx.ActiveContext), nil
     })
 }
 ```

--- a/specs/003-json-output-format/checklists/requirements.md
+++ b/specs/003-json-output-format/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Add JSON Output Format Flag
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Clarification resolved (Q1): `--format=json` must always be explicitly provided; no auto-detection based on TTY state.

--- a/specs/003-json-output-format/contracts/cli-interface.md
+++ b/specs/003-json-output-format/contracts/cli-interface.md
@@ -30,7 +30,7 @@ elastic version --format=xml
 # JSON error output for Cobra-level failures (unknown command)
 elastic nonexistent-command --format=json
 # Exit code: 1
-# stdout: {"data":null,"error":{"code":"command_failed","message":"unknown command \"nonexistent-command\" for \"elastic\""},"warnings":[]}
+# stdout: {"data":null,"error":{"code":"unknown_command","message":"unknown command \"nonexistent-command\" for \"elastic\""},"warnings":[]}
 ```
 
 ## Output Format Contracts
@@ -73,7 +73,8 @@ elastic nonexistent-command --format=json
 **Examples**:
 ```json
 // Unknown / Cobra-level command error
-{"data": null, "error": {"code": "command_failed", "message": "unknown command \"foo\" for \"elastic\""}, "warnings": []}
+// Unrecognized subcommand
+{"data": null, "error": {"code": "unknown_command", "message": "unknown command \"foo\" for \"elastic\""}, "warnings": []}
 
 // Invalid argument
 {"data": null, "error": {"code": "invalid_argument", "message": "unsupported format \"xml\": supported values are \"text\" and \"json\""}, "warnings": []}

--- a/specs/003-json-output-format/contracts/cli-interface.md
+++ b/specs/003-json-output-format/contracts/cli-interface.md
@@ -1,0 +1,173 @@
+# CLI Interface Contract: JSON Output Format
+
+**Phase**: 1 | **Date**: 2026-03-27 | **Plan**: [../plan.md](../plan.md)
+
+## Global Flag Contract
+
+### --format Flag
+**Syntax**: `--format=<value>`
+**Values**: `text` (default) | `json`
+**Scope**: Available on ALL commands (inherited via PersistentFlags)
+
+**Behavior Contract**:
+```bash
+# Text output (current behavior, unchanged)
+elastic version
+# Output: elastic version dev
+
+# JSON output (new behavior)  
+elastic version --format=json
+# Output: {"data": "elastic version dev", "status": "ok"}
+```
+
+**Error Contract**:
+```bash
+# Unsupported format value
+elastic version --format=xml
+# Exit code: 1
+# stderr: Error: unsupported format "xml"; supported: text, json
+
+# JSON error output
+elastic nonexistent-command --format=json
+# Exit code: 1  
+# stdout: {"error": {"code": "unknown_command", "message": "unknown command \"nonexistent-command\" for \"elastic\""}}
+```
+
+## Output Format Contracts
+
+### Success Output - JSON Mode
+**Structure**:
+```json
+{
+  "data": <command_result>,
+  "status": "ok"
+}
+```
+
+**Examples**:
+```json
+// Simple string result
+{"data": "elastic version dev", "status": "ok"}
+
+// Complex object result (future commands)
+{"data": {"cluster": "my-cluster", "version": "8.10.0"}, "status": "ok"}
+
+// No meaningful data result
+{"status": "ok"}
+```
+
+### Error Output - JSON Mode
+**Structure**:
+```json
+{
+  "error": {
+    "code": "error_type",
+    "message": "Human readable description"
+  }
+}
+```
+
+**Examples**:
+```json
+// Unknown command
+{"error": {"code": "unknown_command", "message": "unknown command \"foo\" for \"elastic\""}}
+
+// Invalid argument
+{"error": {"code": "invalid_argument", "message": "required flag \"url\" not set"}}
+
+// Network/service error
+{"error": {"code": "connection_failed", "message": "failed to connect to https://localhost:9200"}}
+
+// Config error  
+{"error": {"code": "config_error", "message": "context \"nonexistent\" not found; available: local, prod"}}
+```
+
+### Success Output - Text Mode (Default)
+**Behavior**: Exactly as current implementation
+**No Changes**: Preserves all existing human-readable formatting
+
+### Error Output - Text Mode (Default)  
+**Behavior**: Exactly as current implementation  
+**Format**: `Error: <message>` to stderr
+
+## Stream Contracts
+
+### Standard Output (stdout)
+**JSON Mode**: 
+- ONLY valid JSON objects
+- No banners, progress indicators, or diagnostic messages
+- Single JSON object per command execution
+
+**Text Mode**:
+- Current behavior unchanged
+- Human-readable formatting preserved
+
+### Standard Error (stderr)
+**JSON Mode**:
+- Error JSON objects for command failures
+- Diagnostic messages MAY be suppressed or redirected here
+- Never mixed with stdout JSON
+
+**Text Mode**:
+- Current behavior unchanged
+- Plain text error messages
+
+### Exit Codes
+**Both Modes**:
+- 0: Success
+- 1: Command error (invalid args, execution failure)
+- Consistent between JSON and text modes
+
+## Validation Contracts
+
+### Format Flag Validation
+```bash
+# Valid values (case sensitive)
+--format=text  ✓
+--format=json  ✓
+
+# Invalid values  
+--format=TEXT  ✗ (case sensitive)
+--format=xml   ✗ (unsupported)
+--format=""    ✗ (empty)
+```
+
+### JSON Output Validation
+**Requirements**:
+1. Must pass `json.Valid()` check
+2. Must parse with `jq` without errors
+3. No ANSI escape codes or control characters
+4. Single JSON object (not array or multiple objects)
+5. UTF-8 encoding
+
+### Pipeline Compatibility
+**Test Contract**:
+```bash
+# Must work without errors
+elastic version --format=json | jq .
+elastic some-command --format=json | jq '.data'
+elastic failing-command --format=json | jq '.error.code'
+```
+
+## Help Output Contract
+
+### JSON Schema Support (Future)
+**Planned Contract**:
+```bash
+elastic version --help --format=json
+# Should return JSON schema for the command
+```
+
+**Not Implemented**: In initial version, `--help` ignores `--format` flag
+
+## Backward Compatibility
+
+### Existing Behavior
+**Guarantee**: NO changes to default behavior
+- Commands without `--format` work exactly as before
+- All existing scripts and integrations unaffected
+
+### Migration Path
+**Recommendation**: Users can adopt `--format=json` incrementally
+- Per-command adoption supported
+- Mixed pipelines work (some commands with/without flag)

--- a/specs/003-json-output-format/contracts/cli-interface.md
+++ b/specs/003-json-output-format/contracts/cli-interface.md
@@ -15,22 +15,22 @@
 elastic version
 # Output: elastic version dev
 
-# JSON output (new behavior)  
+# JSON output (new behavior)
 elastic version --format=json
-# Output: {"data": "elastic version dev", "status": "ok"}
+# Output: {"data":"elastic version dev","error":null,"warnings":[]}
 ```
 
 **Error Contract**:
 ```bash
-# Unsupported format value
+# Unsupported format value — invalid_argument envelope written to stdout, exit 0
 elastic version --format=xml
-# Exit code: 1
-# stderr: Error: unsupported format "xml"; supported: text, json
+# Exit code: 0
+# stdout: {"data":null,"error":{"code":"invalid_argument","message":"unsupported format \"xml\": supported values are \"text\" and \"json\""},"warnings":[]}
 
-# JSON error output
+# JSON error output for Cobra-level failures (unknown command)
 elastic nonexistent-command --format=json
-# Exit code: 1  
-# stdout: {"error": {"code": "unknown_command", "message": "unknown command \"nonexistent-command\" for \"elastic\""}}
+# Exit code: 1
+# stdout: {"data":null,"error":{"code":"command_failed","message":"unknown command \"nonexistent-command\" for \"elastic\""},"warnings":[]}
 ```
 
 ## Output Format Contracts
@@ -40,63 +40,70 @@ elastic nonexistent-command --format=json
 ```json
 {
   "data": <command_result>,
-  "status": "ok"
+  "error": null,
+  "warnings": []
 }
 ```
 
 **Examples**:
 ```json
 // Simple string result
-{"data": "elastic version dev", "status": "ok"}
+{"data": "elastic version dev", "error": null, "warnings": []}
 
 // Complex object result (future commands)
-{"data": {"cluster": "my-cluster", "version": "8.10.0"}, "status": "ok"}
+{"data": {"cluster": "my-cluster", "version": "8.10.0"}, "error": null, "warnings": []}
 
 // No meaningful data result
-{"status": "ok"}
+{"data": null, "error": null, "warnings": []}
 ```
 
 ### Error Output - JSON Mode
 **Structure**:
 ```json
 {
+  "data": null,
   "error": {
     "code": "error_type",
     "message": "Human readable description"
-  }
+  },
+  "warnings": []
 }
 ```
 
 **Examples**:
 ```json
-// Unknown command
-{"error": {"code": "unknown_command", "message": "unknown command \"foo\" for \"elastic\""}}
+// Unknown / Cobra-level command error
+{"data": null, "error": {"code": "command_failed", "message": "unknown command \"foo\" for \"elastic\""}, "warnings": []}
 
 // Invalid argument
-{"error": {"code": "invalid_argument", "message": "required flag \"url\" not set"}}
+{"data": null, "error": {"code": "invalid_argument", "message": "unsupported format \"xml\": supported values are \"text\" and \"json\""}, "warnings": []}
 
 // Network/service error
-{"error": {"code": "connection_failed", "message": "failed to connect to https://localhost:9200"}}
+{"data": null, "error": {"code": "command_failed", "message": "failed to connect to https://localhost:9200"}, "warnings": []}
 
-// Config error  
-{"error": {"code": "config_error", "message": "context \"nonexistent\" not found; available: local, prod"}}
+// Config error
+{"data": null, "error": {"code": "config_error", "message": "read config /home/user/.config/elastic/config.yml: permission denied"}, "warnings": []}
+
+// Context not found
+{"data": null, "error": {"code": "context_not_found", "message": "context \"nonexistent\" not found; available: local, prod"}, "warnings": []}
 ```
 
 ### Success Output - Text Mode (Default)
 **Behavior**: Exactly as current implementation
 **No Changes**: Preserves all existing human-readable formatting
 
-### Error Output - Text Mode (Default)  
-**Behavior**: Exactly as current implementation  
+### Error Output - Text Mode (Default)
+**Behavior**: Exactly as current implementation
 **Format**: `Error: <message>` to stderr
 
 ## Stream Contracts
 
 ### Standard Output (stdout)
-**JSON Mode**: 
+**JSON Mode**:
 - ONLY valid JSON objects
 - No banners, progress indicators, or diagnostic messages
 - Single JSON object per command execution
+- Both success and error responses written here
 
 **Text Mode**:
 - Current behavior unchanged
@@ -104,19 +111,17 @@ elastic nonexistent-command --format=json
 
 ### Standard Error (stderr)
 **JSON Mode**:
-- Error JSON objects for command failures
-- Diagnostic messages MAY be suppressed or redirected here
-- Never mixed with stdout JSON
+- Always empty — all output (including errors) goes to stdout as a JSON envelope
 
 **Text Mode**:
 - Current behavior unchanged
-- Plain text error messages
+- Plain text error messages (`Error: <message>`)
 
 ### Exit Codes
 **Both Modes**:
-- 0: Success
-- 1: Command error (invalid args, execution failure)
-- Consistent between JSON and text modes
+- 0: Success (including invalid `--format` value — error written to stdout as JSON)
+- 1: Command error (invalid args handled by Cobra, execution failure)
+- Consistent between JSON and text modes for Cobra-level errors
 
 ## Validation Contracts
 
@@ -126,10 +131,12 @@ elastic nonexistent-command --format=json
 --format=text  ✓
 --format=json  ✓
 
-# Invalid values  
---format=TEXT  ✗ (case sensitive)
---format=xml   ✗ (unsupported)
---format=""    ✗ (empty)
+# Invalid values — rendered as JSON error envelope to stdout, exit 0
+--format=TEXT  ✗
+--format=xml   ✗
+
+# Empty value — silently treated as text mode (default)
+--format=""    treated as --format=text
 ```
 
 ### JSON Output Validation

--- a/specs/003-json-output-format/contracts/json-envelope.md
+++ b/specs/003-json-output-format/contracts/json-envelope.md
@@ -1,0 +1,122 @@
+# CLI Contract: JSON Envelope
+
+**Phase**: 1 | **Date**: 2026-03-27 | **Plan**: [../plan.md](../plan.md)
+
+## Global Flag
+
+```
+--format=<value>    Output format. Supported: text (default), json.
+```
+
+Registered as a PersistentFlag on the root command. Inherited by all subcommands.
+
+## Envelope Schema
+
+Every command response when `--format=json` is active conforms to this structure:
+
+```json
+{
+  "data": <any | null>,
+  "error": <ErrorObject | null>,
+  "warnings": [<string>, ...]
+}
+```
+
+### Success (exit 0)
+
+```json
+{
+  "data": "elastic version dev",
+  "error": null,
+  "warnings": []
+}
+```
+
+### Success with warnings (exit 0)
+
+```json
+{
+  "data": {"cluster_name": "my-cluster"},
+  "error": null,
+  "warnings": ["API key expires in 3 days"]
+}
+```
+
+### Success with no meaningful output (exit 0)
+
+```json
+{
+  "data": {"status": "ok"},
+  "error": null,
+  "warnings": []
+}
+```
+
+### Error (exit 1)
+
+```json
+{
+  "data": null,
+  "error": {"code": "context_not_found", "message": "context \"bogus\" not found; available: prod, staging"},
+  "warnings": []
+}
+```
+
+## ErrorObject Schema
+
+```json
+{
+  "code": "<snake_case_error_code>",
+  "message": "<human-readable description>"
+}
+```
+
+Both fields are always present and non-empty.
+
+### Error Codes (initial set)
+
+| Code | Description | Example trigger |
+|------|-------------|-----------------|
+| `unknown_command` | Unrecognized subcommand | `elastic bogus --format=json` |
+| `invalid_argument` | Flag validation failure | `elastic version --format=xml` |
+| `config_error` | Config unreadable or malformed | Permission denied on config file |
+| `context_not_found` | `--context` names missing context | `elastic version --context=nope` |
+| `input_error` | Input read failure | `--file` path doesn't exist |
+| `command_failed` | Generic handler error | Network timeout, unexpected failure |
+
+## Stream Contract
+
+| Stream | `--format=json` | `--format=text` (default) |
+|--------|-----------------|--------------------------|
+| stdout | Single JSON envelope (success or error) | Human-readable text (current behavior) |
+| stderr | Empty (nothing written) | `Error: <message>\n` on failure |
+
+## Validation Contract
+
+```
+--format=json   ✓  Recognized
+--format=text   ✓  Recognized (default behavior)
+--format=xml    ✗  Exit 1, error: "unsupported format \"xml\"; supported: text, json"
+--format=JSON   ✗  Exit 1 (case-sensitive)
+--format=""     ✗  Exit 1, treated as unsupported value
+```
+
+When `--format` is not provided at all, default is `text`.
+
+## Pipeline Contract
+
+```bash
+# All of these must succeed without parse errors:
+elastic version --format=json | jq .
+elastic version --format=json | jq -r '.data'
+elastic version --format=json | python3 -c 'import json,sys; json.load(sys.stdin)'
+
+# Error responses are also valid JSON:
+elastic bogus --format=json 2>/dev/null | jq -r '.error.code'
+```
+
+## Backward Compatibility
+
+- Commands invoked without `--format` produce identical output to current behavior.
+- No existing flags or behaviors are modified.
+- Exit codes are preserved: 0 for success, 1 for error (same in both formats).

--- a/specs/003-json-output-format/contracts/json-envelope.md
+++ b/specs/003-json-output-format/contracts/json-envelope.md
@@ -77,8 +77,9 @@ Both fields are always present and non-empty.
 
 | Code | Description | Example trigger |
 |------|-------------|-----------------|
-| `command_failed` | Unrecognized subcommand or generic handler error | `elastic bogus --format=json`; network timeout |
-| `invalid_argument` | Flag value not supported | `elastic version --format=xml` |
+| `unknown_command` | Unrecognized subcommand | `elastic bogus --format=json` |
+| `command_failed` | Generic handler error (network timeout, unexpected failure) | Handler returns an error |
+| `invalid_argument` | Flag value not supported or unknown flag | `elastic version --format=xml`; `elastic version --bogus-flag` |
 | `config_error` | Config unreadable or malformed | Permission denied on config file |
 | `context_not_found` | `--context` names missing context | `elastic version --context=nope` |
 | `input_error` | Input read failure | `--file` path doesn't exist |
@@ -112,7 +113,7 @@ elastic version --format=json | python3 -c 'import json,sys; json.load(sys.stdin
 
 # Error responses are also valid JSON (note: no stderr redirection needed):
 elastic bogus --format=json | jq -r '.error.code'
-# prints: command_failed
+# prints: unknown_command
 ```
 
 ## Backward Compatibility

--- a/specs/003-json-output-format/contracts/json-envelope.md
+++ b/specs/003-json-output-format/contracts/json-envelope.md
@@ -46,7 +46,7 @@ Every command response when `--format=json` is active conforms to this structure
 
 ```json
 {
-  "data": {"status": "ok"},
+  "data": null,
   "error": null,
   "warnings": []
 }
@@ -77,28 +77,27 @@ Both fields are always present and non-empty.
 
 | Code | Description | Example trigger |
 |------|-------------|-----------------|
-| `unknown_command` | Unrecognized subcommand | `elastic bogus --format=json` |
-| `invalid_argument` | Flag validation failure | `elastic version --format=xml` |
+| `command_failed` | Unrecognized subcommand or generic handler error | `elastic bogus --format=json`; network timeout |
+| `invalid_argument` | Flag value not supported | `elastic version --format=xml` |
 | `config_error` | Config unreadable or malformed | Permission denied on config file |
 | `context_not_found` | `--context` names missing context | `elastic version --context=nope` |
 | `input_error` | Input read failure | `--file` path doesn't exist |
-| `command_failed` | Generic handler error | Network timeout, unexpected failure |
 
 ## Stream Contract
 
 | Stream | `--format=json` | `--format=text` (default) |
 |--------|-----------------|--------------------------|
 | stdout | Single JSON envelope (success or error) | Human-readable text (current behavior) |
-| stderr | Empty (nothing written) | `Error: <message>\n` on failure |
+| stderr | Always empty | `Error: <message>\n` on failure |
 
 ## Validation Contract
 
 ```
 --format=json   ✓  Recognized
 --format=text   ✓  Recognized (default behavior)
---format=xml    ✗  Exit 1, error: "unsupported format \"xml\"; supported: text, json"
---format=JSON   ✗  Exit 1 (case-sensitive)
---format=""     ✗  Exit 1, treated as unsupported value
+--format=xml    ✗  Exit 0, stdout JSON: {"data":null,"error":{"code":"invalid_argument","message":"unsupported format \"xml\": supported values are \"text\" and \"json\""},"warnings":[]}
+--format=JSON   ✗  Same as above (case-sensitive)
+--format=""         Silently treated as --format=text (default)
 ```
 
 When `--format` is not provided at all, default is `text`.
@@ -111,8 +110,9 @@ elastic version --format=json | jq .
 elastic version --format=json | jq -r '.data'
 elastic version --format=json | python3 -c 'import json,sys; json.load(sys.stdin)'
 
-# Error responses are also valid JSON:
-elastic bogus --format=json 2>/dev/null | jq -r '.error.code'
+# Error responses are also valid JSON (note: no stderr redirection needed):
+elastic bogus --format=json | jq -r '.error.code'
+# prints: command_failed
 ```
 
 ## Backward Compatibility

--- a/specs/003-json-output-format/data-model.md
+++ b/specs/003-json-output-format/data-model.md
@@ -1,0 +1,109 @@
+# Data Model: JSON Output Format Flag
+
+**Phase**: 1 | **Date**: 2026-03-27 | **Plan**: [plan.md](./plan.md)
+
+## Entities
+
+### Envelope
+
+The top-level JSON response structure emitted on stdout when `--format=json` is active.
+
+**Package**: `internal/output`
+
+| Field | Type | JSON key | Nullable | Description |
+|-------|------|----------|----------|-------------|
+| Data | `any` | `data` | Yes (null when error) | Command result payload. Type varies per command. |
+| Error | `*Error` | `error` | Yes (null on success) | Structured error when the command fails. |
+| Warnings | `[]string` | `warnings` | No (empty `[]`, never null) | Diagnostic warnings collected during execution. |
+
+**Validation rules**:
+- Exactly one of `Data` or `Error` is non-null. Both null and both non-null are programming errors.
+- `Warnings` is always initialized to `[]string{}` so JSON output is `[]` not `null`.
+- The entire struct must produce valid JSON via `json.Marshal` with no error.
+
+**State transitions**: Immutable after construction. Built once by the factory after the handler returns, then serialized and discarded.
+
+---
+
+### Error
+
+A structured error value embedded in the Envelope.
+
+**Package**: `internal/output`
+
+| Field | Type | JSON key | Required | Description |
+|-------|------|----------|----------|-------------|
+| Code | `string` | `code` | Yes | Machine-readable snake_case error identifier. |
+| Message | `string` | `message` | Yes | Human-readable error description. |
+
+**Validation rules**:
+- `Code` must be non-empty.
+- `Message` must be non-empty.
+- Both must be plain UTF-8 text (no ANSI codes, no control characters).
+
+**Known codes** (initial set):
+
+| Code | Trigger |
+|------|---------|
+| `unknown_command` | Unrecognized subcommand |
+| `invalid_argument` | Flag validation failure, unsupported `--format` value |
+| `config_error` | Config file unreadable/unparseable |
+| `context_not_found` | `--context` references unknown context |
+| `input_error` | `--file`/stdin read error, or both provided |
+| `command_failed` | Generic handler error (fallback code) |
+
+---
+
+### RunContext (extended)
+
+Existing struct in `internal/factory`. No new fields are added to RunContext itself — format resolution is handled by the factory wrapper, not exposed to handlers.
+
+**Rationale**: Handlers should not know about output format. They return data; the factory renders it. This prevents handlers from conditionally branching on format, which would defeat centralized control.
+
+---
+
+### RunFunc (signature change)
+
+**Current**: `type RunFunc func(ctx RunContext) error`
+**New**: `type RunFunc func(ctx RunContext) (any, error)`
+
+The first return value is the data payload for the Envelope. Returning `nil, nil` produces `{"data": null, "error": null, "warnings": []}` (used for commands with no meaningful output, though `{"status": "ok"}` is preferred per FR-007).
+
+---
+
+### Format (value object)
+
+Represents the resolved output format. Not a separate struct — just a validated string constant.
+
+**Package**: `internal/output`
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `FormatText` | `"text"` | Default human-readable output. |
+| `FormatJSON` | `"json"` | JSON envelope output. |
+
+**Validation**: `ValidateFormat(s string) error` returns nil for known values, error listing supported formats otherwise.
+
+## Relationships
+
+```
+rootCmd
+  └── PersistentFlags: --format (string, default "text")
+
+factory.New() RunE wrapper
+  ├── reads --format from root flags
+  ├── validates format value via output.ValidateFormat()
+  ├── calls RunFunc handler → (data any, err error)
+  ├── builds output.Envelope{Data: data, Error: err, Warnings: warnings}
+  └── calls output.Render(envelope, format, writer)
+
+output.Render()
+  ├── format == "json" → json.Marshal(envelope) + "\n" → stdout
+  └── format == "text" → text callback or fmt.Fprintln → stdout
+
+cmd.Execute()
+  ├── err == nil → normal exit
+  └── err != nil
+      ├── format == "json" → output.RenderError(err) → stdout, exit 1
+      └── format == "text" → fmt.Fprintf(stderr, "Error: %s\n") → exit 1
+```

--- a/specs/003-json-output-format/plan.md
+++ b/specs/003-json-output-format/plan.md
@@ -1,0 +1,84 @@
+# Implementation Plan: JSON Output Format Flag
+
+**Branch**: `003-json-output-format` | **Date**: 2026-03-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature spec from `/specs/003-json-output-format/spec.md`
+
+## Summary
+
+Add a global `--format` persistent flag to the root command so every subcommand can emit a consistent JSON envelope (`{"data": …, "error": …, "warnings": […]}`) to stdout. The flag is handled entirely in the shared `factory.New` path — individual RunFunc handlers return structured data and the factory serializes it. Errors also serialize to the envelope on stdout with machine-readable codes. No new dependencies are introduced; implementation uses only `encoding/json` from the standard library.
+
+## Technical Context
+
+**Language/Version**: Go 1.25.3
+**Primary Dependencies**: Cobra v1.10.2 (CLI framework), pflag v1.0.9, yaml.v3 (config)
+**Storage**: N/A — CLI tool, no persistent storage
+**Testing**: `go test` with table-driven subtests, existing `*test/` helper packages
+**Target Platform**: Cross-platform CLI (Linux, macOS, Windows)
+**Project Type**: CLI tool
+**Performance Goals**: N/A for this feature — output formatting adds negligible overhead
+**Constraints**: No new third-party dependencies (Constitution §VI). stdlib `encoding/json` only.
+**Scale/Scope**: Currently 1 subcommand (`version`); design must scale to dozens
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| # | Principle | Status | Evidence |
+|---|-----------|--------|----------|
+| I | Config-Driven Commands | ✅ PASS | `--format` is a globally inherited persistent flag, consistent with config-driven approach. No per-command opt-in required. |
+| II | Agent-First I/O (NON-NEG.) | ✅ PASS | This feature **directly implements** the constitution's mandate: "Every command MUST emit machine-readable JSON when `--format=json` is provided." Envelope structure matches required `{"error": {"code": "…", "message": "…"}}`. |
+| III | Input Validation & Safety (NON-NEG.) | ✅ PASS | Unsupported `--format` values are rejected with structured error (FR-005). JSON errors on stdout with code+message (FR-003). |
+| IV | Context-Based Configuration | ✅ N/A | No change to context/config system. `--format` is orthogonal to `--context`. |
+| V | Test-First Development (NON-NEG.) | ✅ PASS | TDD cycle will be followed: tests written before implementation at each step. |
+| VI | Minimal Dependencies | ✅ PASS | Uses only stdlib `encoding/json`. Zero new modules. |
+| — | Error messages (Dev Standards) | ✅ PASS | Errors serialize as `{"error": {"code": "…", "message": "…"}}` per constitution's Development Standards. |
+
+**Gate result: ALL PASS — proceed to Phase 0.**
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/003-json-output-format/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output
+│   └── json-envelope.md
+└── tasks.md             # Phase 2 output (NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+cmd/
+├── root.go              # Add --format persistent flag registration
+├── root_test.go         # Tests for --format flag on root + Execute() JSON error path
+└── cmdtest/
+    └── helpers.go       # Existing helpers (no changes expected)
+
+internal/
+├── factory/
+│   ├── factory.go       # Extend RunContext, modify New() to serialize output
+│   ├── factory_test.go  # Tests for JSON envelope, error serialization, format validation
+│   └── factorytest/
+│       └── helpers.go   # Existing helpers (no changes expected)
+└── output/
+    ├── output.go        # New: Envelope type, Render function, format constants
+    └── output_test.go   # New: Unit tests for envelope marshaling, edge cases
+```
+
+**Structure Decision**: New `internal/output` package isolates envelope types and
+rendering from the factory wiring. The factory calls `output.Render()` after the
+handler returns, keeping RunFunc signatures focused on business logic. This follows
+Go's preference for small, focused packages.
+
+## Complexity Tracking
+
+> No constitution violations to justify.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| (none)    | —          | —                                   |

--- a/specs/003-json-output-format/quickstart.md
+++ b/specs/003-json-output-format/quickstart.md
@@ -1,0 +1,87 @@
+# Quickstart: JSON Output Format
+
+**Phase**: 1 | **Date**: 2026-03-27 | **Plan**: [plan.md](./plan.md)
+
+## Basic Usage
+
+```bash
+# Default (text) — unchanged from current behavior
+elastic version
+# elastic version dev
+
+# JSON output
+elastic version --format=json
+# {"data":"elastic version dev","error":null,"warnings":[]}
+```
+
+## Pipe to jq
+
+```bash
+elastic version --format=json | jq -r '.data'
+# elastic version dev
+```
+
+## Error Handling
+
+```bash
+# Errors are also JSON on stdout (exit code is still 1)
+elastic version --context=bogus --format=json
+# {"data":null,"error":{"code":"context_not_found","message":"context \"bogus\" not found; no contexts are configured"},"warnings":[]}
+
+# Extract error code in a script
+code=$(elastic version --context=bogus --format=json | jq -r '.error.code')
+echo "$code"   # context_not_found
+```
+
+## Scripting Pattern
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+output=$(elastic version --format=json)
+error_code=$(echo "$output" | jq -r '.error.code // empty')
+
+if [[ -n "$error_code" ]]; then
+  echo "Failed: $error_code" >&2
+  exit 1
+fi
+
+echo "Success: $(echo "$output" | jq -r '.data')"
+```
+
+## Unsupported Format
+
+```bash
+elastic version --format=xml
+# Error: unsupported format "xml"; supported: text, json
+# (exit code 1)
+
+elastic version --format=xml --format=json
+# Uses last value — not recommended; pass --format once
+```
+
+## Implementation Notes (for developers)
+
+### Adding JSON support to a new command
+
+No special action needed. If you use `factory.New()`, JSON output works automatically:
+
+```go
+factory.New("my-command", "Does a thing", func(ctx factory.RunContext) (any, error) {
+    // Return data — the factory handles serialization
+    return map[string]string{"result": "hello"}, nil
+})
+```
+
+- `--format=json` → `{"data":{"result":"hello"},"error":null,"warnings":[]}`
+- `--format=text` (default) → text rendering callback or `fmt.Fprintln`
+
+### Returning errors
+
+Just return an error as the second value. The factory converts it to a JSON error envelope automatically:
+
+```go
+return nil, fmt.Errorf("something went wrong")
+// → {"data":null,"error":{"code":"command_failed","message":"something went wrong"},"warnings":[]}
+```

--- a/specs/003-json-output-format/research.md
+++ b/specs/003-json-output-format/research.md
@@ -1,0 +1,120 @@
+# Research: JSON Output Format Flag
+
+**Phase**: 0 | **Date**: 2026-03-27 | **Plan**: [plan.md](./plan.md)
+
+## Research Tasks
+
+### RT-1: Cobra persistent flag for output format control
+
+**Context**: Need a `--format` flag available on all commands without per-command registration.
+
+**Decision**: Register `--format` as a `PersistentFlags().String()` on `rootCmd`, exactly like the existing `--context` flag.
+
+**Rationale**: Cobra's persistent-flag inheritance is already proven in this codebase (`--context`). A persistent string flag on root automatically propagates to every subcommand. The factory's `RunE` can look it up via `cmd.Root().PersistentFlags().Lookup("format")` — the same pattern already used for `--context`.
+
+**Alternatives considered**:
+- Per-command flag registration in `factory.New()` — rejected because it duplicates the flag on every command and breaks the global-inheritance guarantee (FR-001).
+- Environment variable (`ELASTIC_FORMAT`) — rejected because the spec requires an explicit `--format` flag. Env var support could be layered later but is out of scope.
+
+---
+
+### RT-2: JSON envelope design using stdlib `encoding/json`
+
+**Context**: Spec requires a consistent envelope: `{"data": X, "error": null, "warnings": [...]}`.
+
+**Decision**: Define an `Envelope` struct in a new `internal/output` package:
+
+```go
+type Envelope struct {
+    Data     any      `json:"data"`
+    Error    *Error   `json:"error"`
+    Warnings []string `json:"warnings"`
+}
+
+type Error struct {
+    Code    string `json:"code"`
+    Message string `json:"message"`
+}
+```
+
+Marshal with `json.Marshal` (no `json.NewEncoder` to avoid trailing newline inconsistencies across Go versions). Append a single `\n` after the marshaled bytes for shell friendliness.
+
+**Rationale**: `any` (alias for `interface{}`) lets each command return whatever data type it wants. `*Error` is a pointer so it marshals as `null` on success. `Warnings` marshals as `[]` (initialized to empty slice, never nil) so the envelope shape is always predictable.
+
+**Alternatives considered**:
+- `map[string]any` envelope — rejected because it loses compile-time field guarantees.
+- `json.NewEncoder(os.Stdout).Encode()` — rejected because Encode adds a trailing newline that varies across Go versions and makes byte-exact testing harder.
+
+---
+
+### RT-3: Error code taxonomy
+
+**Context**: Constitution requires `{"error": {"code": "…", "message": "…"}}`. Need a set of canonical codes.
+
+**Decision**: Use a small set of snake_case error codes as string constants:
+
+| Code | When |
+|------|------|
+| `unknown_command` | Cobra reports an unknown subcommand |
+| `invalid_argument` | Flag validation or unsupported `--format` value |
+| `config_error` | Config file unreadable or unparseable |
+| `context_not_found` | `--context` names a nonexistent context |
+| `input_error` | `--file` / stdin read failure or both provided |
+| `command_failed` | Handler returns a generic error |
+
+**Rationale**: Snake_case is the most common convention for machine-readable error codes in CLI tools (aws-cli, gcloud, gh). A small initial set avoids over-engineering; commands can introduce domain-specific codes later by returning typed errors.
+
+**Alternatives considered**:
+- Numeric error codes — rejected; harder to read in logs and scripts.
+- Hierarchical codes (e.g., `input.file.not_found`) — rejected as premature; flat codes suffice for current command count.
+
+---
+
+### RT-4: Integration point — where formatting happens
+
+**Context**: Need to decide where in the call chain JSON serialization occurs.
+
+**Decision**: Modify `factory.New()` so that:
+1. The `RunFunc` signature changes to return `(any, error)` instead of just `error` — the first return value is the data to render.
+2. After the handler returns, `factory.New()`'s `RunE` wrapper checks the `--format` flag.
+3. If `json`, it builds an `output.Envelope` and writes it to stdout.
+4. If `text` (default), it calls a text-rendering callback (or `fmt.Fprintln` for simple values).
+
+This keeps handlers format-agnostic: they return data and never write to stdout directly.
+
+**Rationale**: Centralizing serialization in the factory means:
+- New commands automatically get JSON support.
+- Handlers cannot accidentally break JSON purity (no rogue `fmt.Println`).
+- Testing is simpler — assert on returned data, not captured stdout.
+
+**Alternatives considered**:
+- Middleware/decorator on each command — rejected; more boilerplate, easy to forget.
+- Handler writes its own JSON — rejected; violates DRY and risks inconsistent envelopes.
+
+---
+
+### RT-5: Error path in `Execute()` (root command)
+
+**Context**: Currently `cmd.Execute()` catches errors and writes `Error: %s\n` to stderr. With `--format=json`, this must produce a JSON envelope on stdout instead.
+
+**Decision**: Modify `Execute()` to check if `--format=json` was requested. If so, build an error envelope with code `command_failed` (or a more specific code if the error is a known typed error) and write it to stdout. If text mode, preserve existing stderr behavior.
+
+For errors that occur *before* the format flag can be parsed (e.g., truly malformed command lines), fall back to the current stderr text behavior — this is acceptable because such errors mean the flag itself wasn't processable.
+
+**Rationale**: This is the only place where Cobra-level errors (unknown command, flag parse errors) surface. It must be format-aware to satisfy FR-003 and SC-002.
+
+**Alternatives considered**:
+- Always write errors to stderr even in JSON mode — rejected; contradicts the clarification that JSON errors go to stdout (aws-cli convention).
+- Wrap Cobra's error handler — Cobra doesn't expose a clean hook; overriding `Execute()` behavior is the standard approach.
+
+---
+
+## Summary
+
+All technical unknowns resolved. No NEEDS CLARIFICATION items remain. Key decisions:
+
+1. **Flag**: Persistent string on rootCmd, same pattern as `--context`
+2. **Envelope**: `internal/output.Envelope` struct with `Data`, `Error`, `Warnings` fields
+3. **Handler signature**: `RunFunc` returns `(any, error)` — factory handles serialization
+4. **Error codes**: Flat snake_case strings, small initial taxonomy
+5. **Centralized rendering**: All output goes through `factory.New()`'s RunE wrapper

--- a/specs/003-json-output-format/spec.md
+++ b/specs/003-json-output-format/spec.md
@@ -1,0 +1,106 @@
+# Feature spec: JSON Output Format Flag
+
+**Feature Branch**: `003-json-output-format`
+**Created**: 2026-03-27
+**Status**: Draft
+**Input**: User description: "If a --format=json argument is provided for any command, any output should be printed as valid JSON, with no non-JSON text before or after, so that the data can be directly piped into other commands."
+
+## Clarifications
+
+### Session 2026-03-27
+
+- Q: Error Output Stream for JSON Mode → A: JSON errors go to stdout (like aws-cli, gcloud when using --format=json)
+- Q: JSON Response Structure Consistency → A: Consistent envelope: `{"data": X, "error": null}` vs `{"data": null, "error": Y}`
+- Q: Warning Message Handling in JSON Mode → A: Embed warnings in JSON envelope: `{"data": X, "error": null, "warnings": [...]}`
+- Q: Progress/Spinner Output Suppression → A: Complete suppression of all progress/spinner output in JSON mode
+- Q: Error Structure Detail Level → A: Structured: `{"error": {"code": "invalid_argument", "message": "..."}}`
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Machine-readable output for scripting (Priority: P1)
+
+A user running the CLI in a script or pipeline passes `--format=json` to receive structured output that can be directly piped into tools like `jq`, `fx`, or other commands that consume JSON.
+
+**Why this priority**: This is the core value of the feature. Any command that supports `--format=json` must emit pure, valid JSON — no banners, no prompts, no status messages — so automated pipelines work reliably.
+
+**Independent Test**: Run any command with `--format=json` and pipe the output to `jq .`; it must parse without error and produce the expected data.
+
+**Acceptance Scenarios**:
+
+1. **given** a command is run with `--format=json`, **when** the command succeeds, **then** stdout contains only valid JSON with no surrounding text
+2. **given** a command is run with `--format=json`, **when** the command succeeds, **then** the JSON output can be piped directly into `jq` or equivalent tools without errors
+3. **given** a command is run without `--format=json`, **when** the command succeeds, **then** output is unchanged from current behavior (human-readable text)
+
+---
+
+### User Story 2 - Error output does not break JSON pipelines (Priority: P2)
+
+A user running a CLI command with `--format=json` that encounters an error (e.g., invalid arguments, authentication failure, network issue) still receives a JSON-formatted error response rather than a plain-text error message.
+
+**Why this priority**: A mixed-format pipeline breaks silently. If errors produce text while successes produce JSON, automated scripts cannot reliably detect failure conditions.
+
+**Independent Test**: Trigger an error condition on any command with `--format=json`; the stdout output should be a valid JSON object describing the error, not a plain-text message.
+
+**Acceptance Scenarios**:
+
+1. **given** a command is run with `--format=json`, **when** the command fails (e.g., missing required argument, server error), **then** the error is reported as a consistent JSON envelope with structured error codes (e.g., `{"data": null, "error": {"code": "invalid_argument", "message": "..."}}`) rather than unstructured text
+2. **given** a command is run with `--format=json`, **when** a recoverable warning exists alongside successful output, **then** warnings are embedded in the JSON envelope structure (e.g., `{"data": X, "error": null, "warnings": [...]}`) not printed as plain text
+
+---
+
+### User Story 3 - Consistent flag across all commands (Priority: P3)
+
+A user can rely on `--format=json` being available on every command in the CLI, rather than only a subset.
+
+**Why this priority**: Inconsistent availability forces users to check per-command documentation and makes scripting fragile.
+
+**Independent Test**: Run `--help` on each command and confirm `--format` is listed as an available flag.
+
+**Acceptance Scenarios**:
+
+1. **given** any command in the CLI, **when** the user passes `--format=json`, **then** the flag is recognized (not treated as an unknown flag)
+2. **given** a command whose output is already structured data, **when** `--format=json` is used, **then** the JSON output includes all fields present in the default human-readable output
+
+---
+
+### Edge Cases
+
+- What happens when `--format` is provided with an unsupported value (e.g., `--format=xml`)? The command should fail with a clear error indicating supported formats.
+- What happens when a command produces no output (e.g., a delete operation)? The JSON output should be an empty object `{}` or a status confirmation object, not an empty string.
+- What happens when the command writes progress or spinner output to stdout? All progress indicators, spinners, and non-data output must be completely suppressed when `--format=json` is active.
+- What happens when stdout is not a TTY and `--format=json` is not specified? JSON output is never automatic — `--format=json` must always be explicitly provided. Piping output without the flag produces the same human-readable text as terminal output.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Every CLI command MUST accept a `--format` flag with at least the value `json`
+- **FR-002**: When `--format=json` is specified, stdout MUST contain only valid, parseable JSON — no preamble, no trailing text, no ANSI escape codes, no spinner output
+- **FR-003**: When `--format=json` is specified, error conditions MUST be reported using consistent JSON envelope structure with machine-readable error codes (e.g., `{"data": null, "error": {"code": "invalid_argument", "message": "..."}}`) to stdout rather than unstructured text
+- **FR-004**: When `--format=json` is NOT specified, command output MUST remain unchanged from its current human-readable form
+- **FR-005**: When `--format` is given an unsupported value, the command MUST exit with a non-zero status and report the list of supported format values
+- **FR-006**: When `--format=json` is specified, all progress indicators, spinners, and informational banners MUST be completely suppressed (warnings are handled via FR-008)
+- **FR-007**: Commands that produce no meaningful data output (e.g., destructive operations with no return value) MUST emit consistent JSON envelope structure (e.g., `{"data": {"status": "ok"}, "error": null}`) rather than empty output
+- **FR-008**: When `--format=json` is specified, warning messages MUST be embedded in the JSON envelope structure as a "warnings" array rather than output as separate text
+
+### Key Entities
+
+- **Command output**: The structured data a command produces; must be representable as a JSON object or array following consistent envelope structure (`{"data": X, "error": null, "warnings": []}`)
+- **Format flag**: A top-level, globally inherited CLI flag (`--format`) that controls output serialization
+- **Error object**: Structured error information containing machine-readable code and human-readable message (`{"code": "error_type", "message": "description"}`)
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Output produced with `--format=json` passes JSON validation (e.g., `jq .`) on 100% of commands with zero additional transformation
+- **SC-002**: Zero plain-text characters appear on stdout when `--format=json` is active, for both success and error paths
+- **SC-003**: All existing commands recognize `--format=json` without requiring per-command changes by end users
+- **SC-004**: A script piping multiple CLI commands together with `--format=json` runs end-to-end without parsing errors in a standard CI environment
+
+## Assumptions
+
+- The `--format` flag defaults to a human-readable text format when not specified; no existing behavior changes.
+- JSON output structure for each command mirrors the data already shown in human-readable output — no additional fields are added solely for JSON mode.
+- Warning messages are embedded in the JSON envelope structure as a "warnings" array field, ensuring all diagnostic information remains accessible to automated tools while maintaining JSON output purity.
+- A globally registered persistent flag (inherited by all subcommands) is the implementation approach; individual commands need not opt in explicitly.

--- a/specs/003-json-output-format/tasks.md
+++ b/specs/003-json-output-format/tasks.md
@@ -56,15 +56,15 @@
 
 > **Write these tests FIRST, ensure they FAIL, then implement.**
 
-- [ ] T012 [P] [US1] Add test in `internal/factory/factory_test.go`: command with `--format=json` produces valid JSON envelope on stdout with `"data"` field matching handler return value
-- [ ] T013 [P] [US1] Add test in `internal/factory/factory_test.go`: command with `--format=json` stdout output parses with `json.Valid()` — no preamble, no trailing text
-- [ ] T014 [P] [US1] Add test in `internal/factory/factory_test.go`: command without `--format` flag produces unchanged text output (backward compatibility)
-- [ ] T015 [P] [US1] Add test in `internal/factory/factory_test.go`: command with `--format=text` produces identical output to no flag (explicit default)
+- [X] T012 [P] [US1] Add test in `internal/factory/factory_test.go`: command with `--format=json` produces valid JSON envelope on stdout with `"data"` field matching handler return value
+- [X] T013 [P] [US1] Add test in `internal/factory/factory_test.go`: command with `--format=json` stdout output parses with `json.Valid()` — no preamble, no trailing text
+- [X] T014 [P] [US1] Add test in `internal/factory/factory_test.go`: command without `--format` flag produces unchanged text output (backward compatibility)
+- [X] T015 [P] [US1] Add test in `internal/factory/factory_test.go`: command with `--format=text` produces identical output to no flag (explicit default)
 
 ### Implementation for US1
 
-- [ ] T016 [US1] Ensure `output.Render()` with `FormatJSON` writes only `json.Marshal(envelope) + "\n"` to the writer — no extra bytes — in `internal/output/output.go`
-- [ ] T017 [US1] Ensure `output.Render()` with `FormatText` writes data via `fmt.Fprintln` (string data) or `fmt.Fprintf("%v")` (other types) — preserving current behavior — in `internal/output/output.go`
+- [X] T016 [US1] Ensure `output.Render()` with `FormatJSON` writes only `json.Marshal(envelope) + "\n"` to the writer — no extra bytes — in `internal/output/output.go`
+- [X] T017 [US1] Ensure `output.Render()` with `FormatText` writes data via `fmt.Fprintln` (string data) or `fmt.Fprintf("%v")` (other types) — preserving current behavior — in `internal/output/output.go`
 
 **Checkpoint**: T012–T015 all green. `elastic version --format=json` emits pure valid JSON. `elastic version` (no flag) is unchanged.
 
@@ -80,20 +80,20 @@
 
 > **Write these tests FIRST, ensure they FAIL, then implement.**
 
-- [ ] T018 [P] [US2] Add test in `internal/factory/factory_test.go`: handler returning error with `--format=json` produces JSON envelope with `"error": {"code": "command_failed", "message": "..."}` and `"data": null` on stdout
-- [ ] T019 [P] [US2] Add test in `internal/factory/factory_test.go`: handler returning error with `--format=json` writes nothing to stderr
-- [ ] T020 [P] [US2] Add test in `internal/factory/factory_test.go`: handler returning error without `--format=json` writes `Error: <msg>` to stderr (existing behavior preserved)
-- [ ] T021 [P] [US2] Add test in `internal/factory/factory_test.go`: config error (e.g., unreadable config file) with `--format=json` produces JSON envelope with `"code": "config_error"`
-- [ ] T022 [P] [US2] Add test in `internal/factory/factory_test.go`: `--context=bogus` with `--format=json` produces JSON envelope with `"code": "context_not_found"`
-- [ ] T023 [P] [US2] Add test in `internal/factory/factory_test.go`: `--format=xml` (unsupported) produces JSON envelope with `"code": "invalid_argument"` listing supported values
-- [ ] T024 [P] [US2] Add test in `cmd/root_test.go`: `Execute()` with `--format=json` and a failing command writes JSON error envelope to stdout instead of plain text to stderr
+- [X] T018 [P] [US2] Add test in `internal/factory/factory_test.go`: handler returning error with `--format=json` produces JSON envelope with `"error": {"code": "command_failed", "message": "..."}` and `"data": null` on stdout
+- [X] T019 [P] [US2] Add test in `internal/factory/factory_test.go`: handler returning error with `--format=json` writes nothing to stderr
+- [X] T020 [P] [US2] Add test in `internal/factory/factory_test.go`: handler returning error without `--format=json` writes `Error: <msg>` to stderr (existing behavior preserved)
+- [X] T021 [P] [US2] Add test in `internal/factory/factory_test.go`: config error (e.g., unreadable config file) with `--format=json` produces JSON envelope with `"code": "config_error"`
+- [X] T022 [P] [US2] Add test in `internal/factory/factory_test.go`: `--context=bogus` with `--format=json` produces JSON envelope with `"code": "context_not_found"`
+- [X] T023 [P] [US2] Add test in `internal/factory/factory_test.go`: `--format=xml` (unsupported) produces JSON envelope with `"code": "invalid_argument"` listing supported values
+- [X] T024 [P] [US2] Add test in `cmd/root_test.go`: `Execute()` with `--format=json` and a failing command writes JSON error envelope to stdout instead of plain text to stderr
 
 ### Implementation for US2
 
-- [ ] T025 [US2] Define typed error types or error-code extraction logic in `internal/output/output.go` — map known factory errors (context-not-found, config error, input error, validation) to specific error codes
-- [ ] T026 [US2] Update `output.Render()` in `internal/output/output.go` to use error-code extraction when building the error envelope — classify errors into `context_not_found`, `config_error`, `input_error`, `invalid_argument`, or fallback `command_failed`
-- [ ] T027 [US2] Update `factory.New()` RunE in `internal/factory/factory.go` to intercept format-validation errors and pre-factory errors (config, context, input) and route them through `output.Render()` instead of returning raw errors to Cobra
-- [ ] T028 [US2] Update `Execute()` in `cmd/root.go` to check `--format` flag on error path — if `json`, write JSON error envelope to stdout; if `text`, preserve existing stderr behavior
+- [X] T025 [US2] Define typed error types or error-code extraction logic in `internal/output/output.go` — map known factory errors (context-not-found, config error, input error, validation) to specific error codes
+- [X] T026 [US2] Update `output.Render()` in `internal/output/output.go` to use error-code extraction when building the error envelope — classify errors into `context_not_found`, `config_error`, `input_error`, `invalid_argument`, or fallback `command_failed`
+- [X] T027 [US2] Update `factory.New()` RunE in `internal/factory/factory.go` to intercept format-validation errors and pre-factory errors (config, context, input) and route them through `output.Render()` instead of returning raw errors to Cobra
+- [X] T028 [US2] Update `Execute()` in `cmd/root.go` to check `--format` flag on error path — if `json`, write JSON error envelope to stdout; if `text`, preserve existing stderr behavior
 
 **Checkpoint**: T018–T024 all green. All error paths produce JSON envelopes with appropriate codes. No plain text leaks to stdout in JSON mode.
 

--- a/specs/003-json-output-format/tasks.md
+++ b/specs/003-json-output-format/tasks.md
@@ -109,14 +109,14 @@
 
 > **Write these tests FIRST, ensure they FAIL, then implement.**
 
-- [ ] T029 [P] [US3] Add test in `cmd/root_test.go`: every registered subcommand inherits `--format` persistent flag (iterate `rootCmd.Commands()` and assert `cmd.Root().PersistentFlags().Lookup("format") != nil`)
-- [ ] T030 [P] [US3] Add test in `cmd/root_test.go`: `elastic version --help` output contains the string `--format`
-- [ ] T031 [P] [US3] Add test in `internal/factory/factory_test.go`: command with `--format=json` returning nil data produces `{"data":null,"error":null,"warnings":[]}` (no-output command still emits valid envelope)
+- [X] T029 [P] [US3] Add test in `cmd/root_test.go`: every registered subcommand inherits `--format` persistent flag (iterate `rootCmd.Commands()` and assert `cmd.Root().PersistentFlags().Lookup("format") != nil`)
+- [X] T030 [P] [US3] Add test in `cmd/root_test.go`: `elastic version --help` output contains the string `--format`
+- [X] T031 [P] [US3] Add test in `internal/factory/factory_test.go`: command with `--format=json` returning nil data produces `{"data":null,"error":null,"warnings":[]}` (no-output command still emits valid envelope)
 
 ### Implementation for US3
 
-- [ ] T032 [US3] Verify `--format` flag description in `cmd/root.go` is clear and mentions supported values (`"Output format (text|json)"` or similar)
-- [ ] T033 [US3] Verify `factory.New()` in `internal/factory/factory.go` handles nil data return from handler gracefully (data field serializes as `null` in JSON, skipped in text)
+- [X] T032 [US3] Verify `--format` flag description in `cmd/root.go` is clear and mentions supported values (`"Output format (text|json)"` or similar)
+- [X] T033 [US3] Verify `factory.New()` in `internal/factory/factory.go` handles nil data return from handler gracefully (data field serializes as `null` in JSON, skipped in text)
 
 **Checkpoint**: T029–T031 all green. All commands show `--format` in help. Nil-data commands produce valid envelopes.
 
@@ -126,12 +126,12 @@
 
 **Purpose**: Edge cases, documentation, and validation across all stories.
 
-- [ ] T034 [P] Add test in `internal/output/output_test.go`: `Envelope.Warnings` marshals as `[]` (not `null`) when no warnings present
-- [ ] T035 [P] Add test in `internal/output/output_test.go`: `Envelope` with warnings marshals as `{"data": ..., "error": null, "warnings": ["msg1", "msg2"]}`
-- [ ] T036 [P] Add test in `internal/factory/factory_test.go`: command returning `{"status": "ok"}` as data with no error produces correct envelope for no-output commands (FR-007)
-- [ ] T037 Verify all exported symbols in `internal/output/output.go` have Go doc comments per constitution Development Standards
-- [ ] T038 Run `go vet ./...` and `go test -race ./...` — fix any issues
-- [ ] T039 Run quickstart.md scenarios manually or as a script to validate end-to-end behavior
+- [X] T034 [P] Add test in `internal/output/output_test.go`: `Envelope.Warnings` marshals as `[]` (not `null`) when no warnings present
+- [X] T035 [P] Add test in `internal/output/output_test.go`: `Envelope` with warnings marshals as `{"data": ..., "error": null, "warnings": ["msg1", "msg2"]}`
+- [X] T036 [P] Add test in `internal/factory/factory_test.go`: command returning `{"status": "ok"}` as data with no error produces correct envelope for no-output commands (FR-007)
+- [X] T037 Verify all exported symbols in `internal/output/output.go` have Go doc comments per constitution Development Standards
+- [X] T038 Run `go vet ./...` and `go test -race ./...` — fix any issues
+- [X] T039 Run quickstart.md scenarios manually or as a script to validate end-to-end behavior
 
 **Checkpoint**: All tests green, all vet/race checks pass, quickstart scenarios validated.
 

--- a/specs/003-json-output-format/tasks.md
+++ b/specs/003-json-output-format/tasks.md
@@ -1,0 +1,232 @@
+# Tasks: JSON Output Format Flag
+
+**Input**: Design documents from `/specs/003-json-output-format/`
+**Prerequisites**: plan.md ✓, spec.md ✓, research.md ✓, data-model.md ✓, contracts/ ✓, quickstart.md ✓
+
+**Tests**: Included — Constitution §V (Test-First Development) is NON-NEGOTIABLE.
+
+**Organization**: Tasks grouped by user story. Each story is independently testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story (US1, US2, US3)
+- Exact file paths included in every task description
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create the new `internal/output` package and establish the envelope types that all subsequent work depends on.
+
+- [X] T001 [P] Create `internal/output/output.go` with `Envelope`, `Error` structs, `FormatText`/`FormatJSON` constants, and `ValidateFormat()` function
+- [X] T002 [P] Create `internal/output/output_test.go` with tests for `Envelope` JSON marshaling (success, error, warnings, null fields, empty warnings as `[]`) and `ValidateFormat` (valid values, invalid values, empty string, case sensitivity)
+
+**Checkpoint**: `go test ./internal/output/...` passes. Envelope types and validation are proven.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Wire format-aware rendering into `factory.New()` and register the `--format` flag. This changes the core command execution path and MUST be complete before any user story work.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 Add `Render(w io.Writer, format string, data any, err error) error` function to `internal/output/output.go` — builds `Envelope` and writes JSON or text based on format
+- [X] T004 Add tests for `Render()` in `internal/output/output_test.go` — JSON success output, JSON error output, text success fallback, text error passthrough, warnings embedding, nil data produces `null`
+- [X] T005 Change `RunFunc` signature from `func(RunContext) error` to `func(RunContext) (any, error)` in `internal/factory/factory.go`
+- [X] T006 Update `factory.New()` RunE wrapper in `internal/factory/factory.go` to: (a) look up `--format` from root persistent flags, (b) validate format via `output.ValidateFormat()`, (c) call handler to get `(data, err)`, (d) call `output.Render()` to write the result
+- [X] T007 Update all existing tests in `internal/factory/factory_test.go` to match new `RunFunc` `(any, error)` return signature
+- [X] T008 Register `--format` as a `PersistentFlags().StringVar()` on `rootCmd` in `cmd/root.go` (default `"text"`)
+- [X] T009 Update the `version` command handler in `cmd/root.go` to return `("elastic version dev", nil)` instead of calling `fmt.Fprintln`
+- [X] T010 Add test in `cmd/root_test.go` that `--format` persistent flag is registered on `rootCmd`
+- [X] T011 Update existing tests in `cmd/root_test.go` to account for changed `RunFunc` signature and output rendering
+
+**Checkpoint**: `go test ./...` passes. Factory produces JSON envelope when `--format=json` is used, text when default. All existing behavior preserved.
+
+---
+
+## Phase 3: User Story 1 — Machine-readable output for scripting (Priority: P1) 🎯 MVP
+
+**Goal**: A user can pass `--format=json` to any command and receive valid, parseable JSON on stdout that pipes cleanly into `jq`.
+
+**Independent Test**: `elastic version --format=json | jq .` succeeds and returns the expected envelope.
+
+### Tests for US1
+
+> **Write these tests FIRST, ensure they FAIL, then implement.**
+
+- [ ] T012 [P] [US1] Add test in `internal/factory/factory_test.go`: command with `--format=json` produces valid JSON envelope on stdout with `"data"` field matching handler return value
+- [ ] T013 [P] [US1] Add test in `internal/factory/factory_test.go`: command with `--format=json` stdout output parses with `json.Valid()` — no preamble, no trailing text
+- [ ] T014 [P] [US1] Add test in `internal/factory/factory_test.go`: command without `--format` flag produces unchanged text output (backward compatibility)
+- [ ] T015 [P] [US1] Add test in `internal/factory/factory_test.go`: command with `--format=text` produces identical output to no flag (explicit default)
+
+### Implementation for US1
+
+- [ ] T016 [US1] Ensure `output.Render()` with `FormatJSON` writes only `json.Marshal(envelope) + "\n"` to the writer — no extra bytes — in `internal/output/output.go`
+- [ ] T017 [US1] Ensure `output.Render()` with `FormatText` writes data via `fmt.Fprintln` (string data) or `fmt.Fprintf("%v")` (other types) — preserving current behavior — in `internal/output/output.go`
+
+**Checkpoint**: T012–T015 all green. `elastic version --format=json` emits pure valid JSON. `elastic version` (no flag) is unchanged.
+
+---
+
+## Phase 4: User Story 2 — Error output does not break JSON pipelines (Priority: P2)
+
+**Goal**: When a command fails with `--format=json`, stdout contains a JSON error envelope with structured `code` + `message` instead of plain text.
+
+**Independent Test**: `elastic version --context=bogus --format=json | jq -r '.error.code'` outputs `context_not_found`.
+
+### Tests for US2
+
+> **Write these tests FIRST, ensure they FAIL, then implement.**
+
+- [ ] T018 [P] [US2] Add test in `internal/factory/factory_test.go`: handler returning error with `--format=json` produces JSON envelope with `"error": {"code": "command_failed", "message": "..."}` and `"data": null` on stdout
+- [ ] T019 [P] [US2] Add test in `internal/factory/factory_test.go`: handler returning error with `--format=json` writes nothing to stderr
+- [ ] T020 [P] [US2] Add test in `internal/factory/factory_test.go`: handler returning error without `--format=json` writes `Error: <msg>` to stderr (existing behavior preserved)
+- [ ] T021 [P] [US2] Add test in `internal/factory/factory_test.go`: config error (e.g., unreadable config file) with `--format=json` produces JSON envelope with `"code": "config_error"`
+- [ ] T022 [P] [US2] Add test in `internal/factory/factory_test.go`: `--context=bogus` with `--format=json` produces JSON envelope with `"code": "context_not_found"`
+- [ ] T023 [P] [US2] Add test in `internal/factory/factory_test.go`: `--format=xml` (unsupported) produces JSON envelope with `"code": "invalid_argument"` listing supported values
+- [ ] T024 [P] [US2] Add test in `cmd/root_test.go`: `Execute()` with `--format=json` and a failing command writes JSON error envelope to stdout instead of plain text to stderr
+
+### Implementation for US2
+
+- [ ] T025 [US2] Define typed error types or error-code extraction logic in `internal/output/output.go` — map known factory errors (context-not-found, config error, input error, validation) to specific error codes
+- [ ] T026 [US2] Update `output.Render()` in `internal/output/output.go` to use error-code extraction when building the error envelope — classify errors into `context_not_found`, `config_error`, `input_error`, `invalid_argument`, or fallback `command_failed`
+- [ ] T027 [US2] Update `factory.New()` RunE in `internal/factory/factory.go` to intercept format-validation errors and pre-factory errors (config, context, input) and route them through `output.Render()` instead of returning raw errors to Cobra
+- [ ] T028 [US2] Update `Execute()` in `cmd/root.go` to check `--format` flag on error path — if `json`, write JSON error envelope to stdout; if `text`, preserve existing stderr behavior
+
+**Checkpoint**: T018–T024 all green. All error paths produce JSON envelopes with appropriate codes. No plain text leaks to stdout in JSON mode.
+
+---
+
+## Phase 5: User Story 3 — Consistent flag across all commands (Priority: P3)
+
+**Goal**: `--format` is recognized by every command, present and future. No command can silently ignore it.
+
+**Independent Test**: `elastic version --help` output includes `--format` in the flags list.
+
+### Tests for US3
+
+> **Write these tests FIRST, ensure they FAIL, then implement.**
+
+- [ ] T029 [P] [US3] Add test in `cmd/root_test.go`: every registered subcommand inherits `--format` persistent flag (iterate `rootCmd.Commands()` and assert `cmd.Root().PersistentFlags().Lookup("format") != nil`)
+- [ ] T030 [P] [US3] Add test in `cmd/root_test.go`: `elastic version --help` output contains the string `--format`
+- [ ] T031 [P] [US3] Add test in `internal/factory/factory_test.go`: command with `--format=json` returning nil data produces `{"data":null,"error":null,"warnings":[]}` (no-output command still emits valid envelope)
+
+### Implementation for US3
+
+- [ ] T032 [US3] Verify `--format` flag description in `cmd/root.go` is clear and mentions supported values (`"Output format (text|json)"` or similar)
+- [ ] T033 [US3] Verify `factory.New()` in `internal/factory/factory.go` handles nil data return from handler gracefully (data field serializes as `null` in JSON, skipped in text)
+
+**Checkpoint**: T029–T031 all green. All commands show `--format` in help. Nil-data commands produce valid envelopes.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Edge cases, documentation, and validation across all stories.
+
+- [ ] T034 [P] Add test in `internal/output/output_test.go`: `Envelope.Warnings` marshals as `[]` (not `null`) when no warnings present
+- [ ] T035 [P] Add test in `internal/output/output_test.go`: `Envelope` with warnings marshals as `{"data": ..., "error": null, "warnings": ["msg1", "msg2"]}`
+- [ ] T036 [P] Add test in `internal/factory/factory_test.go`: command returning `{"status": "ok"}` as data with no error produces correct envelope for no-output commands (FR-007)
+- [ ] T037 Verify all exported symbols in `internal/output/output.go` have Go doc comments per constitution Development Standards
+- [ ] T038 Run `go vet ./...` and `go test -race ./...` — fix any issues
+- [ ] T039 Run quickstart.md scenarios manually or as a script to validate end-to-end behavior
+
+**Checkpoint**: All tests green, all vet/race checks pass, quickstart scenarios validated.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```
+Phase 1: Setup ──────────────────┐
+                                 ▼
+Phase 2: Foundational ───────────┤ (BLOCKS all user stories)
+                                 ▼
+         ┌───────────────────────┼───────────────────────┐
+         ▼                       ▼                       ▼
+Phase 3: US1 (P1) 🎯    Phase 4: US2 (P2)       Phase 5: US3 (P3)
+         │                       │                       │
+         └───────────────────────┼───────────────────────┘
+                                 ▼
+                       Phase 6: Polish
+```
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Foundational (Phase 2) only. No dependency on other stories.
+- **US2 (P2)**: Depends on Foundational (Phase 2) only. Builds on same infra as US1 but is independently testable.
+- **US3 (P3)**: Depends on Foundational (Phase 2) only. Verifies inheritance — no code changes, just validation.
+
+### Within Each User Story
+
+1. Write tests FIRST → confirm they FAIL
+2. Implement minimum code to make tests PASS
+3. Refactor under green
+
+### Parallel Opportunities
+
+- **Phase 1**: T001, T002 can run in parallel (separate files)
+- **Phase 2**: T003–T004 (output pkg) can parallel with T008, T010 (root.go) initially, but T005–T007 and T009, T011 are sequential
+- **Phase 3–5**: All user stories can start in parallel after Phase 2 completes
+- **Within stories**: All test tasks marked [P] can run in parallel
+- **Phase 6**: T034, T035, T036 can run in parallel
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch all US2 tests together (they target different scenarios, same file):
+T018: JSON error envelope structure test
+T019: JSON error stderr-silence test
+T020: Text error backward-compat test
+T021: Config error code classification test
+T022: Context-not-found error code test
+T023: Unsupported format error code test
+T024: Execute() JSON error path test (different file: cmd/root_test.go)
+
+# Then implement sequentially:
+T025 → T026 → T027 → T028
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Phase 1: Setup (T001–T002)
+2. Complete Phase 2: Foundational (T003–T011)
+3. Complete Phase 3: US1 (T012–T017)
+4. **STOP and VALIDATE**: `elastic version --format=json | jq .` works
+5. This is a usable, shippable increment
+
+### Incremental Delivery
+
+1. Setup + Foundational → Core infrastructure ready
+2. Add US1 → JSON output works for success path → **MVP** 🎯
+3. Add US2 → Errors also produce JSON → Pipelines fully reliable
+4. Add US3 → Flag consistency verified → Full feature complete
+5. Polish → Edge cases, docs, race checks
+
+### Single Developer Strategy (Recommended)
+
+Execute phases sequentially in priority order:
+Phase 1 → Phase 2 → Phase 3 (US1) → Phase 4 (US2) → Phase 5 (US3) → Phase 6
+
+Each phase is a natural commit boundary.
+
+---
+
+## Notes
+
+- Constitution §V mandates TDD — all test tasks must FAIL before implementation
+- [P] tasks target different files or independent scenarios
+- [Story] label traces every task to its user story
+- Commit after each phase or logical group of tasks
+- Stop at any checkpoint to validate independently
+- The `version` command is the only existing command — it serves as the integration test target for all stories


### PR DESCRIPTION
Support a `--format=json` argument for all commands, which ensures JSON is printed to stdout and **nothing else**. Error types are also improved to ensure they can be rendered as JSON.

To be consistent with tools like aws-cli and gcloud, errors printed as JSON will appear on stdout rather than stderr.
