### PR TITLE
.github: remove scheduled agentic workflow

### DIFF
--- a/.github/workflows/agentic-scenarios.yml
+++ b/.github/workflows/agentic-scenarios.yml
@@ -2,8 +2,6 @@ name: Agentic Scenarios
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 4 * * *"
 
 permissions:
   contents: read


### PR DESCRIPTION
It's failing, and creating noise on a branch destined to be superseded.
We can add it back in later, once the MVP is ready for it.