### PR TITLE
Add dry run support

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -28,7 +28,7 @@ const numberSchema = z.coerce.number()
  * ```
  */
 export interface OptionDefinition {
-  /** long option name without `--` prefix (e.g. `'timeout'`, `'dry-run'`) */
+  /** long option name without `--` prefix (e.g. `'timeout'`, `'output-dir'`) */
   long: string
   /** single-character short alias without `-` prefix (e.g. `'t'`) */
   short?: string
@@ -318,7 +318,11 @@ export function defineCommand<T extends z.ZodType>(config: CommandConfig<T>): Op
   validateName(config.name, 'command')
   validateOptions(config.options ?? [])
   validateInput(config.name, config.input)
-  // --file is reserved when input is a schema; catch collision at definition time
+  if (config.options?.some((o) => o.long === 'dry-run')) {
+    throw new Error(
+      `command ${JSON.stringify(config.name)}: option --dry-run is reserved`
+    )
+  }
   if (config.input instanceof z.ZodType && config.options?.some((o) => o.long === 'file')) {
     throw new Error(
       `command ${JSON.stringify(config.name)}: option --file is reserved when input is enabled`
@@ -363,6 +367,7 @@ export function defineCommand<T extends z.ZodType>(config: CommandConfig<T>): Op
   if (config.input instanceof z.ZodType) {
     cmd.option('--file <path>', 'path to a JSON file to use as command input')
   }
+  cmd.option('--dry-run', 'validate all inputs and exit without performing any action')
   cmd.action(async () => {
     const allRaw = cmd.optsWithGlobals() as Record<string, unknown>
     const options: Record<string, string | number | boolean> = {}
@@ -431,6 +436,10 @@ export function defineCommand<T extends z.ZodType>(config: CommandConfig<T>): Op
         }
         return cmd.error(`input validation failed:\n${z.prettifyError(result.error)}`)
       }
+    }
+    if (allRaw['dryRun'] === true) {
+      process.stdout.write(JSON.stringify({ success: true }) + '\n')
+      return
     }
     const handlerResult = await config.handler(parsed)
     assert(handlerResult !== undefined, `command ${JSON.stringify(config.name)}: handler must return a JsonValue`)

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -215,6 +215,10 @@ function validateOptions(options: OptionDefinition[]): void {
     }
     seenLong.add(opt.long)
 
+    if (opt.long === 'dry-run') {
+      throw new Error('option --dry-run is reserved')
+    }
+
     if (opt.short !== undefined) {
       if (seenShort.has(opt.short)) {
         throw new Error(`duplicate option short alias: -${opt.short}`)
@@ -345,11 +349,6 @@ export function defineCommand<T extends z.ZodType>(config: CommandConfig<T>): Op
   validateName(config.name, 'command')
   validateOptions(config.options ?? [])
   validateInput(config.name, config.input)
-  if (config.options?.some((o) => o.long === 'dry-run')) {
-    throw new Error(
-      `command ${JSON.stringify(config.name)}: option --dry-run is reserved`
-    )
-  }
   if (config.input instanceof z.ZodType && config.options?.some((o) => o.long === 'file')) {
     throw new Error(
       `command ${JSON.stringify(config.name)}: option --file is reserved when input is enabled`
@@ -532,7 +531,9 @@ export function defineCommand<T extends z.ZodType>(config: CommandConfig<T>): Op
       }
     }
     if (allRaw['dryRun'] === true) {
-      process.stdout.write(JSON.stringify({ success: true }) + '\n')
+      if (fmt === 'json') {
+        process.stdout.write(JSON.stringify({ success: true }) + '\n')
+      }
       return
     }
     const handlerResult = await config.handler(parsed)

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -257,14 +257,14 @@ describe('defineCommand', () => {
       const cmd = defineCommand({
         name: 'run',
         description: 'Run',
-        options: [{ long: 'dry-run', description: 'Preview', type: 'boolean' }],
+        options: [{ long: 'preview', description: 'Preview', type: 'boolean' }],
         handler: (parsed) => { received.push(parsed); return {} },
       })
-      invoke(cmd, ['--dry-run'])
+      invoke(cmd, ['--preview'])
       assert.equal(received.length, 1)
-      assert.equal(received[0].options['dry-run'], true)
+      assert.equal(received[0].options['preview'], true)
       // no unexpected keys from Commander internals
-      assert.deepEqual(Object.keys(received[0].options), ['dry-run'])
+      assert.deepEqual(Object.keys(received[0].options), ['preview'])
     })
   })
 
@@ -1610,6 +1610,100 @@ describe('defineCommand', () => {
       const out = await invokeUnderRoot(cmd, ['--format', 'json'], [])
       assert.deepEqual(JSON.parse(out), { async: true })
     })
+  })
+
+  describe('--dry-run', () => {
+    async function captureStdout(fn: () => Promise<void>): Promise<string> {
+      let out = ''
+      const orig = process.stdout.write.bind(process.stdout)
+      process.stdout.write = (chunk: unknown) => { out += String(chunk); return true }
+      try { await fn() } finally { process.stdout.write = orig }
+      return out
+    }
+
+    it('appears in help text for every command', () => {
+      const cmd = defineCommand({
+        name: 'ping',
+        description: 'Ping',
+        handler: () => ({}),
+      })
+      assert.match(cmd.helpInformation(), /--dry-run/)
+    })
+
+    it('outputs {"success":true} and skips the handler when set on a no-input command', async () => {
+      let handlerCalled = false
+      const cmd = defineCommand({
+        name: 'ping',
+        description: 'Ping',
+        handler: () => { handlerCalled = true; return {} },
+      })
+      const out = await captureStdout(() => invokeAsync(cmd, ['--dry-run']))
+      assert.equal(handlerCalled, false, 'handler must not be called with --dry-run')
+      assert.deepEqual(JSON.parse(out), { success: true })
+    })
+
+    it('outputs {"success":true} and skips handler with valid JSON input via --file', async () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), 'elastic-cli-dryrun-'))
+      const filePath = join(tmpDir, 'valid.json')
+      writeFileSync(filePath, JSON.stringify({ index: 'logs' }))
+      const origIsTTY = process.stdin.isTTY
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true, writable: true })
+      try {
+        let handlerCalled = false
+        const cmd = defineCommand({
+          name: 'search',
+          description: 'Search',
+          input: z.object({ index: z.string() }),
+          handler: () => { handlerCalled = true; return {} },
+        })
+        const out = await captureStdout(() => invokeAsync(cmd, ['--dry-run', '--file', filePath]))
+        assert.equal(handlerCalled, false, 'handler must not be called with --dry-run')
+        assert.deepEqual(JSON.parse(out), { success: true })
+      } finally {
+        Object.defineProperty(process.stdin, 'isTTY', { value: origIsTTY, configurable: true, writable: true })
+        rmSync(tmpDir, { recursive: true })
+      }
+    })
+
+    it('still reports validation error when --dry-run is set with invalid input', async () => {
+      const tmpDir = mkdtempSync(join(tmpdir(), 'elastic-cli-dryrun-'))
+      const filePath = join(tmpDir, 'invalid.json')
+      writeFileSync(filePath, JSON.stringify({ index: 42 }))
+      const origIsTTY = process.stdin.isTTY
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true, writable: true })
+      try {
+        let handlerCalled = false
+        const cmd = defineCommand({
+          name: 'search',
+          description: 'Search',
+          input: z.object({ index: z.string() }),
+          handler: () => { handlerCalled = true; return {} },
+        })
+        const err = await captureErrAsync(cmd, ['--dry-run', '--file', filePath])
+        assert.match(err, /input validation failed/)
+        assert.equal(handlerCalled, false, 'handler must not be called when validation fails')
+      } finally {
+        Object.defineProperty(process.stdin, 'isTTY', { value: origIsTTY, configurable: true, writable: true })
+        rmSync(tmpDir, { recursive: true })
+      }
+    })
+
+    it('throws at definition time when user defines a --dry-run option', () => {
+      assert.throws(
+        () => defineCommand({
+          name: 'test',
+          description: 'Test',
+          options: [{ long: 'dry-run', description: 'Preview', type: 'boolean' }],
+          handler: () => ({}),
+        }),
+        (e: unknown) => {
+          assert.ok(e instanceof Error)
+          assert.match(e.message, /--dry-run is reserved/)
+          return true
+        },
+      )
+    })
+
   })
 })
 

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -1563,24 +1563,6 @@ describe('defineCommand', () => {
   })
 
   describe('handler return value and output', () => {
-    async function captureOutput(fn: () => Promise<void>): Promise<string> {
-      let out = ''
-      const orig = process.stdout.write.bind(process.stdout)
-      process.stdout.write = (chunk: unknown) => { out += String(chunk); return true }
-      try { await fn() } finally { process.stdout.write = orig }
-      return out
-    }
-
-    async function invokeUnderRoot(cmd: OpaqueCommandHandle, rootArgv: string[], cmdArgv: string[]): Promise<string> {
-      const { Command } = await import('commander')
-      const prog = new Command('elastic')
-      prog.option('--format <fmt>', 'output format')
-      prog.addCommand(cmd)
-      prog.exitOverride()
-      cmd.exitOverride()
-      return captureOutput(() => prog.parseAsync([...rootArgv, cmd.name(), ...cmdArgv], { from: 'user' }))
-    }
-
     it('factory writes handler return value as compact JSON when --format=json', async () => {
       const cmd = defineCommand({
         name: 'status',
@@ -1613,14 +1595,6 @@ describe('defineCommand', () => {
   })
 
   describe('--dry-run', () => {
-    async function captureStdout(fn: () => Promise<void>): Promise<string> {
-      let out = ''
-      const orig = process.stdout.write.bind(process.stdout)
-      process.stdout.write = (chunk: unknown) => { out += String(chunk); return true }
-      try { await fn() } finally { process.stdout.write = orig }
-      return out
-    }
-
     it('appears in help text for every command', () => {
       const cmd = defineCommand({
         name: 'ping',
@@ -1630,16 +1604,28 @@ describe('defineCommand', () => {
       assert.match(cmd.helpInformation(), /--dry-run/)
     })
 
-    it('outputs {"success":true} and skips the handler when set on a no-input command', async () => {
+    it('outputs {"success":true} when --format=json and skips the handler', async () => {
       let handlerCalled = false
       const cmd = defineCommand({
         name: 'ping',
         description: 'Ping',
         handler: () => { handlerCalled = true; return {} },
       })
-      const out = await captureStdout(() => invokeAsync(cmd, ['--dry-run']))
+      const out = await invokeUnderRoot(cmd, ['--format', 'json'], ['--dry-run'])
       assert.equal(handlerCalled, false, 'handler must not be called with --dry-run')
       assert.deepEqual(JSON.parse(out), { success: true })
+    })
+
+    it('produces no output and skips the handler in text mode', async () => {
+      let handlerCalled = false
+      const cmd = defineCommand({
+        name: 'ping',
+        description: 'Ping',
+        handler: () => { handlerCalled = true; return {} },
+      })
+      const out = await invokeUnderRoot(cmd, [], ['--dry-run'])
+      assert.equal(handlerCalled, false, 'handler must not be called with --dry-run')
+      assert.equal(out, '', 'no output expected in text mode')
     })
 
     it('outputs {"success":true} and skips handler with valid JSON input via --file', async () => {
@@ -1656,7 +1642,7 @@ describe('defineCommand', () => {
           input: z.object({ index: z.string() }),
           handler: () => { handlerCalled = true; return {} },
         })
-        const out = await captureStdout(() => invokeAsync(cmd, ['--dry-run', '--file', filePath]))
+        const out = await invokeUnderRoot(cmd, ['--format', 'json'], ['--dry-run', '--file', filePath])
         assert.equal(handlerCalled, false, 'handler must not be called with --dry-run')
         assert.deepEqual(JSON.parse(out), { success: true })
       } finally {
@@ -2599,4 +2585,24 @@ async function captureErrAsync(handle: OpaqueCommandHandle, argv: string[]): Pro
   handle.configureOutput({ writeErr: (s) => { err += s } })
   try { await handle.parseAsync(argv, { from: 'user' }) } catch { /* CommanderError from exitOverride */ }
   return err
+}
+
+/** captures everything written to process.stdout during fn() */
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+  let out = ''
+  const orig = process.stdout.write.bind(process.stdout)
+  process.stdout.write = (chunk: unknown) => { out += String(chunk); return true }
+  try { await fn() } finally { process.stdout.write = orig }
+  return out
+}
+
+/** mounts a command under a root program with --format and captures stdout */
+async function invokeUnderRoot(cmd: OpaqueCommandHandle, rootArgv: string[], cmdArgv: string[]): Promise<string> {
+  const { Command } = await import('commander')
+  const prog = new Command('elastic')
+  prog.option('--format <fmt>', 'output format')
+  prog.addCommand(cmd)
+  prog.exitOverride()
+  cmd.exitOverride()
+  return captureStdout(() => prog.parseAsync([...rootArgv, cmd.name(), ...cmdArgv], { from: 'user' }))
 }


### PR DESCRIPTION
Closes https://github.com/elastic/agentic-interface-program/issues/46

- Adds --dry-run flag to every command via the factory. I am validating all inputs and exiting with {"success":true} without running the handler
- Reserves --dry-run as a built-in option 