### PR TITLE
Add Cloud control plane API support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { createRequire } from 'node:module'
 import { defineCommand } from './factory.js'
 import type { ParsedResult } from './factory.js'
 import { registerEsCommands } from './es/register.ts'
+import { registerCloudCommands } from './cloud/register.ts'
 import { loadConfig } from './config/loader.ts'
 import { setResolvedConfig } from './config/store.ts'
 
@@ -56,6 +57,7 @@ const pingCmd = defineCommand({
 })
 program.addCommand(pingCmd)
 program.addCommand(registerEsCommands())
+program.addCommand(registerCloudCommands())
 
 if (process.argv.slice(2).length === 0) {
   program.outputHelp()

--- a/src/cloud/apis/deployments.ts
+++ b/src/cloud/apis/deployments.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CloudApiDefinition } from '../types.ts'
+
+const deploymentIdParam = {
+  name: 'deployment_id',
+  description: 'Identifier for the Deployment',
+  required: true,
+}
+
+export const deploymentApis: CloudApiDefinition[] = [
+  {
+    name: 'list',
+    namespace: 'deployments',
+    description: 'List all deployments belonging to the authenticated user',
+    method: 'GET',
+    path: '/api/v1/deployments',
+  },
+  {
+    name: 'get',
+    namespace: 'deployments',
+    description: 'Retrieve information about a specific deployment',
+    method: 'GET',
+    path: '/api/v1/deployments/{deployment_id}',
+    pathParams: [deploymentIdParam],
+    queryParams: [
+      { name: 'show_metadata', type: 'boolean', description: 'Include the full cluster metadata in the response' },
+      { name: 'show_plans', type: 'boolean', description: 'Include the full current and pending plan information' },
+      { name: 'show_settings', type: 'boolean', description: 'Include cluster settings in the response' },
+    ],
+  },
+  {
+    name: 'shutdown',
+    namespace: 'deployments',
+    description: 'Shut down all resources in a deployment',
+    method: 'POST',
+    path: '/api/v1/deployments/{deployment_id}/_shutdown',
+    pathParams: [deploymentIdParam],
+    queryParams: [
+      { name: 'skip_snapshot', type: 'boolean', description: 'Whether to skip snapshots before shutting down' },
+    ],
+  },
+]

--- a/src/cloud/apis/index.ts
+++ b/src/cloud/apis/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { deploymentApis } from './deployments.ts'
+import { projectApis } from './projects.ts'
+import type { CloudApiDefinition } from '../types.ts'
+
+/** flat array of all registered Cloud API definitions across all namespaces */
+export const allCloudApis: CloudApiDefinition[] = [...deploymentApis, ...projectApis]

--- a/src/cloud/apis/projects.ts
+++ b/src/cloud/apis/projects.ts
@@ -6,7 +6,7 @@
 import type { CloudApiDefinition } from '../types.ts'
 
 const projectIdParam = {
-  name: 'id',
+  name: 'project_id',
   description: 'ID of the Elasticsearch project',
   required: true,
 }
@@ -24,7 +24,7 @@ export const projectApis: CloudApiDefinition[] = [
     namespace: 'projects',
     description: 'Retrieve information about an Elasticsearch serverless project',
     method: 'GET',
-    path: '/api/v1/serverless/projects/elasticsearch/{id}',
+    path: '/api/v1/serverless/projects/elasticsearch/{project_id}',
     pathParams: [projectIdParam],
   },
   {
@@ -32,7 +32,7 @@ export const projectApis: CloudApiDefinition[] = [
     namespace: 'projects',
     description: 'Delete an Elasticsearch serverless project',
     method: 'DELETE',
-    path: '/api/v1/serverless/projects/elasticsearch/{id}',
+    path: '/api/v1/serverless/projects/elasticsearch/{project_id}',
     pathParams: [projectIdParam],
   },
 ]

--- a/src/cloud/apis/projects.ts
+++ b/src/cloud/apis/projects.ts
@@ -1,0 +1,38 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CloudApiDefinition } from '../types.ts'
+
+const projectIdParam = {
+  name: 'id',
+  description: 'ID of the Elasticsearch project',
+  required: true,
+}
+
+export const projectApis: CloudApiDefinition[] = [
+  {
+    name: 'list',
+    namespace: 'projects',
+    description: 'List all Elasticsearch serverless projects',
+    method: 'GET',
+    path: '/api/v1/serverless/projects/elasticsearch',
+  },
+  {
+    name: 'get',
+    namespace: 'projects',
+    description: 'Retrieve information about an Elasticsearch serverless project',
+    method: 'GET',
+    path: '/api/v1/serverless/projects/elasticsearch/{id}',
+    pathParams: [projectIdParam],
+  },
+  {
+    name: 'delete',
+    namespace: 'projects',
+    description: 'Delete an Elasticsearch serverless project',
+    method: 'DELETE',
+    path: '/api/v1/serverless/projects/elasticsearch/{id}',
+    pathParams: [projectIdParam],
+  },
+]

--- a/src/cloud/handler.ts
+++ b/src/cloud/handler.ts
@@ -1,0 +1,66 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CloudApiDefinition } from './types.ts'
+import type { CloudClient } from '../lib/cloud-client.ts'
+import { getCloudClient } from '../lib/cloud-client.ts'
+import { buildCloudRequestParams } from './request-builder.ts'
+import type { JsonValue, ParsedResult } from '../factory.ts'
+
+/**
+ * Dependencies for `createCloudHandler`. Production code uses the defaults;
+ * callers may supply alternatives for composition or isolation.
+ */
+export interface CloudHandlerDeps {
+  getCloudClient: () => CloudClient
+  buildCloudRequestParams: typeof buildCloudRequestParams
+}
+
+const defaultDeps: CloudHandlerDeps = { getCloudClient, buildCloudRequestParams }
+
+/**
+ * Creates a handler function for a Cloud control plane API command.
+ *
+ * The returned handler is bound to `def` at registration time and called by
+ * the factory with the validated `ParsedResult` on each invocation. It:
+ *
+ * 1. Calls `getCloudClient()` to obtain the cached client (throws `missing_config`
+ *    if no Cloud service is configured).
+ * 2. Calls `buildCloudRequestParams(def, parsed)` to assemble the request.
+ * 3. Calls `client.request(params)` and returns the JSON response.
+ * 4. Catches errors and returns structured `missing_config` or `cloud_api_error` payloads.
+ */
+export function createCloudHandler(
+  def: CloudApiDefinition,
+  deps: CloudHandlerDeps = defaultDeps,
+): (parsed: ParsedResult) => Promise<JsonValue> {
+  return async (parsed: ParsedResult): Promise<JsonValue> => {
+    let client: CloudClient
+    try {
+      client = deps.getCloudClient()
+    } catch (err) {
+      return missingConfigError(err)
+    }
+
+    const params = deps.buildCloudRequestParams(def, parsed)
+
+    try {
+      const body = await client.request(params)
+      return body as JsonValue
+    } catch (err) {
+      return cloudApiError(err)
+    }
+  }
+}
+
+function missingConfigError(err: unknown): JsonValue {
+  const message = err instanceof Error ? err.message : String(err)
+  return { error: { code: 'missing_config', message } }
+}
+
+function cloudApiError(err: unknown): JsonValue {
+  const message = err instanceof Error ? err.message : String(err)
+  return { error: { code: 'cloud_api_error', message } }
+}

--- a/src/cloud/handler.ts
+++ b/src/cloud/handler.ts
@@ -10,8 +10,7 @@ import { buildCloudRequestParams } from './request-builder.ts'
 import type { JsonValue, ParsedResult } from '../factory.ts'
 
 /**
- * Dependencies for `createCloudHandler`. Production code uses the defaults;
- * callers may supply alternatives for composition or isolation.
+ * Dependencies for `createCloudHandler`. 
  */
 export interface CloudHandlerDeps {
   getCloudClient: () => CloudClient

--- a/src/cloud/register.ts
+++ b/src/cloud/register.ts
@@ -1,0 +1,115 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from 'zod'
+import { defineCommand, defineGroup } from '../factory.ts'
+import type { OpaqueCommandHandle } from '../factory.ts'
+import type { CloudApiDefinition, CloudPathParam, CloudQueryParam } from './types.ts'
+import { validateCloudApiDefinition } from './types.ts'
+import { allCloudApis } from './apis/index.ts'
+import { createCloudHandler } from './handler.ts'
+
+/**
+ * Builds the unified flat Zod schema for a Cloud API command.
+ *
+ * Path params, query params, and body fields are combined into a single `z.object`
+ * so the factory registers them as CLI flags, merges --file/stdin input, validates,
+ * and delivers the whole thing to the handler as `parsed.input`.
+ */
+function buildCommandSchema(def: CloudApiDefinition) {
+  const shape: Record<string, z.ZodType> = {}
+
+  for (const p of def.pathParams ?? []) {
+    shape[p.name] = pathParamToZod(p)
+  }
+
+  for (const q of def.queryParams ?? []) {
+    shape[q.cliFlag ?? q.name] = queryParamToZod(q)
+  }
+
+  if (def.body != null) {
+    for (const [fieldName, fieldSchema] of Object.entries(def.body.shape as Record<string, z.ZodType>)) {
+      if (!fieldName.startsWith('_')) {
+        shape[fieldName] = fieldSchema
+      }
+    }
+  }
+
+  return z.looseObject(shape)
+}
+
+function pathParamToZod(p: CloudPathParam): z.ZodType {
+  const base = z.string().describe(p.description)
+  return p.required ? base : base.optional()
+}
+
+function queryParamToZod(q: CloudQueryParam): z.ZodType {
+  const base =
+    q.type === 'boolean' ? z.boolean().describe(q.description) :
+    q.type === 'number'  ? z.number().describe(q.description) :
+                           z.string().describe(q.description)
+  if (q.defaultValue !== undefined) {
+    if (q.type === 'boolean') return (base as z.ZodBoolean).default(q.defaultValue as boolean)
+    if (q.type === 'number')  return (base as z.ZodNumber).default(q.defaultValue as number)
+    return (base as z.ZodString).default(q.defaultValue as string)
+  }
+  return q.required === true ? base : base.optional()
+}
+
+/**
+ * Registers all Cloud control plane API commands under a top-level `cloud` group.
+ *
+ * For each definition:
+ * 1. A unified flat Zod schema is built from `pathParams` + `queryParams` + optional `body`.
+ * 2. `defineCommand` is called with that schema as `input`.
+ * 3. Commands are grouped by namespace (e.g. `deployments`, `projects`).
+ *
+ * @param definitions - flat array of API definitions; defaults to the full built-in registry
+ * @returns an `OpaqueCommandHandle` for the top-level `cloud` group
+ */
+export function registerCloudCommands(
+  definitions: CloudApiDefinition[] = allCloudApis,
+): OpaqueCommandHandle {
+  for (const def of definitions) {
+    validateCloudApiDefinition(def)
+  }
+
+  const byNamespace = new Map<string, CloudApiDefinition[]>()
+  for (const def of definitions) {
+    let group = byNamespace.get(def.namespace)
+    if (group == null) {
+      group = []
+      byNamespace.set(def.namespace, group)
+    }
+    group.push(def)
+  }
+
+  const namespaceHandles: OpaqueCommandHandle[] = []
+  for (const [namespace, defs] of byNamespace) {
+    const seen = new Set<string>()
+    for (const def of defs) {
+      if (seen.has(def.name)) {
+        throw new Error(`duplicate command name "${def.name}" in namespace "${namespace}"`)
+      }
+      seen.add(def.name)
+    }
+
+    const leafHandles = defs.map((def) => {
+      const schema = buildCommandSchema(def)
+      return defineCommand({
+        name: def.name,
+        description: def.description,
+        input: schema,
+        handler: createCloudHandler(def),
+      })
+    })
+
+    namespaceHandles.push(
+      defineGroup({ name: namespace, description: `Cloud ${namespace} commands` }, ...leafHandles)
+    )
+  }
+
+  return defineGroup({ name: 'cloud', description: 'Manage Elastic Cloud deployments and serverless projects' }, ...namespaceHandles)
+}

--- a/src/cloud/request-builder.ts
+++ b/src/cloud/request-builder.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from 'zod'
+import type { CloudApiDefinition } from './types.ts'
+import type { CloudRequestParams } from '../lib/cloud-client.ts'
+import type { ParsedResult } from '../factory.ts'
+
+/**
+ * Builds a `CloudRequestParams` object from an API definition and parsed CLI input.
+ *
+ * All path params, query params, and body fields arrive in `parsed.input` as a
+ * single flat object. The definition's param arrays act as a routing manifest
+ * to classify each key back to its destination:
+ *
+ * - `pathParams` → interpolated into the URL path
+ * - `queryParams` → added to the querystring (stringified for fetch)
+ * - `body` shape keys → collected into the request body object
+ */
+export function buildCloudRequestParams(
+  def: CloudApiDefinition,
+  parsed: ParsedResult,
+): CloudRequestParams {
+  const input = (parsed.input ?? {}) as Record<string, unknown>
+
+  const path = interpolatePath(def, input)
+  const querystring = buildQuerystring(def, input)
+  const body = collectBody(def, input)
+
+  const params: CloudRequestParams = { method: def.method, path }
+  if (Object.keys(querystring).length > 0) params.querystring = querystring
+  if (body !== undefined) params.body = body
+  return params
+}
+
+function interpolatePath(
+  def: CloudApiDefinition,
+  input: Record<string, unknown>,
+): string {
+  let path = def.path
+
+  for (const param of def.pathParams ?? []) {
+    const value = input[param.name]
+    if (value !== undefined) {
+      path = path.replace(`{${param.name}}`, String(value))
+    } else if (!param.required) {
+      path = path.replace(new RegExp(`/?\\{${param.name}\\}/?`), '')
+      path = path.replace(/\/$/, '') || '/'
+    }
+  }
+
+  return path
+}
+
+function buildQuerystring(
+  def: CloudApiDefinition,
+  input: Record<string, unknown>,
+): Record<string, string> {
+  const qs: Record<string, string> = {}
+
+  for (const qp of def.queryParams ?? []) {
+    const inputKey = qp.cliFlag ?? qp.name
+    const value = input[inputKey]
+    if (value !== undefined) {
+      qs[qp.name] = String(value)
+    }
+  }
+
+  return qs
+}
+
+function collectBody(
+  def: CloudApiDefinition,
+  input: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!(def.body instanceof z.ZodObject)) return undefined
+
+  const body: Record<string, unknown> = {}
+  for (const fieldName of Object.keys(def.body.shape as Record<string, unknown>)) {
+    if (input[fieldName] !== undefined) {
+      body[fieldName] = input[fieldName]
+    }
+  }
+
+  return Object.keys(body).length > 0 ? body : undefined
+}

--- a/src/cloud/types.ts
+++ b/src/cloud/types.ts
@@ -1,0 +1,149 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { z } from 'zod'
+
+/**
+ * Valid HTTP methods for Cloud control plane API requests.
+ */
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH'
+
+/**
+ * Describes a path parameter that gets interpolated into the URL template.
+ *
+ * @example
+ * ```ts
+ * const param: CloudPathParam = { name: 'deployment_id', description: 'Deployment ID', required: true }
+ * ```
+ */
+export interface CloudPathParam {
+  name: string
+  description: string
+  required: boolean
+}
+
+/**
+ * Describes a query string parameter for a Cloud API request.
+ *
+ * The `name` field (snake_case) is used in the query string;
+ * the `cliFlag` (kebab-case) is what users type on the command line.
+ */
+export interface CloudQueryParam {
+  name: string
+  cliFlag?: string
+  type: 'string' | 'number' | 'boolean'
+  description: string
+  required?: boolean
+  defaultValue?: string | number | boolean
+}
+
+/**
+ * Declarative description of a single Cloud control plane API endpoint.
+ *
+ * Covers both Elastic Cloud Hosted (deployments) and Serverless (projects)
+ * APIs. Definitions are grouped by namespace and collected by the barrel
+ * module (`src/cloud/apis/index.ts`).
+ *
+ * @example
+ * ```ts
+ * const listDef: CloudApiDefinition = {
+ *   name: 'list',
+ *   namespace: 'deployments',
+ *   description: 'List all deployments',
+ *   method: 'GET',
+ *   path: '/api/v1/deployments',
+ * }
+ * ```
+ */
+export interface CloudApiDefinition {
+  name: string
+  namespace: string
+  description: string
+  method: HttpMethod
+  path: string
+  pathParams?: CloudPathParam[]
+  queryParams?: CloudQueryParam[]
+  body?: z.ZodObject<z.ZodRawShape>
+}
+
+const VALID_NAME = /^[a-z0-9][a-z0-9-]*$/
+const VALID_NAMESPACE = /^[a-z][a-z-]*$/
+
+function extractPathTokens(path: string): string[] {
+  return [...path.matchAll(/\{([^}]+)\}/g)].map((m) => m[1] as string)
+}
+
+/**
+ * Validates a `CloudApiDefinition` against the data-model rules.
+ *
+ * @throws {Error} if any validation rule is violated
+ */
+export function validateCloudApiDefinition(def: CloudApiDefinition): void {
+  if (!VALID_NAME.test(def.name)) {
+    throw new Error(
+      `invalid name ${JSON.stringify(def.name)}: ` +
+      'names must start with a lowercase letter or digit and contain only lowercase letters, digits, and hyphens'
+    )
+  }
+
+  if (!VALID_NAMESPACE.test(def.namespace)) {
+    throw new Error(
+      `invalid namespace ${JSON.stringify(def.namespace)}: ` +
+      'namespaces must start with a lowercase letter and contain only lowercase letters and hyphens'
+    )
+  }
+
+  if (!def.path.startsWith('/')) {
+    throw new Error(`path must start with "/" — got ${JSON.stringify(def.path)}`)
+  }
+
+  const tokens = extractPathTokens(def.path)
+  const paramNames = new Set((def.pathParams ?? []).map((p) => p.name))
+
+  for (const token of tokens) {
+    if (!paramNames.has(token)) {
+      throw new Error(
+        `path param {${token}} is not defined in pathParams for definition ${JSON.stringify(def.name)}`
+      )
+    }
+  }
+
+  const pathSet = new Set(tokens)
+  for (const param of def.pathParams ?? []) {
+    if (param.required && !pathSet.has(param.name)) {
+      throw new Error(
+        `required pathParam "${param.name}" is not in path template for definition ${JSON.stringify(def.name)}`
+      )
+    }
+  }
+
+  const schemaKeys = new Set<string>()
+  const collisions: string[] = []
+
+  for (const p of def.pathParams ?? []) {
+    if (schemaKeys.has(p.name)) collisions.push(p.name)
+    schemaKeys.add(p.name)
+  }
+
+  for (const q of def.queryParams ?? []) {
+    const key = q.cliFlag ?? q.name
+    if (schemaKeys.has(key)) collisions.push(key)
+    schemaKeys.add(key)
+  }
+
+  if (def.body != null) {
+    for (const fieldName of Object.keys(def.body.shape as Record<string, unknown>)) {
+      if (schemaKeys.has(fieldName)) collisions.push(fieldName)
+      schemaKeys.add(fieldName)
+    }
+  }
+
+  if (collisions.length > 0) {
+    throw new Error(
+      `schema key collision(s) in definition "${def.name}": ${collisions.join(', ')}. ` +
+      'Use cliFlag to rename the conflicting query param, or restructure the definition to avoid the conflict.'
+    )
+  }
+}

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -33,12 +33,3 @@ export function setResolvedConfig(config: ResolvedConfig): void {
 export function getResolvedConfig(): ResolvedConfig | undefined {
   return _config
 }
-
-/**
- * Clears the resolved configuration.
- *
- * @internal test seam — call in `afterEach` to prevent config leaking across tests
- */
-export function clearResolvedConfig(): void {
-  _config = undefined
-}

--- a/src/config/store.ts
+++ b/src/config/store.ts
@@ -33,3 +33,12 @@ export function setResolvedConfig(config: ResolvedConfig): void {
 export function getResolvedConfig(): ResolvedConfig | undefined {
   return _config
 }
+
+/**
+ * Clears the resolved configuration.
+ *
+ * @internal test seam — call in `afterEach` to prevent config leaking across tests
+ */
+export function clearResolvedConfig(): void {
+  _config = undefined
+}

--- a/src/lib/cloud-client.ts
+++ b/src/lib/cloud-client.ts
@@ -41,8 +41,10 @@ export class CloudClient {
     let url = `${this.baseUrl}${params.path}`
 
     if (params.querystring != null && Object.keys(params.querystring).length > 0) {
-      const qs = new URLSearchParams(params.querystring)
-      url += `?${qs.toString()}`
+      const pieces = Object.entries(params.querystring)
+        .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+        .join('&')
+      url += `?${pieces}`
     }
 
     const headers: Record<string, string> = {

--- a/src/lib/cloud-client.ts
+++ b/src/lib/cloud-client.ts
@@ -3,13 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Buffer } from 'node:buffer'
+import type { HttpMethod } from '../cloud/types.ts'
 import { getResolvedConfig } from '../config/store.ts'
 
 /**
  * Parameters for a single Cloud API request.
  */
 export interface CloudRequestParams {
-  method: string
+  method: HttpMethod
   path: string
   querystring?: Record<string, string>
   body?: unknown
@@ -24,12 +26,12 @@ export interface CloudRequestParams {
  */
 export class CloudClient {
   readonly baseUrl: string
-  private readonly apiKey: string
+  private readonly authHeader: string
   private _fetch: typeof fetch = globalThis.fetch
 
-  constructor(baseUrl: string, apiKey: string) {
+  constructor(baseUrl: string, authHeader: string) {
     this.baseUrl = baseUrl.replace(/\/+$/, '')
-    this.apiKey = apiKey
+    this.authHeader = authHeader
   }
 
   /**
@@ -48,7 +50,7 @@ export class CloudClient {
     }
 
     const headers: Record<string, string> = {
-      'Authorization': `ApiKey ${this.apiKey}`,
+      'Authorization': this.authHeader,
       'Accept': 'application/json',
     }
 
@@ -66,7 +68,8 @@ export class CloudClient {
       throw new Error(`Cloud API error ${response.status}: ${text}`)
     }
 
-    return response.json()
+    const text = await response.text()
+    return text.length > 0 ? JSON.parse(text) : {}
   }
 
   /**
@@ -100,16 +103,21 @@ export function getCloudClient(): CloudClient {
 
   const { url, auth } = cloud
   const authRecord = auth as Record<string, unknown>
-  const apiKey = typeof authRecord['api_key'] === 'string' ? authRecord['api_key'] : undefined
 
-  if (apiKey == null) {
+  let authHeader: string
+  if (typeof authRecord['api_key'] === 'string') {
+    authHeader = `ApiKey ${authRecord['api_key']}`
+  } else if (typeof authRecord['username'] === 'string' && typeof authRecord['password'] === 'string') {
+    const encoded = Buffer.from(`${authRecord['username']}:${authRecord['password']}`).toString('base64')
+    authHeader = `Basic ${encoded}`
+  } else {
     throw new Error(
-      'missing_config: Cloud auth requires an api_key. ' +
-      'Run `elastic config set` to configure a Cloud API key.'
+      'missing_config: Cloud auth requires either an api_key or username/password. ' +
+      'Run `elastic config set` to configure Cloud credentials.'
     )
   }
 
-  _client = new CloudClient(url, apiKey)
+  _client = new CloudClient(url, authHeader)
   return _client
 }
 

--- a/src/lib/cloud-client.ts
+++ b/src/lib/cloud-client.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Buffer } from 'node:buffer'
 import type { HttpMethod } from '../cloud/types.ts'
 import { getResolvedConfig } from '../config/store.ts'
 
@@ -26,12 +25,12 @@ export interface CloudRequestParams {
  */
 export class CloudClient {
   readonly baseUrl: string
-  private readonly authHeader: string
+  private readonly apiKey: string
   private _fetch: typeof fetch = globalThis.fetch
 
-  constructor(baseUrl: string, authHeader: string) {
+  constructor(baseUrl: string, apiKey: string) {
     this.baseUrl = baseUrl.replace(/\/+$/, '')
-    this.authHeader = authHeader
+    this.apiKey = apiKey
   }
 
   /**
@@ -50,7 +49,7 @@ export class CloudClient {
     }
 
     const headers: Record<string, string> = {
-      'Authorization': this.authHeader,
+      'Authorization': `ApiKey ${this.apiKey}`,
       'Accept': 'application/json',
     }
 
@@ -104,20 +103,16 @@ export function getCloudClient(): CloudClient {
   const { url, auth } = cloud
   const authRecord = auth as Record<string, unknown>
 
-  let authHeader: string
-  if (typeof authRecord['api_key'] === 'string') {
-    authHeader = `ApiKey ${authRecord['api_key']}`
-  } else if (typeof authRecord['username'] === 'string' && typeof authRecord['password'] === 'string') {
-    const encoded = Buffer.from(`${authRecord['username']}:${authRecord['password']}`).toString('base64')
-    authHeader = `Basic ${encoded}`
-  } else {
+  const apiKey = typeof authRecord['api_key'] === 'string' ? authRecord['api_key'] : undefined
+
+  if (apiKey == null) {
     throw new Error(
-      'missing_config: Cloud auth requires either an api_key or username/password. ' +
+      'missing_config: Cloud auth requires an api_key. ' +
       'Run `elastic config set` to configure Cloud credentials.'
     )
   }
 
-  _client = new CloudClient(url, authHeader)
+  _client = new CloudClient(url, apiKey)
   return _client
 }
 

--- a/src/lib/cloud-client.ts
+++ b/src/lib/cloud-client.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getResolvedConfig } from '../config/store.ts'
+
+/**
+ * Parameters for a single Cloud API request.
+ */
+export interface CloudRequestParams {
+  method: string
+  path: string
+  querystring?: Record<string, string>
+  body?: unknown
+}
+
+/**
+ * Lightweight HTTP client for Elastic Cloud control plane APIs.
+ *
+ * Uses the native `fetch` API rather than `@elastic/transport`, since the
+ * Cloud API is a standard REST service with no ES-specific connection
+ * pooling, sniffing, or product-check requirements.
+ */
+export class CloudClient {
+  readonly baseUrl: string
+  private readonly apiKey: string
+  private _fetch: typeof fetch = globalThis.fetch
+
+  constructor(baseUrl: string, apiKey: string) {
+    this.baseUrl = baseUrl.replace(/\/+$/, '')
+    this.apiKey = apiKey
+  }
+
+  /**
+   * Sends an HTTP request to the Cloud API and returns the parsed JSON response.
+   *
+   * @throws {Error} on non-2xx responses, including the status code and response body
+   */
+  async request(params: CloudRequestParams): Promise<unknown> {
+    let url = `${this.baseUrl}${params.path}`
+
+    if (params.querystring != null && Object.keys(params.querystring).length > 0) {
+      const qs = new URLSearchParams(params.querystring)
+      url += `?${qs.toString()}`
+    }
+
+    const headers: Record<string, string> = {
+      'Authorization': `ApiKey ${this.apiKey}`,
+      'Accept': 'application/json',
+    }
+
+    const init: RequestInit = { method: params.method, headers }
+
+    if (params.body !== undefined) {
+      headers['Content-Type'] = 'application/json'
+      init.body = JSON.stringify(params.body)
+    }
+
+    const response = await this._fetch(url, init)
+
+    if (!response.ok) {
+      const text = await response.text()
+      throw new Error(`Cloud API error ${response.status}: ${text}`)
+    }
+
+    return response.json()
+  }
+
+  /**
+   * @internal test seam — replaces the fetch implementation for unit tests
+   */
+  _testSetFetch(fn: typeof fetch): void {
+    this._fetch = fn
+  }
+}
+
+let _client: CloudClient | undefined
+
+/**
+ * Returns a lazily-created, cached `CloudClient` configured from the
+ * resolved config context's `cloud` service block.
+ *
+ * @throws {Error} with `missing_config` when no Cloud service is configured
+ */
+export function getCloudClient(): CloudClient {
+  if (_client != null) return _client
+
+  const config = getResolvedConfig()
+  const cloud = config?.context.cloud
+
+  if (cloud == null) {
+    throw new Error(
+      'missing_config: No Cloud connection configured in the active context. ' +
+      'Run `elastic config set` to configure a Cloud endpoint.'
+    )
+  }
+
+  const { url, auth } = cloud
+  const authRecord = auth as Record<string, unknown>
+  const apiKey = typeof authRecord['api_key'] === 'string' ? authRecord['api_key'] : undefined
+
+  if (apiKey == null) {
+    throw new Error(
+      'missing_config: Cloud auth requires an api_key. ' +
+      'Run `elastic config set` to configure a Cloud API key.'
+    )
+  }
+
+  _client = new CloudClient(url, apiKey)
+  return _client
+}
+
+/**
+ * Resets the cached CloudClient instance.
+ *
+ * @internal test seam — call in `afterEach` to prevent instance reuse across tests
+ */
+export function _testResetCloudClient(): void {
+  _client = undefined
+}

--- a/test/cloud/handler.test.ts
+++ b/test/cloud/handler.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createCloudHandler } from '../../src/cloud/handler.ts'
+import type { CloudApiDefinition } from '../../src/cloud/types.ts'
+import type { CloudClient, CloudRequestParams } from '../../src/lib/cloud-client.ts'
+import type { ParsedResult } from '../../src/factory.ts'
+
+function listDef(): CloudApiDefinition {
+  return {
+    name: 'list',
+    namespace: 'deployments',
+    description: 'List deployments',
+    method: 'GET',
+    path: '/api/v1/deployments',
+  }
+}
+
+function parsed(input?: Record<string, unknown>): ParsedResult {
+  return { options: {}, ...(input !== undefined ? { input } : {}) }
+}
+
+function stubClient(response: unknown): CloudClient {
+  return {
+    baseUrl: 'https://api.elastic-cloud.com',
+    request: async () => response,
+    _testSetFetch: () => {},
+  } as unknown as CloudClient
+}
+
+function failingClient(err: Error): CloudClient {
+  return {
+    baseUrl: 'https://api.elastic-cloud.com',
+    request: async () => { throw err },
+    _testSetFetch: () => {},
+  } as unknown as CloudClient
+}
+
+describe('createCloudHandler', () => {
+  it('returns the API response as JsonValue', async () => {
+    const handler = createCloudHandler(listDef(), {
+      getCloudClient: () => stubClient({ deployments: [{ id: 'abc' }] }),
+      buildCloudRequestParams: () => ({ method: 'GET', path: '/api/v1/deployments' }),
+    })
+    const result = await handler(parsed())
+    assert.deepEqual(result, { deployments: [{ id: 'abc' }] })
+  })
+
+  it('passes the definition and parsed result to buildCloudRequestParams', async () => {
+    const captured: { def: CloudApiDefinition; parsed: ParsedResult }[] = []
+    const def = listDef()
+    const p = parsed({ foo: 'bar' })
+
+    const handler = createCloudHandler(def, {
+      getCloudClient: () => stubClient({}),
+      buildCloudRequestParams: (d, pr) => {
+        captured.push({ def: d, parsed: pr })
+        return { method: 'GET', path: '/test' }
+      },
+    })
+    await handler(p)
+    assert.equal(captured.length, 1)
+    assert.strictEqual(captured[0]!.def, def)
+    assert.strictEqual(captured[0]!.parsed, p)
+  })
+
+  it('passes the built request params to client.request', async () => {
+    const capturedParams: CloudRequestParams[] = []
+    const fakeClient = {
+      baseUrl: 'https://api.elastic-cloud.com',
+      request: async (params: CloudRequestParams) => {
+        capturedParams.push(params)
+        return { ok: true }
+      },
+    } as unknown as CloudClient
+
+    const handler = createCloudHandler(listDef(), {
+      getCloudClient: () => fakeClient,
+      buildCloudRequestParams: () => ({ method: 'POST', path: '/api/v1/test', body: { x: 1 } }),
+    })
+    await handler(parsed())
+    assert.equal(capturedParams.length, 1)
+    assert.equal(capturedParams[0]!.method, 'POST')
+    assert.equal(capturedParams[0]!.path, '/api/v1/test')
+    assert.deepEqual(capturedParams[0]!.body, { x: 1 })
+  })
+
+  it('returns a missing_config error when getCloudClient throws', async () => {
+    const handler = createCloudHandler(listDef(), {
+      getCloudClient: () => { throw new Error('missing_config: No Cloud connection') },
+      buildCloudRequestParams: () => ({ method: 'GET', path: '/test' }),
+    })
+    const result = await handler(parsed())
+    assert.deepEqual(result, {
+      error: { code: 'missing_config', message: 'missing_config: No Cloud connection' },
+    })
+  })
+
+  it('returns a cloud_api_error when client.request throws', async () => {
+    const handler = createCloudHandler(listDef(), {
+      getCloudClient: () => failingClient(new Error('Cloud API error 404: {"errors":[{"message":"not found"}]}')),
+      buildCloudRequestParams: () => ({ method: 'GET', path: '/test' }),
+    })
+    const result = await handler(parsed())
+    assert.deepEqual(result, {
+      error: { code: 'cloud_api_error', message: 'Cloud API error 404: {"errors":[{"message":"not found"}]}' },
+    })
+  })
+})

--- a/test/cloud/register.test.ts
+++ b/test/cloud/register.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { registerCloudCommands } from '../../src/cloud/register.ts'
+import type { CloudApiDefinition } from '../../src/cloud/types.ts'
+
+describe('registerCloudCommands', () => {
+  describe('command tree structure', () => {
+    it('returns a top-level "cloud" group', () => {
+      const group = registerCloudCommands([])
+      assert.equal(group.name(), 'cloud')
+    })
+
+    it('creates namespace subgroups from definitions', () => {
+      const defs: CloudApiDefinition[] = [
+        { name: 'list', namespace: 'deployments', description: 'List', method: 'GET', path: '/api/v1/deployments' },
+        { name: 'list', namespace: 'projects', description: 'List', method: 'GET', path: '/api/v1/projects' },
+      ]
+      const group = registerCloudCommands(defs)
+      const subcommands = group.commands.map((c) => c.name())
+      assert.ok(subcommands.includes('deployments'))
+      assert.ok(subcommands.includes('projects'))
+    })
+
+    it('registers leaf commands under their namespace', () => {
+      const defs: CloudApiDefinition[] = [
+        { name: 'list', namespace: 'deployments', description: 'List', method: 'GET', path: '/api/v1/deployments' },
+        { name: 'get', namespace: 'deployments', description: 'Get', method: 'GET', path: '/api/v1/deployments/{deployment_id}', pathParams: [{ name: 'deployment_id', description: 'ID', required: true }] },
+      ]
+      const group = registerCloudCommands(defs)
+      const deploymentsGroup = group.commands.find((c) => c.name() === 'deployments')!
+      const leafNames = deploymentsGroup.commands.map((c) => c.name())
+      assert.deepEqual(leafNames, ['list', 'get'])
+    })
+  })
+
+  describe('validation', () => {
+    it('throws on invalid definition', () => {
+      const defs: CloudApiDefinition[] = [
+        { name: '', namespace: 'deployments', description: 'Bad', method: 'GET', path: '/test' },
+      ]
+      assert.throws(() => registerCloudCommands(defs), /invalid name/)
+    })
+
+    it('throws on duplicate command names within a namespace', () => {
+      const defs: CloudApiDefinition[] = [
+        { name: 'list', namespace: 'deployments', description: 'List 1', method: 'GET', path: '/a' },
+        { name: 'list', namespace: 'deployments', description: 'List 2', method: 'GET', path: '/b' },
+      ]
+      assert.throws(() => registerCloudCommands(defs), /duplicate/)
+    })
+  })
+
+  describe('default API definitions', () => {
+    it('includes deployments and projects namespaces by default', () => {
+      const group = registerCloudCommands()
+      const subcommands = group.commands.map((c) => c.name())
+      assert.ok(subcommands.includes('deployments'), 'should have deployments')
+      assert.ok(subcommands.includes('projects'), 'should have projects')
+    })
+
+    it('deployments namespace has list, get, and shutdown commands', () => {
+      const group = registerCloudCommands()
+      const deploymentsGroup = group.commands.find((c) => c.name() === 'deployments')!
+      const leafNames = deploymentsGroup.commands.map((c) => c.name())
+      assert.ok(leafNames.includes('list'))
+      assert.ok(leafNames.includes('get'))
+      assert.ok(leafNames.includes('shutdown'))
+    })
+
+    it('projects namespace has list, get, and delete commands', () => {
+      const group = registerCloudCommands()
+      const projectsGroup = group.commands.find((c) => c.name() === 'projects')!
+      const leafNames = projectsGroup.commands.map((c) => c.name())
+      assert.ok(leafNames.includes('list'))
+      assert.ok(leafNames.includes('get'))
+      assert.ok(leafNames.includes('delete'))
+    })
+  })
+})

--- a/test/cloud/request-builder.test.ts
+++ b/test/cloud/request-builder.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { z } from 'zod'
+import { buildCloudRequestParams } from '../../src/cloud/request-builder.ts'
+import type { CloudApiDefinition } from '../../src/cloud/types.ts'
+import type { ParsedResult } from '../../src/factory.ts'
+
+function parsed(input?: Record<string, unknown>): ParsedResult {
+  return { options: {}, ...(input !== undefined ? { input } : {}) }
+}
+
+describe('buildCloudRequestParams', () => {
+  it('returns method and path for a simple GET', () => {
+    const def: CloudApiDefinition = {
+      name: 'list',
+      namespace: 'deployments',
+      description: 'List deployments',
+      method: 'GET',
+      path: '/api/v1/deployments',
+    }
+    const result = buildCloudRequestParams(def, parsed())
+    assert.equal(result.method, 'GET')
+    assert.equal(result.path, '/api/v1/deployments')
+    assert.equal(result.querystring, undefined)
+    assert.equal(result.body, undefined)
+  })
+
+  it('interpolates required path params', () => {
+    const def: CloudApiDefinition = {
+      name: 'get',
+      namespace: 'deployments',
+      description: 'Get deployment',
+      method: 'GET',
+      path: '/api/v1/deployments/{deployment_id}',
+      pathParams: [{ name: 'deployment_id', description: 'ID', required: true }],
+    }
+    const result = buildCloudRequestParams(def, parsed({ deployment_id: 'abc-123' }))
+    assert.equal(result.path, '/api/v1/deployments/abc-123')
+  })
+
+  it('strips optional path params when absent', () => {
+    const def: CloudApiDefinition = {
+      name: 'get',
+      namespace: 'deployments',
+      description: 'Get deployment',
+      method: 'GET',
+      path: '/api/v1/deployments/{deployment_id}',
+      pathParams: [{ name: 'deployment_id', description: 'ID', required: false }],
+    }
+    const result = buildCloudRequestParams(def, parsed())
+    assert.equal(result.path, '/api/v1/deployments')
+  })
+
+  it('builds querystring from query params present in input', () => {
+    const def: CloudApiDefinition = {
+      name: 'list',
+      namespace: 'deployments',
+      description: 'List deployments',
+      method: 'GET',
+      path: '/api/v1/deployments',
+      queryParams: [
+        { name: 'show_metadata', type: 'boolean', description: 'Include metadata' },
+        { name: 'limit', type: 'number', description: 'Max results' },
+      ],
+    }
+    const result = buildCloudRequestParams(def, parsed({ show_metadata: true, limit: 10 }))
+    assert.deepEqual(result.querystring, { show_metadata: 'true', limit: '10' })
+  })
+
+  it('omits query params not present in input', () => {
+    const def: CloudApiDefinition = {
+      name: 'list',
+      namespace: 'deployments',
+      description: 'List',
+      method: 'GET',
+      path: '/api/v1/deployments',
+      queryParams: [
+        { name: 'show_metadata', type: 'boolean', description: 'Include metadata' },
+      ],
+    }
+    const result = buildCloudRequestParams(def, parsed())
+    assert.equal(result.querystring, undefined)
+  })
+
+  it('uses cliFlag as input key when provided on query param', () => {
+    const def: CloudApiDefinition = {
+      name: 'list',
+      namespace: 'deployments',
+      description: 'List',
+      method: 'GET',
+      path: '/api/v1/deployments',
+      queryParams: [
+        { name: 'show_metadata', cliFlag: 'show-metadata', type: 'boolean', description: 'Meta' },
+      ],
+    }
+    const result = buildCloudRequestParams(def, parsed({ 'show-metadata': true }))
+    assert.deepEqual(result.querystring, { show_metadata: 'true' })
+  })
+
+  it('collects body fields from input', () => {
+    const def: CloudApiDefinition = {
+      name: 'create',
+      namespace: 'deployments',
+      description: 'Create deployment',
+      method: 'POST',
+      path: '/api/v1/deployments',
+      body: z.object({ name: z.string(), region: z.string() }),
+    }
+    const result = buildCloudRequestParams(def, parsed({ name: 'my-deploy', region: 'us-east-1' }))
+    assert.deepEqual(result.body, { name: 'my-deploy', region: 'us-east-1' })
+  })
+
+  it('returns undefined body when no body fields are in input', () => {
+    const def: CloudApiDefinition = {
+      name: 'create',
+      namespace: 'deployments',
+      description: 'Create',
+      method: 'POST',
+      path: '/api/v1/deployments',
+      body: z.object({ name: z.string() }),
+    }
+    const result = buildCloudRequestParams(def, parsed())
+    assert.equal(result.body, undefined)
+  })
+
+  it('separates path, query, and body params from the same input', () => {
+    const def: CloudApiDefinition = {
+      name: 'update',
+      namespace: 'deployments',
+      description: 'Update deployment',
+      method: 'PUT',
+      path: '/api/v1/deployments/{deployment_id}',
+      pathParams: [{ name: 'deployment_id', description: 'ID', required: true }],
+      queryParams: [{ name: 'validate_only', type: 'boolean', description: 'Dry run' }],
+      body: z.object({ name: z.string() }),
+    }
+    const result = buildCloudRequestParams(def, parsed({
+      deployment_id: 'abc',
+      validate_only: true,
+      name: 'new-name',
+    }))
+    assert.equal(result.path, '/api/v1/deployments/abc')
+    assert.deepEqual(result.querystring, { validate_only: 'true' })
+    assert.deepEqual(result.body, { name: 'new-name' })
+  })
+})

--- a/test/cloud/types.test.ts
+++ b/test/cloud/types.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { validateCloudApiDefinition } from '../../src/cloud/types.ts'
+import type { CloudApiDefinition } from '../../src/cloud/types.ts'
+
+function validDef(overrides: Partial<CloudApiDefinition> = {}): CloudApiDefinition {
+  return {
+    name: 'list',
+    namespace: 'deployments',
+    description: 'List all deployments',
+    method: 'GET',
+    path: '/api/v1/deployments',
+    ...overrides,
+  }
+}
+
+describe('validateCloudApiDefinition', () => {
+  describe('valid definitions', () => {
+    it('accepts a minimal valid definition', () => {
+      assert.doesNotThrow(() => validateCloudApiDefinition(validDef()))
+    })
+
+    it('accepts a definition with path params', () => {
+      assert.doesNotThrow(() => validateCloudApiDefinition(validDef({
+        name: 'get',
+        path: '/api/v1/deployments/{deployment_id}',
+        pathParams: [{ name: 'deployment_id', description: 'Deployment ID', required: true }],
+      })))
+    })
+
+    it('accepts a definition with query params', () => {
+      assert.doesNotThrow(() => validateCloudApiDefinition(validDef({
+        queryParams: [{ name: 'show_metadata', type: 'boolean', description: 'Include metadata' }],
+      })))
+    })
+  })
+
+  describe('name validation', () => {
+    it('rejects empty name', () => {
+      assert.throws(() => validateCloudApiDefinition(validDef({ name: '' })), /invalid name/)
+    })
+
+    it('rejects name with uppercase', () => {
+      assert.throws(() => validateCloudApiDefinition(validDef({ name: 'List' })), /invalid name/)
+    })
+
+    it('accepts hyphenated name', () => {
+      assert.doesNotThrow(() => validateCloudApiDefinition(validDef({ name: 'get-status' })))
+    })
+  })
+
+  describe('namespace validation', () => {
+    it('rejects empty namespace', () => {
+      assert.throws(() => validateCloudApiDefinition(validDef({ namespace: '' })), /invalid namespace/)
+    })
+
+    it('rejects namespace starting with digit', () => {
+      assert.throws(() => validateCloudApiDefinition(validDef({ namespace: '1bad' })), /invalid namespace/)
+    })
+
+    it('accepts hyphenated namespace', () => {
+      assert.doesNotThrow(() => validateCloudApiDefinition(validDef({ namespace: 'es-projects' })))
+    })
+  })
+
+  describe('path validation', () => {
+    it('rejects path not starting with /', () => {
+      assert.throws(() => validateCloudApiDefinition(validDef({ path: 'api/v1/foo' })), /must start with/)
+    })
+  })
+
+  describe('path param validation', () => {
+    it('rejects path token without matching pathParam', () => {
+      assert.throws(() => validateCloudApiDefinition(validDef({
+        path: '/api/v1/deployments/{id}',
+        pathParams: [],
+      })), /not defined in pathParams/)
+    })
+
+    it('rejects required pathParam missing from path template', () => {
+      assert.throws(() => validateCloudApiDefinition(validDef({
+        path: '/api/v1/deployments',
+        pathParams: [{ name: 'id', description: 'ID', required: true }],
+      })), /not in path template/)
+    })
+  })
+
+  describe('schema key collision detection', () => {
+    it('rejects duplicate keys across path and query params', () => {
+      assert.throws(() => validateCloudApiDefinition(validDef({
+        path: '/api/v1/{name}',
+        pathParams: [{ name: 'name', description: 'Name', required: true }],
+        queryParams: [{ name: 'name', type: 'string', description: 'Also name' }],
+      })), /collision/)
+    })
+
+    it('uses cliFlag for query param collision check when present', () => {
+      assert.doesNotThrow(() => validateCloudApiDefinition(validDef({
+        path: '/api/v1/{name}',
+        pathParams: [{ name: 'name', description: 'Name', required: true }],
+        queryParams: [{ name: 'name', cliFlag: 'query-name', type: 'string', description: 'Also name' }],
+      })))
+    })
+  })
+})

--- a/test/lib/cloud-client.test.ts
+++ b/test/lib/cloud-client.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { getCloudClient, _testResetCloudClient } from '../../src/lib/cloud-client.ts'
+import { setResolvedConfig, clearResolvedConfig } from '../../src/config/store.ts'
+
+afterEach(() => {
+  _testResetCloudClient()
+  clearResolvedConfig()
+})
+
+describe('getCloudClient', () => {
+  it('throws missing_config when no cloud service is configured', () => {
+    setResolvedConfig({ context: { elasticsearch: { url: 'http://localhost:9200', auth: { api_key: 'x' } } } })
+    assert.throws(() => getCloudClient(), /missing_config/)
+  })
+
+  it('throws missing_config when no config is set at all', () => {
+    assert.throws(() => getCloudClient(), /missing_config/)
+  })
+
+  it('returns a client with the correct baseUrl', () => {
+    setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com', auth: { api_key: 'test-key' } } } })
+    const client = getCloudClient()
+    assert.equal(client.baseUrl, 'https://api.elastic-cloud.com')
+  })
+
+  it('strips trailing slash from baseUrl', () => {
+    setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com/', auth: { api_key: 'test-key' } } } })
+    const client = getCloudClient()
+    assert.equal(client.baseUrl, 'https://api.elastic-cloud.com')
+  })
+
+  it('returns the same cached instance on repeated calls', () => {
+    setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com', auth: { api_key: 'k' } } } })
+    const a = getCloudClient()
+    const b = getCloudClient()
+    assert.strictEqual(a, b)
+  })
+
+  it('returns a fresh instance after _testResetCloudClient', () => {
+    setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com', auth: { api_key: 'k' } } } })
+    const a = getCloudClient()
+    _testResetCloudClient()
+    const b = getCloudClient()
+    assert.notStrictEqual(a, b)
+  })
+
+  it('client.request makes a fetch call with correct method, url, headers', async () => {
+    setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com', auth: { api_key: 'my-key' } } } })
+    const client = getCloudClient()
+
+    const calls: { url: string; init: RequestInit }[] = []
+    client._testSetFetch(((url: string, init: RequestInit) => {
+      calls.push({ url, init })
+      return Promise.resolve(new Response(JSON.stringify({ ok: true }), { status: 200 }))
+    }) as typeof fetch)
+
+    const result = await client.request({ method: 'GET', path: '/api/v1/deployments' })
+    assert.equal(calls.length, 1)
+    assert.equal(calls[0]!.url, 'https://api.elastic-cloud.com/api/v1/deployments')
+    assert.equal(calls[0]!.init.method, 'GET')
+    const headers = calls[0]!.init.headers as Record<string, string>
+    assert.equal(headers['Authorization'], 'ApiKey my-key')
+    assert.deepEqual(result, { ok: true })
+  })
+
+  it('client.request includes query string when provided', async () => {
+    setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com', auth: { api_key: 'k' } } } })
+    const client = getCloudClient()
+
+    const calls: { url: string }[] = []
+    client._testSetFetch(((url: string, init: RequestInit) => {
+      calls.push({ url })
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    }) as typeof fetch)
+
+    await client.request({ method: 'GET', path: '/api/v1/deployments', querystring: { show_metadata: 'true', limit: '10' } })
+    const parsed = new URL(calls[0]!.url)
+    assert.equal(parsed.searchParams.get('show_metadata'), 'true')
+    assert.equal(parsed.searchParams.get('limit'), '10')
+  })
+
+  it('client.request sends JSON body when provided', async () => {
+    setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com', auth: { api_key: 'k' } } } })
+    const client = getCloudClient()
+
+    const calls: { init: RequestInit }[] = []
+    client._testSetFetch(((url: string, init: RequestInit) => {
+      calls.push({ init })
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    }) as typeof fetch)
+
+    await client.request({ method: 'POST', path: '/api/v1/deployments', body: { name: 'test' } })
+    assert.equal(calls[0]!.init.body, JSON.stringify({ name: 'test' }))
+  })
+
+  it('client.request throws on non-2xx response', async () => {
+    setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com', auth: { api_key: 'k' } } } })
+    const client = getCloudClient()
+
+    client._testSetFetch((() =>
+      Promise.resolve(new Response(JSON.stringify({ errors: [{ message: 'not found' }] }), { status: 404 }))
+    ) as typeof fetch)
+
+    await assert.rejects(() => client.request({ method: 'GET', path: '/api/v1/bad' }), (err: Error) => {
+      assert.match(err.message, /404/)
+      return true
+    })
+  })
+
+  it('sends ApiKey authorization header', async () => {
+    setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com', auth: { api_key: 'secret-key' } } } })
+    const client = getCloudClient()
+
+    let capturedHeaders: Record<string, string> = {}
+    client._testSetFetch(((url: string, init: RequestInit) => {
+      capturedHeaders = init.headers as Record<string, string>
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    }) as typeof fetch)
+
+    await client.request({ method: 'GET', path: '/test' })
+    assert.equal(capturedHeaders['Authorization'], 'ApiKey secret-key')
+  })
+})

--- a/test/lib/cloud-client.test.ts
+++ b/test/lib/cloud-client.test.ts
@@ -6,11 +6,12 @@
 import { describe, it, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
 import { getCloudClient, _testResetCloudClient } from '../../src/lib/cloud-client.ts'
-import { setResolvedConfig, clearResolvedConfig } from '../../src/config/store.ts'
+import { setResolvedConfig } from '../../src/config/store.ts'
+import type { ResolvedConfig } from '../../src/config/types.ts'
 
 afterEach(() => {
   _testResetCloudClient()
-  clearResolvedConfig()
+  setResolvedConfig(undefined as unknown as ResolvedConfig)
 })
 
 describe('getCloudClient', () => {

--- a/test/lib/cloud-client.test.ts
+++ b/test/lib/cloud-client.test.ts
@@ -127,4 +127,36 @@ describe('getCloudClient', () => {
     await client.request({ method: 'GET', path: '/test' })
     assert.equal(capturedHeaders['Authorization'], 'ApiKey secret-key')
   })
+
+  it('sends Basic authorization header for username/password auth', async () => {
+    setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com', auth: { username: 'user', password: 'pass' } } } })
+    const client = getCloudClient()
+
+    let capturedHeaders: Record<string, string> = {}
+    client._testSetFetch(((url: string, init: RequestInit) => {
+      capturedHeaders = init.headers as Record<string, string>
+      return Promise.resolve(new Response('{}', { status: 200 }))
+    }) as typeof fetch)
+
+    await client.request({ method: 'GET', path: '/test' })
+    const expected = `Basic ${Buffer.from('user:pass').toString('base64')}`
+    assert.equal(capturedHeaders['Authorization'], expected)
+  })
+
+  it('throws missing_config when auth has neither api_key nor username/password', () => {
+    setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com', auth: {} } } } as unknown as ResolvedConfig)
+    assert.throws(() => getCloudClient(), /missing_config/)
+  })
+
+  it('handles empty response body without throwing', async () => {
+    setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com', auth: { api_key: 'k' } } } })
+    const client = getCloudClient()
+
+    client._testSetFetch((() =>
+      Promise.resolve(new Response('', { status: 200 }))
+    ) as typeof fetch)
+
+    const result = await client.request({ method: 'DELETE', path: '/api/v1/something' })
+    assert.deepEqual(result, {})
+  })
 })

--- a/test/lib/cloud-client.test.ts
+++ b/test/lib/cloud-client.test.ts
@@ -75,7 +75,7 @@ describe('getCloudClient', () => {
     const client = getCloudClient()
 
     const calls: { url: string }[] = []
-    client._testSetFetch(((url: string, init: RequestInit) => {
+    client._testSetFetch(((url: string) => {
       calls.push({ url })
       return Promise.resolve(new Response('{}', { status: 200 }))
     }) as typeof fetch)

--- a/test/lib/cloud-client.test.ts
+++ b/test/lib/cloud-client.test.ts
@@ -128,22 +128,7 @@ describe('getCloudClient', () => {
     assert.equal(capturedHeaders['Authorization'], 'ApiKey secret-key')
   })
 
-  it('sends Basic authorization header for username/password auth', async () => {
-    setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com', auth: { username: 'user', password: 'pass' } } } })
-    const client = getCloudClient()
-
-    let capturedHeaders: Record<string, string> = {}
-    client._testSetFetch(((url: string, init: RequestInit) => {
-      capturedHeaders = init.headers as Record<string, string>
-      return Promise.resolve(new Response('{}', { status: 200 }))
-    }) as typeof fetch)
-
-    await client.request({ method: 'GET', path: '/test' })
-    const expected = `Basic ${Buffer.from('user:pass').toString('base64')}`
-    assert.equal(capturedHeaders['Authorization'], expected)
-  })
-
-  it('throws missing_config when auth has neither api_key nor username/password', () => {
+  it('throws missing_config when auth has no api_key', () => {
     setResolvedConfig({ context: { cloud: { url: 'https://api.elastic-cloud.com', auth: {} } } } as unknown as ResolvedConfig)
     assert.throws(() => getCloudClient(), /missing_config/)
   })


### PR DESCRIPTION
closes https://github.com/elastic/agentic-interface-program/issues/50

Add Cloud control plane API support, mirroring the ES API pattern from [#64.](https://github.com/elastic/cli/pull/64)
- added new type CloudApiDefinition
- example API definitions (deployments: list/get/shutdown, projects/sls: list/get/delete)
- registers everything under elastic cloud <namespace> <command>

spec ref https://api.elastic-cloud.com/api/v1/api-docs-user/swagger.json
