### PR TITLE
fix: print human-readable output for --dry-run without --json

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -642,6 +642,8 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
     if (allRaw['dryRun'] === true) {
       if (jsonFormat) {
         process.stdout.write(JSON.stringify({ success: true }) + '\n')
+      } else {
+        process.stdout.write('dry run: inputs valid, no action performed\n')
       }
       return
     }

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -1609,7 +1609,7 @@ describe('defineCommand', () => {
       })
       const out = await invokeUnderRoot(cmd, [], ['--dry-run'])
       assert.equal(handlerCalled, false, 'handler must not be called with --dry-run')
-      assert.equal(out, '', 'no output expected in text mode')
+      assert.equal(out, 'dry run: inputs valid, no action performed\n')
     })
 
     it('outputs {"success":true} and skips handler with valid JSON input via --input-file', async () => {


### PR DESCRIPTION
## Summary

- Fixes #89 — `--dry-run` now prints `dry run: inputs valid, no action performed` in text mode instead of producing no output
- JSON mode (`--dry-run --json`) continues to output `{"success":true}` as before