### PR TITLE
fix: Write error results to stderr and exit non-zero

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,13 +1,10 @@
 <!--
 SYNC IMPACT REPORT
 ==================
-Version change: 1.2.0 → 1.2.1 (PATCH — wording update to reflect renamed global flags)
+Version change: 1.2.1 → 1.2.2 (PATCH — clarify error output goes to stderr with non-zero exit)
 
 Modified principles:
-  - Principle II: updated `--file=<path>` → `--input-file=<path>`, `--format=json` → `--json`.
-  - Principle III: updated `--format=json` error payload reference → `--json`.
-  - Principle IV: updated `--context=<name>` → `--use-context=<name>`.
-  - Development Standards: updated `--format=json` error reference → `--json`.
+  - Development Standards: Error messages clause now requires stderr output and non-zero exit code.
 
 Added sections:
   - None.
@@ -141,7 +138,9 @@ behave differently on any of these three platforms.
   rather than authored manually. Any exception requires written justification.
 - **Error messages**: Errors MUST be structured and distinguishable (error code +
   human message). When `--json`, errors MUST serialize to JSON with at
-  minimum `{"error": {"code": "…", "message": "…"}}`.
+  minimum `{"error": {"code": "…", "message": "…"}}`. All structured errors
+  MUST be written to stderr (never stdout) and the process MUST exit with a
+  non-zero status code so that scripts and CI pipelines can detect failures.
 - **Node.js ecosystem conventions**: Standard JavaScript/TypeScript idioms, `npm test`,
   MUST pass before merge. Any deviation from ecosystem idioms MUST be
   explained in a comment or docstring at the point of deviation.
@@ -182,4 +181,4 @@ or error messages.
 - Schema introspection tooling for *developers* of the CLI itself (not end users)
   may inspect `found_in` values internally, but MUST NOT propagate them outward.
 
-**Version**: 1.2.1 | **Ratified**: TODO(RATIFICATION_DATE): confirm adoption date | **Last Amended**: 2026-04-06
+**Version**: 1.2.2 | **Ratified**: TODO(RATIFICATION_DATE): confirm adoption date | **Last Amended**: 2026-04-13

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -397,6 +397,20 @@ function parseJsonContent (raw: string, source: string, cmd: OpaqueCommandHandle
   }
 }
 
+function isErrorResult (value: JsonValue): boolean {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    'error' in value &&
+    typeof value.error === 'object' &&
+    value.error !== null &&
+    !Array.isArray(value.error) &&
+    'code' in value.error &&
+    typeof value.error.code === 'string'
+  )
+}
+
 /**
  * Creates a leaf command from a declarative config and returns an opaque handle.
  *
@@ -595,7 +609,7 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
       const dotPath = (parts.length > 1 ? parts.slice(1) : parts).join('.')
       if (!isCommandAllowed(dotPath, resolvedConfig.commands)) {
         if (jsonFormat === true) {
-          process.stdout.write(JSON.stringify({
+          process.stderr.write(JSON.stringify({
             error: {
               code: 'command_blocked',
               message: `command "${dotPath}" is not allowed by the current policy`,
@@ -626,7 +640,7 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
       } else {
         if (jsonFormat === true) {
           const issues = result.error.issues
-          process.stdout.write(JSON.stringify({
+          process.stderr.write(JSON.stringify({
             error: {
               code: 'input_validation_failed',
               message: `Input validation failed with ${issues.length} issue(s)`,
@@ -647,7 +661,14 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
     }
     const handlerResult = await config.handler(parsed)
     assert(handlerResult !== undefined, `command ${JSON.stringify(config.name)}: handler must return a JsonValue`)
-    if (jsonFormat === true) {
+    if (isErrorResult(handlerResult)) {
+      if (jsonFormat === true) {
+        process.stderr.write(JSON.stringify(handlerResult) + '\n')
+      } else {
+        process.stderr.write(renderText(handlerResult))
+      }
+      process.exitCode = 1
+    } else if (jsonFormat === true) {
       process.stdout.write(JSON.stringify(handlerResult) + '\n')
     } else if (config.formatOutput !== undefined) {
       process.stdout.write(config.formatOutput(handlerResult, parsed))

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -1384,7 +1384,7 @@ describe('defineCommand', () => {
     })
 
 
-    /** mounts cmd under a root program with --json, captures stdout, returns parsed JSON */
+    /** mounts cmd under a root program with --json, captures stdout + stderr, returns parsed JSON */
     async function invokeWithJsonFormat(cmd: OpaqueCommandHandle, argv: string[]): Promise<{ out: string, parsed: unknown }> {
       const { Command } = await import('commander')
       const prog = new Command('elastic')
@@ -1393,9 +1393,10 @@ describe('defineCommand', () => {
       prog.exitOverride()
       cmd.exitOverride()
       let out = ''
-      // intercept process.stdout.write so JSON written directly to stdout is captured
-      const origWrite = process.stdout.write.bind(process.stdout)
+      const origOut = process.stdout.write.bind(process.stdout)
+      const origErr = process.stderr.write.bind(process.stderr)
       process.stdout.write = (chunk: unknown) => { out += String(chunk); return true }
+      process.stderr.write = (chunk: unknown) => { out += String(chunk); return true }
       prog.configureOutput({ writeOut: (s) => { out += s }, writeErr: (s) => { out += s } })
       cmd.configureOutput({ writeOut: (s) => { out += s }, writeErr: (s) => { out += s } })
       try {
@@ -1403,7 +1404,8 @@ describe('defineCommand', () => {
       } catch {
         // exitOverride throws on cmd.error(); that's expected
       } finally {
-        process.stdout.write = origWrite
+        process.stdout.write = origOut
+        process.stderr.write = origErr
       }
       let parsed: unknown = null
       try { parsed = JSON.parse(out) } catch { /* not JSON - test will fail on assertion */ }
@@ -2315,15 +2317,16 @@ describe('command policy enforcement', () => {
     assert.equal(handlerCalled, true)
   })
 
-  it('emits structured JSON error when --json and command is blocked', async () => {
+  it('emits structured JSON error to stderr when --json and command is blocked', async () => {
     setResolvedConfig({ context: {}, commands: { allowed: ['ping'] } })
     const cmd = defineCommand({
       name: 'search',
       description: 'Search',
       handler: () => ({}),
     })
-    const out = await invokeUnderRoot(cmd, ['--json'], [])
-    const parsed = JSON.parse(out) as Record<string, unknown>
+    const { stdout, stderr } = await invokeCapturingStreams(cmd, ['--json'], [])
+    assert.equal(stdout, '', 'stdout should be empty for blocked command errors')
+    const parsed = JSON.parse(stderr) as Record<string, unknown>
     assert.ok('error' in parsed)
     const err = parsed['error'] as Record<string, unknown>
     assert.equal(err['code'], 'command_blocked')
@@ -3022,3 +3025,129 @@ async function invokeUnderRoot(cmd: OpaqueCommandHandle, rootArgv: string[], cmd
   cmd.exitOverride()
   return captureStdout(() => prog.parseAsync([...rootArgv, cmd.name(), ...cmdArgv], { from: 'user' }))
 }
+
+/** captures stdout, stderr, and exitCode separately */
+async function captureStreams(fn: () => Promise<void>): Promise<{ stdout: string, stderr: string, exitCode: number }> {
+  let stdout = ''
+  let stderr = ''
+  let exitCode = 0
+  const origOut = process.stdout.write.bind(process.stdout)
+  const origErr = process.stderr.write.bind(process.stderr)
+  const origExitCode = process.exitCode
+  process.exitCode = 0
+  process.stdout.write = (chunk: unknown) => { stdout += String(chunk); return true }
+  process.stderr.write = (chunk: unknown) => { stderr += String(chunk); return true }
+  try {
+    await fn()
+  } catch {
+    /* swallow -- caller inspects captured output */
+  } finally {
+    exitCode = process.exitCode ?? 0
+    process.stdout.write = origOut
+    process.stderr.write = origErr
+    process.exitCode = origExitCode as typeof process.exitCode
+  }
+  return { stdout, stderr, exitCode }
+}
+
+/** mounts a command under a root program and captures stdout, stderr, exitCode */
+async function invokeCapturingStreams(
+  cmd: OpaqueCommandHandle,
+  rootArgv: string[],
+  cmdArgv: string[],
+): Promise<{ stdout: string, stderr: string, exitCode: number }> {
+  const { Command } = await import('commander')
+  const prog = new Command('elastic')
+  prog.option('--json', 'output as JSON')
+  prog.addCommand(cmd)
+  prog.exitOverride()
+  cmd.exitOverride()
+  return captureStreams(() => prog.parseAsync([...rootArgv, cmd.name(), ...cmdArgv], { from: 'user' }))
+}
+
+describe('error result detection', () => {
+  it('error result in JSON mode goes to stderr with non-zero exit', async () => {
+    const cmd = defineCommand({
+      name: 'fail',
+      description: 'Fail',
+      handler: () => ({ error: { code: 'transport_error', message: 'connection refused' } }),
+    })
+    const { stdout, stderr, exitCode } = await invokeCapturingStreams(cmd, ['--json'], [])
+    assert.equal(stdout, '', 'stdout should be empty for error results')
+    const parsed = JSON.parse(stderr) as Record<string, unknown>
+    const err = parsed['error'] as Record<string, unknown>
+    assert.equal(err['code'], 'transport_error')
+    assert.equal(err['message'], 'connection refused')
+    assert.equal(exitCode, 1)
+  })
+
+  it('error result in text mode goes to stderr with non-zero exit', async () => {
+    const cmd = defineCommand({
+      name: 'fail',
+      description: 'Fail',
+      handler: () => ({ error: { code: 'missing_config', message: 'No ES configured' } }),
+    })
+    const { stdout, stderr, exitCode } = await invokeCapturingStreams(cmd, [], [])
+    assert.equal(stdout, '', 'stdout should be empty for error results')
+    assert.ok(stderr.length > 0, 'stderr should contain error output')
+    assert.match(stderr, /missing_config/)
+    assert.equal(exitCode, 1)
+  })
+
+  it('successful result in JSON mode goes to stdout with exit 0', async () => {
+    const cmd = defineCommand({
+      name: 'ok',
+      description: 'OK',
+      handler: () => ({ status: 'green' }),
+    })
+    const { stdout, stderr, exitCode } = await invokeCapturingStreams(cmd, ['--json'], [])
+    assert.deepEqual(JSON.parse(stdout), { status: 'green' })
+    assert.equal(stderr, '')
+    assert.equal(exitCode, 0)
+  })
+
+  it('result with non-contract error shape is not treated as error', async () => {
+    const cmd = defineCommand({
+      name: 'ok',
+      description: 'OK',
+      handler: () => ({ error: 'just a string' }),
+    })
+    const { stdout, stderr, exitCode } = await invokeCapturingStreams(cmd, ['--json'], [])
+    assert.deepEqual(JSON.parse(stdout), { error: 'just a string' })
+    assert.equal(stderr, '')
+    assert.equal(exitCode, 0)
+  })
+
+  it('error result with status_code and body is written to stderr', async () => {
+    const cmd = defineCommand({
+      name: 'fail',
+      description: 'Fail',
+      handler: () => ({
+        error: {
+          code: 'transport_error',
+          status_code: 404,
+          body: { error: { type: 'index_not_found_exception' } },
+        },
+      }),
+    })
+    const { stdout, stderr, exitCode } = await invokeCapturingStreams(cmd, ['--json'], [])
+    assert.equal(stdout, '')
+    const parsed = JSON.parse(stderr) as Record<string, unknown>
+    const err = parsed['error'] as Record<string, unknown>
+    assert.equal(err['code'], 'transport_error')
+    assert.equal(err['status_code'], 404)
+    assert.equal(exitCode, 1)
+  })
+
+  it('formatOutput is not called for error results', async () => {
+    let formatCalled = false
+    const cmd = defineCommand({
+      name: 'fail',
+      description: 'Fail',
+      handler: () => ({ error: { code: 'cloud_api_error', message: 'bad' } }),
+      formatOutput: () => { formatCalled = true; return 'custom\n' },
+    })
+    await invokeCapturingStreams(cmd, [], [])
+    assert.equal(formatCalled, false)
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #98. API errors, missing config errors, input validation failures, and command policy blocks now:

- Write structured error output to **stderr** instead of stdout
- Exit with **non-zero status code** (1)

This applies to all error paths in the factory: `transport_error`, `missing_config`, `cloud_api_error`, `input_validation_failed`, and `command_blocked`.

### Changes

- **`src/factory.ts`**: Added `isErrorResult()` to detect handler-returned error payloads (`{ error: { code: string, ... } }`). Error results route to stderr with `process.exitCode = 1`. Switched `command_blocked` and `input_validation_failed` JSON paths from stdout to stderr.
- **`test/factory.test.ts`**: 6 new tests for error result detection (stderr output, exit code, edge cases). Updated existing tests for the stderr change.
- **`.specify/memory/constitution.md`**: Development Standards error clause now requires stderr and non-zero exit. Version 1.2.1 -> 1.2.2.

## Test plan

- [x] All 514 existing tests pass
- [x] 6 new tests covering: JSON/text error to stderr, exit code 1, success still on stdout, non-contract error shapes ignored, formatOutput skipped for errors
- [ ] Manual: `elastic es info` against bad config exits non-zero with error on stderr
