### PR TITLE
fix: --input-file should work in non-TTY contexts

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -541,9 +541,6 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
     let inputValue: unknown
     if (config.input instanceof z.ZodType) {
       const filePath = cmd.getOptionValue('inputFile') as string | undefined
-      if (filePath !== undefined && !process.stdin.isTTY) {
-        return cmd.error('cannot read input from both --input-file and stdin; provide one or the other')
-      }
       if (filePath !== undefined) {
         let fileContent: string
         try {

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -1104,23 +1104,26 @@ describe('defineCommand', () => {
       Object.defineProperty(process.stdin, 'isTTY', { value: origIsTTY, configurable: true, writable: true })
     })
 
-    it('errors with conflict message when both --input-file and stdin are provided', async () => {
+    it('--input-file takes precedence over stdin in non-TTY context', async () => {
       const filePath = join(tmpDir, 'input.json')
       writeFileSync(filePath, JSON.stringify({ index: 'my-index' }))
       const restore = _testSetStdinReader(() => JSON.stringify({ index: 'other-index' }))
       try {
+        const received: ParsedResult[] = []
         const cmd = defineCommand({
           name: 'search',
           description: 'Run a search',
-        input: z.object({ index: z.string() }),
-          handler: () => ({}),
+          input: z.object({ index: z.string() }),
+          handler: (parsed) => { received.push(parsed); return {} },
         })
-        const err = await captureErrAsync(cmd, ['--input-file', filePath])
-        assert.match(err, /cannot read input from both --input-file and stdin/)
+        await invokeAsync(cmd, ['--input-file', filePath])
+        assert.strictEqual(received.length, 1)
+        assert.deepStrictEqual(received[0]!.input, { index: 'my-index' })
       } finally {
         restore()
       }
     })
+
   })
   describe('schema input - type acceptance', () => {
     it('accepts a Zod object schema as input without throwing', () => {


### PR DESCRIPTION
## Summary

- `--input-file` now works in non-TTY contexts (CI, scripts, piped processes)
- Removed the `process.stdin.isTTY` guard that conflated "stdin is a pipe" with "stdin has data", causing `--input-file` to always error in non-interactive environments
- `--input-file` takes unconditional precedence over stdin

Closes #93

## Test plan

- [x] Updated existing conflict test to verify `--input-file` takes precedence over stdin in non-TTY context
- [x] Full test suite passes (508 tests, 0 failures)
- [x] Manual verification: run `echo '{}' > /tmp/test.json && echo "" | elastic es search --input-file /tmp/test.json` in a non-TTY context

BEGIN_COMMIT_OVERRIDE
fix: --input-file should work in non-TTY contexts (#121)

Release-As: 0.1.0
END_COMMIT_OVERRIDE
