### PR TITLE
feat: add msearch helper command

### DIFF
--- a/src/es/helpers/msearch.ts
+++ b/src/es/helpers/msearch.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Transport } from '@elastic/transport'
+import { defineCommand } from '../../factory.ts'
+import type { OpaqueCommandHandle, JsonValue, ParsedResult } from '../../factory.ts'
+import { getTransport } from '../../lib/transport.ts'
+import { missingConfigError, transportError } from '../errors.ts'
+import { readRawInput, runWithConcurrency } from './shared.ts'
+
+interface MsearchOptions {
+  index?: string | undefined
+  'input-file'?: string | undefined
+  'batch-size': number
+  concurrency: number
+}
+
+interface SearchItem {
+  header?: Record<string, unknown>
+  body: Record<string, unknown>
+}
+
+interface MsearchResponse {
+  responses?: JsonValue[]
+}
+
+/** Dependencies injectable for testing. */
+export interface MsearchDeps {
+  getTransport: () => Transport
+}
+
+const defaultDeps: MsearchDeps = { getTransport }
+
+/** Builds the NDJSON body for _msearch: alternating header/body lines. */
+function buildMsearchNdjsonBody (items: SearchItem[], defaultIndex?: string | undefined): string {
+  const lines: string[] = []
+  for (const item of items) {
+    const header = { ...item.header }
+    if (header.index == null && defaultIndex != null) {
+      header.index = defaultIndex
+    }
+    lines.push(JSON.stringify(header))
+    lines.push(JSON.stringify(item.body))
+  }
+  return lines.join('\n') + '\n'
+}
+
+/** Parses raw input into an array of search items. */
+function parseSearchItems (raw: string): SearchItem[] {
+  const parsed = JSON.parse(raw)
+  if (!Array.isArray(parsed)) {
+    throw new Error('Expected a JSON array of search objects')
+  }
+  return parsed.map((item: unknown, i: number) => {
+    if (item == null || typeof item !== 'object') {
+      throw new Error(`Search item at index ${i} must be an object`)
+    }
+    const obj = item as Record<string, unknown>
+    if (obj.body == null || typeof obj.body !== 'object') {
+      throw new Error(`Search item at index ${i} must have a "body" object`)
+    }
+    return {
+      header: (obj.header as Record<string, unknown> | undefined) ?? {},
+      body: obj.body as Record<string, unknown>
+    }
+  })
+}
+
+function createMsearchHandler (deps: MsearchDeps = defaultDeps) {
+  return async (parsed: ParsedResult): Promise<JsonValue> => {
+    const opts = parsed.options as unknown as MsearchOptions
+
+    let transport: Transport
+    try {
+      transport = deps.getTransport()
+    } catch (err) {
+      return missingConfigError(err)
+    }
+
+    // Read and parse input
+    let items: SearchItem[]
+    try {
+      let raw: string | undefined
+      if (opts['input-file'] != null) {
+        raw = readRawInput(opts['input-file'])
+      } else if (!process.stdin.isTTY) {
+        raw = readRawInput()
+      }
+      if (raw == null || raw.trim().length === 0) {
+        return {
+          error: {
+            code: 'input_error',
+            message: 'No input provided. Use --input-file or pipe data to stdin'
+          }
+        }
+      }
+      items = parseSearchItems(raw)
+    } catch (err) {
+      return {
+        error: {
+          code: 'input_error',
+          message: err instanceof Error ? err.message : String(err)
+        }
+      }
+    }
+
+    if (items.length === 0) {
+      return { responses: [] }
+    }
+
+    // Split into batches
+    const batchSize = opts['batch-size']
+    const batches: SearchItem[][] = []
+    for (let i = 0; i < items.length; i += batchSize) {
+      batches.push(items.slice(i, i + batchSize))
+    }
+
+    // Build path
+    const path = opts.index != null
+      ? `/${encodeURIComponent(opts.index)}/_msearch`
+      : '/_msearch'
+
+    try {
+      const allResponses: JsonValue[] = []
+
+      await runWithConcurrency(batches, opts.concurrency, async (batch) => {
+        const ndjsonBody = buildMsearchNdjsonBody(batch, opts.index)
+        const result = await transport.request<MsearchResponse>(
+          { method: 'POST', path, body: ndjsonBody },
+          { headers: { 'content-type': 'application/x-ndjson' } }
+        )
+        if (result.responses != null) {
+          allResponses.push(...result.responses)
+        }
+        return result
+      })
+
+      return { responses: allResponses }
+    } catch (err) {
+      return transportError(err)
+    }
+  }
+}
+
+export function createMsearchCommand (deps?: MsearchDeps): OpaqueCommandHandle {
+  return defineCommand({
+    name: 'msearch',
+    description: 'Batch multiple search requests via _msearch with configurable batch size and concurrency.',
+    options: [
+      { long: 'index', short: 'i', description: 'Default index for searches', type: 'string' },
+      { long: 'input-file', description: 'Path to JSON file with search array', type: 'string' },
+      { long: 'batch-size', description: 'Searches per _msearch request', type: 'number', defaultValue: 5 },
+      { long: 'concurrency', description: 'Parallel _msearch requests', type: 'number', defaultValue: 5 },
+    ],
+    handler: createMsearchHandler(deps)
+  })
+}

--- a/src/es/helpers/register.ts
+++ b/src/es/helpers/register.ts
@@ -7,6 +7,7 @@ import { defineGroup } from '../../factory.ts'
 import type { OpaqueCommandHandle } from '../../factory.ts'
 import { createScrollSearchCommand } from './scroll-search.ts'
 import { createBulkIngestCommand } from './bulk-ingest.ts'
+import { createMsearchCommand } from './msearch.ts'
 
 /**
  * Registers all high-level helper commands under a `helpers` group.
@@ -19,6 +20,7 @@ export function registerHelperCommands (): OpaqueCommandHandle {
   return defineGroup(
     { name: 'helpers', description: 'High-level helper commands for common Elasticsearch workflows' },
     createScrollSearchCommand(),
-    createBulkIngestCommand()
+    createBulkIngestCommand(),
+    createMsearchCommand()
   )
 }

--- a/test/es/helpers/msearch.test.ts
+++ b/test/es/helpers/msearch.test.ts
@@ -41,20 +41,32 @@ async function runCommand (args: string[], deps: MsearchDeps): Promise<unknown> 
   program.option('--json', 'output as JSON')
   program.addCommand(cmd)
 
-  const chunks: string[] = []
-  const origWrite = process.stdout.write.bind(process.stdout)
+  // Capture stdout and stderr
+  const origStdoutWrite = process.stdout.write.bind(process.stdout)
+  const origStderrWrite = process.stderr.write.bind(process.stderr)
+  const stdoutChunks: string[] = []
+  const stderrChunks: string[] = []
   process.stdout.write = ((chunk: string) => {
-    chunks.push(typeof chunk === 'string' ? chunk : chunk.toString())
+    stdoutChunks.push(typeof chunk === 'string' ? chunk : chunk.toString())
     return true
   }) as typeof process.stdout.write
+  process.stderr.write = ((chunk: string) => {
+    stderrChunks.push(typeof chunk === 'string' ? chunk : chunk.toString())
+    return true
+  }) as typeof process.stderr.write
 
   try {
     await program.parseAsync(['node', 'test', 'msearch', ...args])
   } finally {
-    process.stdout.write = origWrite
+    process.stdout.write = origStdoutWrite
+    process.stderr.write = origStderrWrite
+    process.exitCode = 0
   }
 
-  const output = chunks.join('')
+  // Prefer stderr (error results) over stdout; parse whichever has content
+  const errOutput = stderrChunks.join('')
+  const stdOutput = stdoutChunks.join('')
+  const output = errOutput.trim().length > 0 ? errOutput : stdOutput
   if (output.trim().length > 0) {
     try { return JSON.parse(output.trim()) } catch { return output.trim() }
   }

--- a/test/es/helpers/msearch.test.ts
+++ b/test/es/helpers/msearch.test.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import type { Transport, TransportRequestParams, TransportRequestOptions } from '@elastic/transport'
+import { createMsearchCommand } from '../../../src/es/helpers/msearch.ts'
+import type { MsearchDeps } from '../../../src/es/helpers/msearch.ts'
+import { Command } from 'commander'
+
+function mockTransport (responses: Array<{ responses: unknown[] }>): {
+  transport: Transport
+  requests: Array<{ params: TransportRequestParams, opts?: TransportRequestOptions }>
+} {
+  const requests: Array<{ params: TransportRequestParams, opts?: TransportRequestOptions }> = []
+  let callIndex = 0
+  const transport = {
+    request: async (params: TransportRequestParams, opts?: TransportRequestOptions) => {
+      requests.push({ params, opts })
+      const response = responses[callIndex] ?? responses[responses.length - 1]
+      callIndex++
+      return response
+    }
+  } as unknown as Transport
+  return { transport, requests }
+}
+
+function makeDeps (transport: Transport): MsearchDeps {
+  return { getTransport: () => transport }
+}
+
+async function runCommand (args: string[], deps: MsearchDeps): Promise<unknown> {
+  const cmd = createMsearchCommand(deps)
+  const program = new Command()
+  program.exitOverride()
+  program.option('--json', 'output as JSON')
+  program.addCommand(cmd)
+
+  const chunks: string[] = []
+  const origWrite = process.stdout.write.bind(process.stdout)
+  process.stdout.write = ((chunk: string) => {
+    chunks.push(typeof chunk === 'string' ? chunk : chunk.toString())
+    return true
+  }) as typeof process.stdout.write
+
+  try {
+    await program.parseAsync(['node', 'test', 'msearch', ...args])
+  } finally {
+    process.stdout.write = origWrite
+  }
+
+  const output = chunks.join('')
+  if (output.trim().length > 0) {
+    try { return JSON.parse(output.trim()) } catch { return output.trim() }
+  }
+  return undefined
+}
+
+function makeSearchInput (items: Array<{ header?: Record<string, unknown>, body: Record<string, unknown> }>): string {
+  return JSON.stringify(items)
+}
+
+describe('msearch command', () => {
+  it('creates a command named msearch', () => {
+    const { transport } = mockTransport([])
+    const cmd = createMsearchCommand(makeDeps(transport))
+    assert.equal(cmd.name(), 'msearch')
+  })
+
+  it('batches and sends searches from --input-file', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'msearch-test-'))
+    const filePath = join(tmpDir, 'searches.json')
+    writeFileSync(filePath, makeSearchInput([
+      { body: { query: { match_all: {} } } },
+      { body: { query: { term: { status: 'active' } } } }
+    ]))
+
+    const { transport, requests } = mockTransport([
+      { responses: [{ hits: { total: 10 } }, { hits: { total: 5 } }] }
+    ])
+
+    const result = await runCommand(
+      ['--input-file', filePath, '--index', 'test-idx', '--json'],
+      makeDeps(transport)
+    ) as Record<string, unknown>
+
+    assert.equal(requests.length, 1)
+    const responses = result.responses as unknown[]
+    assert.equal(responses.length, 2)
+  })
+
+  it('splits searches into batches by --batch-size', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'msearch-test-'))
+    const filePath = join(tmpDir, 'searches.json')
+    const items = Array.from({ length: 6 }, (_, i) => ({
+      body: { query: { term: { id: i } } }
+    }))
+    writeFileSync(filePath, makeSearchInput(items))
+
+    const { transport, requests } = mockTransport([
+      { responses: [{ hits: {} }, { hits: {} }] },
+      { responses: [{ hits: {} }, { hits: {} }] },
+      { responses: [{ hits: {} }, { hits: {} }] }
+    ])
+
+    const result = await runCommand(
+      ['--input-file', filePath, '--batch-size', '2', '--index', 'test-idx', '--json'],
+      makeDeps(transport)
+    ) as Record<string, unknown>
+
+    assert.equal(requests.length, 3, 'Expected 3 batches of 2')
+    assert.equal((result.responses as unknown[]).length, 6)
+  })
+
+  it('applies default index from --index to items without header.index', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'msearch-test-'))
+    const filePath = join(tmpDir, 'searches.json')
+    writeFileSync(filePath, makeSearchInput([
+      { body: { query: { match_all: {} } } },
+      { header: { index: 'custom-idx' }, body: { query: { match_all: {} } } }
+    ]))
+
+    const { transport, requests } = mockTransport([
+      { responses: [{}, {}] }
+    ])
+
+    await runCommand(
+      ['--input-file', filePath, '--index', 'default-idx', '--json'],
+      makeDeps(transport)
+    )
+
+    const body = requests[0]!.params.body as string
+    const lines = body.split('\n').filter((l: string) => l.length > 0)
+    const header1 = JSON.parse(lines[0]!)
+    const header2 = JSON.parse(lines[2]!)
+    assert.equal(header1.index, 'default-idx')
+    assert.equal(header2.index, 'custom-idx')
+  })
+
+  it('sends content-type application/x-ndjson header', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'msearch-test-'))
+    const filePath = join(tmpDir, 'searches.json')
+    writeFileSync(filePath, makeSearchInput([{ body: { query: { match_all: {} } } }]))
+
+    const { transport, requests } = mockTransport([{ responses: [{}] }])
+
+    await runCommand(
+      ['--input-file', filePath, '--index', 'test-idx', '--json'],
+      makeDeps(transport)
+    )
+
+    const opts = requests[0]!.opts as Record<string, unknown>
+    const headers = opts.headers as Record<string, string>
+    assert.equal(headers['content-type'], 'application/x-ndjson')
+  })
+
+  it('builds correct NDJSON body with alternating header/body lines', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'msearch-test-'))
+    const filePath = join(tmpDir, 'searches.json')
+    writeFileSync(filePath, makeSearchInput([
+      { body: { query: { match_all: {} } } }
+    ]))
+
+    const { transport, requests } = mockTransport([{ responses: [{}] }])
+
+    await runCommand(
+      ['--input-file', filePath, '--index', 'test-idx', '--json'],
+      makeDeps(transport)
+    )
+
+    const body = requests[0]!.params.body as string
+    const lines = body.split('\n')
+    // header line, body line, trailing empty
+    assert.equal(lines.length, 3)
+    assert.deepStrictEqual(JSON.parse(lines[0]!), { index: 'test-idx' })
+    assert.deepStrictEqual(JSON.parse(lines[1]!), { query: { match_all: {} } })
+    assert.equal(lines[2], '') // trailing newline
+  })
+
+  it('uses index-specific path when --index is provided', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'msearch-test-'))
+    const filePath = join(tmpDir, 'searches.json')
+    writeFileSync(filePath, makeSearchInput([{ body: { query: { match_all: {} } } }]))
+
+    const { transport, requests } = mockTransport([{ responses: [{}] }])
+
+    await runCommand(
+      ['--input-file', filePath, '--index', 'my-idx', '--json'],
+      makeDeps(transport)
+    )
+
+    assert.ok(requests[0]!.params.path!.includes('my-idx'))
+    assert.ok(requests[0]!.params.path!.includes('_msearch'))
+  })
+
+  it('returns missing_config error when transport is not configured', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'msearch-test-'))
+    const filePath = join(tmpDir, 'searches.json')
+    writeFileSync(filePath, makeSearchInput([{ body: { query: { match_all: {} } } }]))
+
+    const deps: MsearchDeps = {
+      getTransport: () => { throw new Error('missing_config: no ES configured') }
+    }
+
+    const result = await runCommand(
+      ['--input-file', filePath, '--json'],
+      deps
+    ) as Record<string, unknown>
+
+    const error = result.error as Record<string, unknown>
+    assert.equal(error.code, 'missing_config')
+  })
+
+  it('returns empty responses for empty input array', async () => {
+    const tmpDir = mkdtempSync(join(tmpdir(), 'msearch-test-'))
+    const filePath = join(tmpDir, 'searches.json')
+    writeFileSync(filePath, '[]')
+
+    const { transport } = mockTransport([])
+
+    const result = await runCommand(
+      ['--input-file', filePath, '--json'],
+      makeDeps(transport)
+    ) as Record<string, unknown>
+
+    assert.deepStrictEqual(result.responses, [])
+  })
+})


### PR DESCRIPTION
## Summary

- Add `elastic es helpers msearch` command for batching multiple search requests via `_msearch`
- Accepts JSON array of `{header?, body}` objects from `--input-file` or stdin
- Configurable `--batch-size` (default 5) and `--concurrency` (default 5)
- Applies default `--index` to items missing a header index
- Collects all responses into a single combined result array

Depends on #118