### PR TITLE
Fix: incorrect elastic config set suggestion in missing config error

### DIFF
--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -30,7 +30,7 @@ export function getTransport (): Transport {
   if (es == null) {
     const err = new Error(
       'missing_config: No Elasticsearch connection configured in the active context. ' +
-      'Run `elastic config set` to configure an Elasticsearch endpoint.'
+      'Add an elasticsearch block to your .elasticrc.yml config file.'
     )
     throw err
   }


### PR DESCRIPTION
Closes https://github.com/elastic/cli/issues/84

The error message when no Elasticsearch connection is configured tells the user to run elastic config set, but that command doesn't exist. Updated the suggestion to point users to the actual config file instead.

Before:

```
missing_config: No Elasticsearch connection configured in the active context.
Run `elastic config set` to configure an Elasticsearch endpoint.
```

After:

```
missing_config: No Elasticsearch connection configured in the active context.
Add an elasticsearch block to your .elasticrc.yml config file.
```