### PR TITLE
ci: add single gate job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,19 @@ jobs:
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert"]'
           add_label: "false"
+
+  ci:
+    name: CI Result
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - test-node
+      - license-header
+      - test-bun
+      - validate-pr-title
+    steps:
+      - run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more required jobs failed or were cancelled."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Adds a `ci` gate job that depends on all other CI jobs (`test-node`, `license-header`, `test-bun`, `validate-pr-title`)
- Enables using a single required status check (`CI Result`) in branch protection instead of listing each job individually
- Uses `if: always()` so the gate job runs even when upstream jobs are skipped (e.g. `validate-pr-title` on push events)

## Follow-up

After merging, update branch protection rules to require only `CI Result` and remove the individual job checks.

## Test plan

- [ ] Verify the `ci` job appears in the workflow run
- [ ] Verify it passes when all upstream jobs pass
- [ ] Verify it fails when any upstream job fails
