### PR TITLE
feat: add elastic docs commands (search, ask, chat, read)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "@elastic/transport": "^9.3.5",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
+        "marked": "^14.1.4",
+        "marked-terminal": "^7.3.0",
         "yaml": "^2.8.3",
         "zod": "^4.3.6"
       },
@@ -20,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
+        "@types/marked-terminal": "^6.1.1",
         "@types/node": "25.5.0",
         "eslint": "10.1.0",
         "license-checker": "25.0.1",
@@ -83,74 +86,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.27.7",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
@@ -163,363 +98,6 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=18"
@@ -798,6 +376,57 @@
         "@types/node": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@inquirer/core/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@inquirer/core/node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@inquirer/editor": {
@@ -2009,6 +1638,18 @@
         "@simple-git/args-pathspec": "^1.0.3"
       }
     },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -2045,6 +1686,13 @@
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
+    },
+    "node_modules/@types/cardinal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@types/cardinal/-/cardinal-2.1.1.tgz",
+      "integrity": "sha512-/xCVwg8lWvahHsV2wXZt4i64H1sdL+sN1Uoq7fAc8/FA6uYHjuIveDwPwvGUYp4VZiv85dVl6J/Bum3NDAOm8g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ejs": {
       "version": "3.1.5",
@@ -2096,6 +1744,45 @@
       "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
+      }
+    },
+    "node_modules/@types/marked-terminal": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/marked-terminal/-/marked-terminal-6.1.1.tgz",
+      "integrity": "sha512-DfoUqkmFDCED7eBY9vFUhJ9fW8oZcMAK5EwRDQ9drjTbpQa+DnBTQQCwWhTFVf4WsZ6yYcJTI8D91wxTWXRZZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/cardinal": "^2.1",
+        "@types/node": "*",
+        "chalk": "^5.3.0",
+        "marked": ">=6.0.0 <12"
+      }
+    },
+    "node_modules/@types/marked-terminal/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@types/marked-terminal/node_modules/marked": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-11.2.0.tgz",
+      "integrity": "sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/@types/node": {
@@ -2654,6 +2341,21 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2675,6 +2377,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -2956,6 +2664,15 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chardet": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
@@ -2987,6 +2704,97 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/cli-highlight/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cli-spinners": {
@@ -3037,6 +2845,17 @@
       "license": "ISC",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
       }
     },
     "node_modules/clone": {
@@ -3323,6 +3142,12 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
     },
+    "node_modules/emojilib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
+      "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
+      "license": "MIT"
+    },
     "node_modules/env-paths": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
@@ -3331,6 +3156,18 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3376,6 +3213,15 @@
         "@esbuild/win32-arm64": "0.27.7",
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -3925,6 +3771,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
@@ -4119,6 +3974,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/hosted-git-info": {
@@ -4814,6 +4678,63 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/marked": {
+      "version": "14.1.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.4.tgz",
+      "integrity": "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/marked-terminal": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-7.3.0.tgz",
+      "integrity": "sha512-t4rBvPsHc57uE/2nJOLmMbZCQ4tgAccAED3ngXQqW6g+TxA488JzJ+FK3lQkzBQOI1mRV/r/Kq+1ZlJ4D0owQw==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "ansi-regex": "^6.1.0",
+        "chalk": "^5.4.1",
+        "cli-highlight": "^2.1.11",
+        "cli-table3": "^0.6.5",
+        "node-emoji": "^2.2.0",
+        "supports-hyperlinks": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "marked": ">=1 <16"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/marked-terminal/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/mega-linter-runner": {
       "version": "9.4.0",
       "resolved": "https://registry.npmjs.org/mega-linter-runner/-/mega-linter-runner-9.4.0.tgz",
@@ -5346,6 +5267,17 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5361,6 +5293,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-emoji": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
+      "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.6.0",
+        "char-regex": "^1.0.2",
+        "emojilib": "^2.4.0",
+        "skin-tone": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/node-gyp": {
@@ -5712,6 +5659,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/once": {
@@ -6147,6 +6103,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -6629,6 +6606,15 @@
         "node": ">= 10"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -6856,6 +6842,18 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/skin-tone": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
+      "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
+      "license": "MIT",
+      "dependencies": {
+        "unicode-emoji-modifier-base": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/slash": {
       "version": "5.1.0",
@@ -7137,6 +7135,43 @@
         "node": ">=4"
       }
     },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-hyperlinks/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -7208,6 +7243,27 @@
       },
       "funding": {
         "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/tinyglobby": {
@@ -7393,6 +7449,15 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicode-emoji-modifier-base": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
+      "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/unicorn-magic": {
       "version": "0.4.0",
@@ -7697,10 +7762,9 @@
       }
     },
     "node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -7708,14 +7772,16 @@
         "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -7731,7 +7797,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -7744,7 +7809,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrappy": {
@@ -7784,6 +7848,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
@@ -7807,6 +7880,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/yeoman-environment": {

--- a/package.json
+++ b/package.json
@@ -42,11 +42,14 @@
     "@elastic/transport": "^9.3.5",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",
+    "marked": "^14.1.4",
+    "marked-terminal": "^7.3.0",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "10.0.1",
+    "@types/marked-terminal": "^6.1.1",
     "@types/node": "25.5.0",
     "eslint": "10.1.0",
     "license-checker": "25.0.1",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -27,6 +27,8 @@ program
 // silently propagate into the command handler.
 program.hook('preAction', async (thisCommand, actionCommand) => {
   if (actionCommand.name() === 'version') return
+  // docs commands use public elastic.co APIs — no config required
+  if (actionCommand.parent?.name() === 'docs') return
   const { configFile: configPath, useContext: contextName } = thisCommand.opts()
   const result = await loadConfig({
     ...(configPath != null && { configPath }),
@@ -77,6 +79,13 @@ if (firstArg === 'serverless') {
   program.addCommand(registerServerlessCommands())
 } else {
   program.addCommand(defineGroup({ name: 'serverless', description: 'Manage Elastic Serverless projects and resources' }))
+}
+
+if (firstArg === 'docs') {
+  const { registerDocsCommands } = await import('./docs/register.ts')
+  program.addCommand(registerDocsCommands())
+} else {
+  program.addCommand(defineGroup({ name: 'docs', description: 'Search, read, and ask questions about Elastic documentation' }))
 }
 
 // Load config early so --help can hide blocked commands. Skip for commands

--- a/src/docs/ask.ts
+++ b/src/docs/ask.ts
@@ -31,13 +31,14 @@ export function createAskCommand (deps: AskDeps = defaultDeps): OpaqueCommandHan
       if (question === '') return { error: { code: 'missing_input', message: 'question is required' } }
 
       const conversationId = newUuid()
-      const spinner = startSpinner(deps.stderr, 'Thinking…')
+      const interactive = process.stderr.isTTY === true && parsed.options['json'] !== true
+      const spinner = interactive ? startSpinner(deps.stderr, 'Thinking…') : undefined
 
       try {
         const gen = deps.docsAskStream(question, conversationId)
         await streamAnswer(gen, renderMarkdown, deps.stdout, spinner)
       } catch (err) {
-        spinner.stop()
+        spinner?.stop()
         return {
           error: {
             code: 'docs_error',

--- a/src/docs/ask.ts
+++ b/src/docs/ask.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { defineCommand } from '../factory.ts'
+import type { OpaqueCommandHandle, JsonValue, ParsedResult } from '../factory.ts'
+import { docsAskStream, newUuid, type AskStreamEvent } from './client.ts'
+import { startSpinner, streamAnswer } from './stream.ts'
+import { renderMarkdown } from './renderer.ts'
+
+export interface AskDeps {
+  docsAskStream: (message: string, conversationId: string) => AsyncGenerator<AskStreamEvent>
+  stdout: { write: (s: string) => boolean }
+  stderr: { write: (s: string) => boolean }
+}
+
+const defaultDeps: AskDeps = {
+  docsAskStream,
+  stdout: process.stdout,
+  stderr: process.stderr,
+}
+
+export function createAskCommand (deps: AskDeps = defaultDeps): OpaqueCommandHandle {
+  return defineCommand({
+    name: 'ask',
+    description: 'Ask a question about Elastic documentation using AI (single answer)',
+    positionalArg: { name: 'question', description: 'Question to ask', required: true },
+    handler: async (parsed: ParsedResult): Promise<JsonValue> => {
+      const question = (parsed.arg ?? '').trim()
+      if (question === '') return { error: { code: 'missing_input', message: 'question is required' } }
+
+      const conversationId = newUuid()
+      const spinner = startSpinner(deps.stderr, 'Thinking…')
+
+      try {
+        const gen = deps.docsAskStream(question, conversationId)
+        await streamAnswer(gen, renderMarkdown, deps.stdout, spinner)
+      } catch (err) {
+        spinner.stop()
+        return {
+          error: {
+            code: 'docs_error',
+            message: err instanceof Error ? err.message : String(err),
+          },
+        }
+      }
+
+      return null
+    },
+    formatOutput: () => '',
+  })
+}

--- a/src/docs/chat.ts
+++ b/src/docs/chat.ts
@@ -7,7 +7,7 @@ import { createInterface } from 'node:readline'
 import { defineCommand } from '../factory.ts'
 import type { OpaqueCommandHandle, JsonValue, ParsedResult } from '../factory.ts'
 import { docsAskStream, newUuid, type AskStreamEvent } from './client.ts'
-import { startSpinner, streamAnswer } from './stream.ts'
+import { startSpinner, streamAnswer, type SpinnerHandle } from './stream.ts'
 import { renderMarkdown } from './renderer.ts'
 
 export interface ChatDeps {
@@ -29,16 +29,14 @@ async function askQuestion (
   question: string,
   conversationId: string,
   deps: ChatDeps,
-): Promise<boolean> {
-  const spinner = startSpinner(deps.stderr, 'Thinking…')
+  spinner?: SpinnerHandle,
+): Promise<void> {
   try {
     const gen = deps.docsAskStream(question, conversationId)
     await streamAnswer(gen, renderMarkdown, deps.stdout, spinner)
-    return true
   } catch (err) {
-    spinner.stop()
+    spinner?.stop()
     deps.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`)
-    return false
   }
 }
 
@@ -51,29 +49,34 @@ export function createChatCommand (deps: ChatDeps = defaultDeps): OpaqueCommandH
       const question = (parsed.arg ?? '').trim()
       if (question === '') return { error: { code: 'missing_input', message: 'question is required' } }
 
+      // Spinner and interactive loop are disabled when stderr is not a TTY (piped/redirected)
+      // or when --json is requested, so agents and scripts get clean output.
+      const interactive = process.stderr.isTTY === true && parsed.options['json'] !== true
+
       const conversationId = newUuid()
-      await askQuestion(question, conversationId, deps)
+      await askQuestion(question, conversationId, deps, interactive ? startSpinner(deps.stderr, 'Thinking…') : undefined)
 
-      // readline prompt goes to stderr; only stdin is injected for testability
-      const rl = createInterface({ input: deps.getStdin(), output: process.stderr, terminal: false })
+      if (interactive) {
+        const rl = createInterface({ input: deps.getStdin(), output: process.stderr, terminal: false })
 
-      await new Promise<void>((resolve) => {
-        const prompt = (): void => {
-          process.stderr.write('\nAsk a follow-up (or press Enter to quit): ')
-          rl.once('line', async (answer) => {
-            const followUp = answer.trim()
-            if (followUp === '') {
-              rl.close()
-              resolve()
-              return
-            }
-            await askQuestion(followUp, conversationId, deps)
-            prompt()
-          })
-        }
-        prompt()
-        rl.on('close', resolve)
-      })
+        await new Promise<void>((resolve) => {
+          const prompt = (): void => {
+            process.stderr.write('\nAsk a follow-up (or press Enter to quit): ')
+            rl.once('line', async (answer) => {
+              const followUp = answer.trim()
+              if (followUp === '') {
+                rl.close()
+                resolve()
+                return
+              }
+              await askQuestion(followUp, conversationId, deps, startSpinner(deps.stderr, 'Thinking…'))
+              prompt()
+            })
+          }
+          prompt()
+          rl.on('close', resolve)
+        })
+      }
 
       return null
     },

--- a/src/docs/chat.ts
+++ b/src/docs/chat.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createInterface } from 'node:readline'
+import { defineCommand } from '../factory.ts'
+import type { OpaqueCommandHandle, JsonValue, ParsedResult } from '../factory.ts'
+import { docsAskStream, newUuid, type AskStreamEvent } from './client.ts'
+import { startSpinner, streamAnswer } from './stream.ts'
+import { renderMarkdown } from './renderer.ts'
+
+export interface ChatDeps {
+  docsAskStream: (message: string, conversationId: string) => AsyncGenerator<AskStreamEvent>
+  stdout: { write: (s: string) => boolean }
+  stderr: { write: (s: string) => boolean }
+  /** Injected for testing; defaults to process.stdin */
+  getStdin: () => NodeJS.ReadableStream
+}
+
+const defaultDeps: ChatDeps = {
+  docsAskStream,
+  stdout: process.stdout,
+  stderr: process.stderr,
+  getStdin: () => process.stdin,
+}
+
+async function askQuestion (
+  question: string,
+  conversationId: string,
+  deps: ChatDeps,
+): Promise<boolean> {
+  const spinner = startSpinner(deps.stderr, 'Thinking…')
+  try {
+    const gen = deps.docsAskStream(question, conversationId)
+    await streamAnswer(gen, renderMarkdown, deps.stdout, spinner)
+    return true
+  } catch (err) {
+    spinner.stop()
+    deps.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`)
+    return false
+  }
+}
+
+export function createChatCommand (deps: ChatDeps = defaultDeps): OpaqueCommandHandle {
+  return defineCommand({
+    name: 'chat',
+    description: 'Ask a question about Elastic documentation using AI, with follow-up conversation',
+    positionalArg: { name: 'question', description: 'Opening question', required: true },
+    handler: async (parsed: ParsedResult): Promise<JsonValue> => {
+      const question = (parsed.arg ?? '').trim()
+      if (question === '') return { error: { code: 'missing_input', message: 'question is required' } }
+
+      const conversationId = newUuid()
+      await askQuestion(question, conversationId, deps)
+
+      // readline prompt goes to stderr; only stdin is injected for testability
+      const rl = createInterface({ input: deps.getStdin(), output: process.stderr, terminal: false })
+
+      await new Promise<void>((resolve) => {
+        const prompt = (): void => {
+          process.stderr.write('\nAsk a follow-up (or press Enter to quit): ')
+          rl.once('line', async (answer) => {
+            const followUp = answer.trim()
+            if (followUp === '') {
+              rl.close()
+              resolve()
+              return
+            }
+            await askQuestion(followUp, conversationId, deps)
+            prompt()
+          })
+        }
+        prompt()
+        rl.on('close', resolve)
+      })
+
+      return null
+    },
+    formatOutput: () => '',
+  })
+}

--- a/src/docs/client.ts
+++ b/src/docs/client.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const DOCS_BASE_URL = 'https://www.elastic.co/docs'
+const DOCS_COOKIE = 'feature_search_or_askai_enabled=true'
+
+export interface DocsProduct {
+  id: string
+  displayName: string
+}
+
+export interface DocsSearchResult {
+  type: string
+  url: string
+  title: string
+  description: string
+  aiShortSummary?: string
+  score: number
+  navigationSection: string
+  lastUpdated: string
+  product?: DocsProduct
+  relatedProducts?: DocsProduct[]
+}
+
+export interface DocsSearchResponse {
+  results: DocsSearchResult[]
+  totalResults: number
+  pageNumber: number
+  pageSize: number
+  pageCount: number
+}
+
+/**
+ * Search the Elastic documentation.
+ */
+export async function docsSearch (query: string, page = 1, size = 5): Promise<DocsSearchResponse> {
+  const params = new URLSearchParams({ q: query, page: String(page), size: String(size), sort: 'relevance' })
+  const url = `${DOCS_BASE_URL}/_api/v1/search?${params.toString()}`
+
+  const resp = await fetch(url, {
+    headers: { Accept: 'application/json', Cookie: DOCS_COOKIE }
+  })
+
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '')
+    throw new Error(`docs search error (${resp.status}): ${body.trim() || resp.statusText}`)
+  }
+
+  return resp.json() as Promise<DocsSearchResponse>
+}
+
+/**
+ * Fetch a docs page as raw markdown.
+ * Accepts a relative path (e.g. `/reference/elasticsearch`), a full elastic.co URL,
+ * or a free-text query (performs a search and reads the first result).
+ */
+export async function docsRead (path: string): Promise<string> {
+  // strip trailing .md if already present
+  path = path.replace(/\.md$/, '')
+
+  let url: string
+  if (path.startsWith('/docs')) {
+    url = `https://www.elastic.co${path}.md`
+  } else if (path.startsWith('/')) {
+    url = `${DOCS_BASE_URL}${path}.md`
+  } else {
+    url = `${DOCS_BASE_URL}/${path}.md`
+  }
+
+  const resp = await fetch(url)
+  if (!resp.ok) {
+    throw new Error(`docs read error (${resp.status}) for ${url}`)
+  }
+  return resp.text()
+}
+
+/**
+ * Resolve user input to a docs path suitable for `docsRead`.
+ * Accepts a full elastic.co URL, a /path, or a free-text query.
+ */
+export async function resolveDocsPath (input: string): Promise<string> {
+  if (input.startsWith('https://www.elastic.co/docs')) {
+    return input.replace('https://www.elastic.co', '')
+  }
+  if (input.startsWith('https://elastic.co/docs')) {
+    return input.replace('https://elastic.co', '')
+  }
+  if (input.startsWith('/')) {
+    return input
+  }
+  // free-text: search and return the first result's URL
+  const resp = await docsSearch(input, 1, 1)
+  if (resp.results.length === 0) {
+    throw new Error(`no docs found for "${input}"`)
+  }
+  return resp.results[0]!.url
+}
+
+/**
+ * Discriminated union emitted by {@link docsAskStream}.
+ * - `status` events carry a human-readable phase label for the spinner.
+ * - `chunk` events carry a fragment of the AI response text.
+ */
+export type AskStreamEvent =
+  | { kind: 'status'; message: string }
+  | { kind: 'chunk'; text: string }
+
+/**
+ * Stream an AI answer from the Elastic docs ask endpoint.
+ * Yields {@link AskStreamEvent} values: `status` events during the thinking
+ * phase and `chunk` events once text generation begins.
+ * Stops after the message_complete or conversation_end event.
+ * The caller is responsible for generating a unique conversationId.
+ */
+export async function* docsAskStream (message: string, conversationId: string): AsyncGenerator<AskStreamEvent> {
+  const resp = await fetch(`${DOCS_BASE_URL}/_api/v1/ask-ai/stream`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'text/event-stream',
+      Cookie: DOCS_COOKIE,
+    },
+    body: JSON.stringify({ message, conversationId }),
+  })
+
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => '')
+    throw new Error(`docs ask error (${resp.status}): ${body.trim() || resp.statusText}`)
+  }
+
+  if (resp.body == null) {
+    throw new Error('docs ask: response body is null')
+  }
+
+  const decoder = new TextDecoder()
+  let eventType = ''
+  let dataLines: string[] = []
+  // Buffer for incomplete lines: HTTP body chunks can split anywhere, including
+  // in the middle of a `data:` line. Without this, the two halves of a split
+  // line are each pushed to dataLines separately, making dataLines.join('\n')
+  // produce invalid JSON that silently drops the event and its content.
+  let lineBuf = ''
+
+  for await (const chunk of resp.body as unknown as AsyncIterable<Uint8Array>) {
+    lineBuf += decoder.decode(chunk, { stream: true })
+    const lines = lineBuf.split('\n')
+    lineBuf = lines.pop() ?? '' // keep the last (possibly incomplete) line for next chunk
+
+    for (const line of lines) {
+      if (line === '') {
+        // blank line = dispatch event
+        if (dataLines.length > 0) {
+          const data = dataLines.join('\n')
+          dataLines = []
+          const type = eventType
+          eventType = ''
+
+          try {
+            const payload = JSON.parse(data) as Record<string, unknown>
+            if (payload.type === 'search_tool_call' && typeof payload.searchQuery === 'string') {
+              yield { kind: 'status', message: `Searching: ${payload.searchQuery}…` }
+            } else if (payload.type === 'tool_result') {
+              yield { kind: 'status', message: 'Generating answer…' }
+            } else if (payload.type === 'message_chunk' && typeof payload.content === 'string') {
+              yield { kind: 'chunk', text: payload.content }
+            } else if (payload.type === 'message_complete' || payload.type === 'conversation_end' || type === 'done') {
+              return
+            }
+          } catch {
+            // ignore malformed JSON
+          }
+        }
+        continue
+      }
+
+      if (line.startsWith('event:')) {
+        eventType = line.slice('event:'.length).trim()
+      } else if (line.startsWith('data:')) {
+        dataLines.push(line.slice('data:'.length).trim())
+      }
+    }
+  }
+}
+
+/**
+ * Strip simple HTML tags (e.g. `<mark>`) from a string.
+ */
+export function stripHtmlTags (s: string): string {
+  return s.replace(/<[^>]*>/g, '')
+}
+
+/**
+ * Generate a UUID v4.
+ */
+export function newUuid (): string {
+  return crypto.randomUUID()
+}

--- a/src/docs/read.ts
+++ b/src/docs/read.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { defineCommand } from '../factory.ts'
+import type { OpaqueCommandHandle, JsonValue, ParsedResult } from '../factory.ts'
+import { docsRead, resolveDocsPath } from './client.ts'
+import { renderMarkdown } from './renderer.ts'
+
+export interface ReadDeps {
+  docsRead: typeof docsRead
+  resolveDocsPath: typeof resolveDocsPath
+  stdout: { write: (s: string) => boolean }
+}
+
+const defaultDeps: ReadDeps = {
+  docsRead,
+  resolveDocsPath,
+  stdout: process.stdout,
+}
+
+export function createReadCommand (deps: ReadDeps = defaultDeps): OpaqueCommandHandle {
+  return defineCommand({
+    name: 'read',
+    description: 'Read an Elastic documentation page',
+    positionalArg: { name: 'path', description: 'Docs path, full elastic.co URL, or search query', required: true },
+    options: [
+      { long: 'raw', type: 'boolean', description: 'Output unrendered markdown instead of formatted output' },
+    ],
+    handler: async (parsed: ParsedResult): Promise<JsonValue> => {
+      const input = (parsed.arg ?? '').trim()
+      if (input === '') return { error: { code: 'missing_input', message: 'path is required' } }
+
+      const raw = parsed.options['raw'] === true
+
+      try {
+        const path = await deps.resolveDocsPath(input)
+        const markdown = await deps.docsRead(path)
+
+        if (raw) {
+          deps.stdout.write(markdown)
+        } else {
+          const rendered = renderMarkdown(markdown) + '\n'
+          deps.stdout.write(rendered)
+        }
+      } catch (err) {
+        return {
+          error: {
+            code: 'docs_error',
+            message: err instanceof Error ? err.message : String(err),
+          },
+        }
+      }
+
+      return null
+    },
+    formatOutput: () => '',
+  })
+}

--- a/src/docs/read.ts
+++ b/src/docs/read.ts
@@ -38,12 +38,11 @@ export function createReadCommand (deps: ReadDeps = defaultDeps): OpaqueCommandH
         const path = await deps.resolveDocsPath(input)
         const markdown = await deps.docsRead(path)
 
-        if (raw) {
-          deps.stdout.write(markdown)
-        } else {
-          const rendered = renderMarkdown(markdown) + '\n'
-          deps.stdout.write(rendered)
+        if (parsed.options['json'] === true) {
+          return { markdown }
         }
+
+        deps.stdout.write(raw ? markdown : renderMarkdown(markdown) + '\n')
       } catch (err) {
         return {
           error: {

--- a/src/docs/register.ts
+++ b/src/docs/register.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { defineGroup } from '../factory.ts'
+import type { OpaqueCommandHandle } from '../factory.ts'
+import { createSearchCommand } from './search.ts'
+import { createAskCommand } from './ask.ts'
+import { createChatCommand } from './chat.ts'
+import { createReadCommand } from './read.ts'
+
+export function registerDocsCommands (): OpaqueCommandHandle {
+  return defineGroup(
+    { name: 'docs', description: 'Search, read, and ask questions about Elastic documentation' },
+    createSearchCommand(),
+    createAskCommand(),
+    createChatCommand(),
+    createReadCommand(),
+  )
+}

--- a/src/docs/renderer.ts
+++ b/src/docs/renderer.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { marked } from 'marked'
+import { markedTerminal } from 'marked-terminal'
+
+// Register the terminal renderer once at module load.
+// Use markedTerminal() (the extension factory) rather than new TerminalRenderer(),
+// so that each renderer method has access to the parser instance (r.parser = this.parser).
+//
+// Pass an empty cli-highlight theme as the second argument so that individual
+// syntax tokens (keywords, strings, identifiers) are not colored by cli-highlight.
+// Per-token ANSI coloring conflicts with many terminal themes, making keywords like
+// `using` or string delimiters invisible. Code blocks still render with 4-space
+// indentation via marked-terminal; they just won't have language-specific colors.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+marked.use(markedTerminal({}, { theme: {} }) as any)
+
+/**
+ * Parse `md` as markdown and render it for terminal output.
+ * Returns the rendered string with trailing whitespace trimmed.
+ */
+export function renderMarkdown (md: string): string {
+  return (marked.parse(md) as string).trimEnd()
+}

--- a/src/docs/search.ts
+++ b/src/docs/search.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { defineCommand } from '../factory.ts'
+import type { OpaqueCommandHandle, JsonValue, ParsedResult } from '../factory.ts'
+import { docsSearch, stripHtmlTags } from './client.ts'
+import { renderMarkdown } from './renderer.ts'
+
+function resultSummary (aiShortSummary: string | undefined, description: string): string {
+  return (aiShortSummary != null && aiShortSummary !== '') ? aiShortSummary : stripHtmlTags(description)
+}
+
+export interface SearchDeps {
+  docsSearch: typeof docsSearch
+  stderr: { write: (chunk: string) => boolean }
+}
+
+const defaultDeps: SearchDeps = { docsSearch, stderr: process.stderr }
+
+export function createSearchCommand (deps: SearchDeps = defaultDeps): OpaqueCommandHandle {
+  return defineCommand({
+    name: 'search',
+    description: 'Search Elastic documentation',
+    positionalArg: { name: 'query', description: 'Search terms', required: true },
+    options: [
+      { long: 'page', type: 'number', description: 'Page number', defaultValue: 1 },
+      { long: 'size', type: 'number', description: 'Results per page', defaultValue: 5 },
+    ],
+    handler: async (parsed: ParsedResult): Promise<JsonValue> => {
+      const query = parsed.arg ?? ''
+      const page = parsed.options['page'] as number
+      const size = parsed.options['size'] as number
+
+      try {
+        const resp = await deps.docsSearch(query, page, size)
+        // Return structured data for --json; formatOutput handles text rendering
+        return {
+          results: resp.results.map((r) => ({
+            title: stripHtmlTags(r.title),
+            url: `https://www.elastic.co${r.url}`,
+            description: resultSummary(r.aiShortSummary, r.description),
+            product: r.product?.displayName ?? null,
+          })),
+          total: resp.totalResults,
+          page: resp.pageNumber,
+          pageCount: resp.pageCount,
+        }
+      } catch (err) {
+        return {
+          error: {
+            code: 'docs_error',
+            message: err instanceof Error ? err.message : String(err),
+          },
+        }
+      }
+    },
+    formatOutput: (result: JsonValue): string => {
+      if (
+        typeof result === 'object' && result !== null && !Array.isArray(result) &&
+        'error' in result
+      ) {
+        return ''
+      }
+      const data = result as { results: Array<{ title: string; url: string; description: string; product: string | null }>; total: number; page: number; pageCount: number }
+
+      if (data.results.length === 0) {
+        return 'No results found.\n'
+      }
+
+      let md = ''
+      for (let i = 0; i < data.results.length; i++) {
+        const r = data.results[i]!
+        const summary = r.description.length > 250 ? r.description.slice(0, 250).trimEnd() + '…' : r.description
+        md += `# ${r.title}\n`
+        if (r.product != null && r.product !== '') md += `### ${r.product}\n`
+        md += `${r.url}\n\n`
+        md += `${summary}\n`
+        if (i < data.results.length - 1) md += '\n---\n\n'
+      }
+
+      deps.stderr.write(`Showing ${data.results.length} of ${data.total} results (page ${data.page} of ${data.pageCount})\n`)
+      return renderMarkdown(md) + '\n'
+    },
+  })
+}

--- a/src/docs/stream.ts
+++ b/src/docs/stream.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AskStreamEvent } from './client.ts'
+
+/**
+ * Split the first complete paragraph from `text`, where a paragraph boundary
+ * is a `\n\n` that is not inside a fenced code block (``` ... ```).
+ * Returns [paragraph, rest] if found, or null if no complete paragraph yet.
+ */
+export function splitCompleteParagraph (text: string): [string, string] | null {
+  let inFence = false
+  let i = 0
+  while (i < text.length) {
+    if (i + 2 < text.length && text[i] === '`' && text[i + 1] === '`' && text[i + 2] === '`') {
+      inFence = !inFence
+      i += 3
+      continue
+    }
+    if (!inFence && i + 1 < text.length && text[i] === '\n' && text[i + 1] === '\n') {
+      return [text.slice(0, i), text.slice(i + 2)]
+    }
+    i++
+  }
+  return null
+}
+
+export interface SpinnerHandle {
+  setPhase: (phase: string) => void
+  stop: () => void
+}
+
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+const REFERENCES_MARKER = '<!--REFERENCES'
+
+/** Start a spinner that writes to `err`. Returns a handle to change its phase and stop it. */
+export function startSpinner (err: { write: (s: string) => boolean }, initialPhase = 'Thinking…'): SpinnerHandle {
+  let phase = initialPhase
+  let frame = 0
+  const interval = setInterval(() => {
+    err.write(`\r\x1b[K${SPINNER_FRAMES[frame++ % SPINNER_FRAMES.length]} ${phase}`)
+  }, 80)
+
+  return {
+    setPhase: (p: string) => { phase = p },
+    stop: () => {
+      clearInterval(interval)
+      err.write('\r\x1b[K')
+    },
+  }
+}
+
+/**
+ * Strip any partial prefix of `<!--REFERENCES` from the end of `text`.
+ * Handles the case where the marker is split across SSE chunk boundaries.
+ */
+function stripPartialMarker (text: string): string {
+  for (let len = REFERENCES_MARKER.length - 1; len >= 1; len--) {
+    if (text.endsWith(REFERENCES_MARKER.slice(0, len))) {
+      return text.slice(0, text.length - len)
+    }
+  }
+  return text
+}
+
+/**
+ * Stream an AI answer to stdout, flushing complete paragraphs incrementally.
+ * The `<!--REFERENCES-->` block appended by the API is silently stripped —
+ * the AI's own inline references section already covers this content.
+ *
+ * @param gen      - async generator yielding {@link AskStreamEvent} values
+ * @param renderMd - markdown renderer applied to each flushed paragraph
+ * @param stdout   - writable for answer output
+ * @param spinner  - optional spinner; `status` events update its phase label
+ */
+export async function streamAnswer (
+  gen: AsyncGenerator<AskStreamEvent>,
+  renderMd: (md: string) => string,
+  stdout: { write: (s: string) => boolean },
+  spinner?: SpinnerHandle,
+): Promise<void> {
+  let buffer = ''
+  let spinnerStopped = false
+  let referencesStarted = false
+
+  function flushOutput (text: string): void {
+    if (!spinnerStopped) {
+      spinner?.stop()
+      spinnerStopped = true
+    }
+    stdout.write(text)
+  }
+
+  function tryFlushParagraphs (): void {
+    let remaining = buffer
+    let flushed = false
+    while (true) {
+      const split = splitCompleteParagraph(remaining)
+      if (split == null) break
+      const [para, rest] = split
+      const trimmed = para.trim()
+      if (trimmed !== '') flushOutput(renderMd(trimmed) + '\n\n')
+      remaining = rest
+      flushed = true
+    }
+    if (flushed) buffer = remaining
+  }
+
+  for await (const event of gen) {
+    if (event.kind === 'status') {
+      spinner?.setPhase(event.message)
+      continue
+    }
+    if (referencesStarted) continue
+
+    const combined = buffer + event.text
+    const markerIdx = combined.indexOf(REFERENCES_MARKER)
+    if (markerIdx >= 0) {
+      buffer = combined.slice(0, markerIdx).trimEnd()
+      referencesStarted = true
+    } else {
+      buffer = combined
+    }
+    tryFlushParagraphs()
+  }
+
+  const remaining = stripPartialMarker(buffer).trim()
+  if (remaining !== '') {
+    flushOutput(renderMd(remaining) + '\n')
+  } else if (!spinnerStopped) {
+    spinner?.stop()
+  }
+}

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -83,6 +83,8 @@ export interface ParsedResult<T = unknown> {
   config?: ResolvedConfig
   /** parsed JSON content when `input` is enabled and data is provided via --input-file or stdin */
   input?: T
+  /** value of the positional argument, if `positionalArg` was declared in the command config */
+  arg?: string
 }
 
 /**
@@ -110,8 +112,10 @@ export interface CommandConfig<T extends z.ZodType = z.ZodType> {
   name: string
   /** human-readable description shown in help text */
   description: string
-  /** option and flag definitions; all inputs are named options - positional arguments are not supported */
+  /** option and flag definitions */
   options?: OptionDefinition[]
+  /** optional single positional argument; appears in usage as `<name>` (required) or `[name]` (optional) */
+  positionalArg?: { name: string; description: string; required?: boolean }
   /**
    * invoked after successful parsing and type coercion.
    * errors thrown here propagate to the caller; the factory does not catch handler errors.
@@ -484,6 +488,13 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
   cmd.description(config.description)
   configureErrorOutput(cmd)
 
+  if (config.positionalArg != null) {
+    const placeholder = config.positionalArg.required !== false
+      ? `<${config.positionalArg.name}>`
+      : `[${config.positionalArg.name}]`
+    cmd.argument(placeholder, config.positionalArg.description)
+  }
+
   // EXTENSION POINT: output formatting (Principle II)
   // Future: inspect config for a `format?: 'text' | 'json'` field and configure
   // a global output serialiser here, before any option registration.
@@ -635,6 +646,10 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
       }
     }
 
+    const positionalValue = config.positionalArg != null
+      ? (cmd.processedArgs[0] as string | undefined)
+      : undefined
+
     const resolvedConfig = getResolvedConfig()
 
     // enforce command policy before any other work
@@ -659,7 +674,8 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
 
     const parsed: ParsedResult<z.infer<T>> = {
       options,
-      ...(resolvedConfig != null ? { config: resolvedConfig } : {})
+      ...(resolvedConfig != null ? { config: resolvedConfig } : {}),
+      ...(positionalValue !== undefined ? { arg: positionalValue } : {})
     }
     if (inputValue !== undefined) {
       assert(config.input instanceof z.ZodType, `command ${JSON.stringify(config.name)}: input must be a Zod schema`)

--- a/test/docs/client.test.ts
+++ b/test/docs/client.test.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { stripHtmlTags, newUuid } from '../../src/docs/client.ts'
+
+describe('docs client utilities', () => {
+  describe('stripHtmlTags', () => {
+    it('removes simple HTML tags', () => {
+      assert.equal(stripHtmlTags('<mark>highlighted</mark> text'), 'highlighted text')
+    })
+
+    it('removes multiple tags', () => {
+      assert.equal(stripHtmlTags('<b>bold</b> and <em>italic</em>'), 'bold and italic')
+    })
+
+    it('passes through plain text unchanged', () => {
+      assert.equal(stripHtmlTags('no tags here'), 'no tags here')
+    })
+
+    it('handles empty string', () => {
+      assert.equal(stripHtmlTags(''), '')
+    })
+  })
+
+  describe('newUuid', () => {
+    it('generates a UUID v4 formatted string', () => {
+      const uuid = newUuid()
+      assert.match(uuid, /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/)
+    })
+
+    it('generates unique values', () => {
+      const ids = new Set(Array.from({ length: 10 }, () => newUuid()))
+      assert.equal(ids.size, 10)
+    })
+  })
+})

--- a/test/docs/read.test.ts
+++ b/test/docs/read.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createReadCommand } from '../../src/docs/read.ts'
+
+describe('createReadCommand', () => {
+  it('creates a command named "read"', () => {
+    const cmd = createReadCommand()
+    assert.equal(cmd.name(), 'read')
+  })
+
+  it('has a positional argument named "path"', () => {
+    const cmd = createReadCommand()
+    const args = cmd.registeredArguments
+    assert.equal(args.length, 1)
+    assert.equal(args[0].name(), 'path')
+  })
+
+  it('has a --raw flag', () => {
+    const cmd = createReadCommand()
+    const optNames = cmd.options.map((o) => o.long)
+    assert.ok(optNames.includes('--raw'))
+  })
+
+  it('writes rendered markdown to stdout', async () => {
+    const written: string[] = []
+    const cmd = createReadCommand({
+      resolveDocsPath: async (input) => input,
+      docsRead: async () => '# Hello\n\nWorld',
+      stdout: { write: (s) => { written.push(s); return true } },
+    })
+
+    cmd.exitOverride()
+    await cmd.parseAsync(['/reference/test'], { from: 'user' })
+
+    assert.ok(written.join('').length > 0)
+  })
+
+  it('writes raw markdown when --raw is passed', async () => {
+    const written: string[] = []
+    const cmd = createReadCommand({
+      resolveDocsPath: async (input) => input,
+      docsRead: async () => '# Raw markdown\n\nContent here',
+      stdout: { write: (s) => { written.push(s); return true } },
+    })
+
+    cmd.exitOverride()
+    await cmd.parseAsync(['/reference/test', '--raw'], { from: 'user' })
+
+    assert.equal(written.join(''), '# Raw markdown\n\nContent here')
+  })
+
+  it('sets exitCode=1 when docsRead throws', async () => {
+    const cmd = createReadCommand({
+      resolveDocsPath: async (input) => input,
+      docsRead: async () => { throw new Error('not found') },
+      stdout: { write: () => true },
+    })
+
+    cmd.exitOverride()
+    cmd.configureOutput({ writeErr: () => {} })
+
+    await cmd.parseAsync(['/bad-path'], { from: 'user' })
+
+    assert.equal(process.exitCode, 1)
+    process.exitCode = 0 // reset
+  })
+})

--- a/test/docs/search.test.ts
+++ b/test/docs/search.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { createSearchCommand } from '../../src/docs/search.ts'
+import type { DocsSearchResponse } from '../../src/docs/client.ts'
+
+function makeResp (overrides: Partial<DocsSearchResponse> = {}): DocsSearchResponse {
+  return {
+    results: [
+      {
+        type: 'page',
+        url: '/reference/elasticsearch',
+        title: 'Elasticsearch',
+        description: 'The search engine',
+        score: 1,
+        navigationSection: 'Reference',
+        lastUpdated: '2024-01-01',
+        product: { id: 'es', displayName: 'Elasticsearch' },
+        relatedProducts: [],
+      },
+    ],
+    totalResults: 1,
+    pageNumber: 1,
+    pageSize: 5,
+    pageCount: 1,
+    ...overrides,
+  }
+}
+
+describe('createSearchCommand', () => {
+  it('creates a command named "search"', () => {
+    const cmd = createSearchCommand()
+    assert.equal(cmd.name(), 'search')
+  })
+
+  it('has a positional argument', () => {
+    const cmd = createSearchCommand()
+    const args = cmd.registeredArguments
+    assert.equal(args.length, 1)
+    assert.equal(args[0].name(), 'query')
+  })
+
+  it('has --page and --size options', () => {
+    const cmd = createSearchCommand()
+    const optNames = cmd.options.map((o) => o.long)
+    assert.ok(optNames.includes('--page'))
+    assert.ok(optNames.includes('--size'))
+  })
+
+  it('returns structured results from handler', async () => {
+    const stderrOutput: string[] = []
+    const cmd = createSearchCommand({
+      docsSearch: async () => makeResp(),
+      stderr: { write: (s) => { stderrOutput.push(s); return true } },
+    })
+
+    // Access the handler indirectly by invoking the command
+    const results: unknown[] = []
+    const parseResult = await new Promise<unknown>((resolve) => {
+      cmd.exitOverride()
+      cmd.configureOutput({ writeOut: (s) => results.push(s), writeErr: () => {} })
+      cmd.parseAsync(['elasticsearch'], { from: 'user' }).then(() => resolve(results)).catch(resolve)
+    })
+
+    // The command itself handles output, just verify no crash
+    assert.ok(parseResult !== undefined)
+  })
+
+  it('returns error object when docsSearch throws', async () => {
+    const stderrOutput: string[] = []
+    const cmd = createSearchCommand({
+      docsSearch: async () => { throw new Error('network error') },
+      stderr: { write: (s) => { stderrOutput.push(s); return true } },
+    })
+
+    cmd.exitOverride()
+    cmd.configureOutput({ writeErr: () => {} })
+
+    await cmd.parseAsync(['test-query'], { from: 'user' })
+
+    // Error is written to stderr by the factory; verify process.exitCode was set
+    assert.equal(process.exitCode, 1)
+    process.exitCode = 0 // reset
+  })
+})

--- a/test/docs/stream.test.ts
+++ b/test/docs/stream.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { splitCompleteParagraph, streamAnswer } from '../../src/docs/stream.ts'
+import type { AskStreamEvent } from '../../src/docs/client.ts'
+
+function chunks (...texts: string[]): AsyncGenerator<AskStreamEvent> {
+  return (async function* () {
+    for (const t of texts) yield { kind: 'chunk' as const, text: t }
+  })()
+}
+
+describe('splitCompleteParagraph', () => {
+  it('returns null when no double newline is present', () => {
+    assert.equal(splitCompleteParagraph('single paragraph text'), null)
+  })
+
+  it('splits on double newline', () => {
+    assert.deepEqual(splitCompleteParagraph('first paragraph\n\nsecond paragraph'), ['first paragraph', 'second paragraph'])
+  })
+
+  it('does not split inside a fenced code block', () => {
+    assert.equal(splitCompleteParagraph('```\nsome code\n\nmore code\n```'), null)
+  })
+
+  it('splits after a code block closes', () => {
+    const result = splitCompleteParagraph('```\ncode\n```\n\nnext paragraph')
+    assert.ok(result != null)
+    assert.equal(result[1], 'next paragraph')
+  })
+
+  it('does not split on \\n\\n inside a code block with preceding text', () => {
+    const text = 'intro\n\n```csharp\nusing X;\n\nvar y = 1;\n```\n\nafter'
+    const [para] = splitCompleteParagraph(text)!
+    assert.equal(para, 'intro')
+    const [code] = splitCompleteParagraph('```csharp\nusing X;\n\nvar y = 1;\n```\n\nafter')!
+    assert.ok(code.startsWith('```csharp'))
+    assert.ok(code.endsWith('```'))
+  })
+})
+
+describe('streamAnswer', () => {
+  it('renders complete paragraphs incrementally and flushes remainder', async () => {
+    const output: string[] = []
+    const stdout = { write: (s: string) => { output.push(s); return true } }
+
+    await streamAnswer(chunks('Hello world\n\n', 'Second paragraph'), (md) => md.trim(), stdout)
+
+    assert.equal(output.length, 2)
+    assert.equal(output[0], 'Hello world\n\n')
+    assert.equal(output[1], 'Second paragraph\n')
+  })
+
+  it('strips <!--REFERENCES block — does not render it', async () => {
+    const output: string[] = []
+    const stdout = { write: (s: string) => { output.push(s); return true } }
+
+    await streamAnswer(
+      chunks('Answer text\n\n<!--REFERENCES\n[{"url":"https://x.com","title":"X"}]\n-->'),
+      (md) => md.trim(), stdout
+    )
+
+    const joined = output.join('')
+    assert.ok(joined.includes('Answer text'))
+    assert.ok(!joined.includes('<!--'))
+    assert.ok(!joined.includes('"url"'))
+  })
+
+  it('handles <!--REFERENCES marker split across chunks', async () => {
+    async function* gen (): AsyncGenerator<AskStreamEvent> {
+      yield { kind: 'chunk', text: 'Answer\n\n<!--REFER' }
+      yield { kind: 'chunk', text: 'ENCES\n[{"url":"https://x.com","title":"X"}]\n-->' }
+    }
+
+    const output: string[] = []
+    const stdout = { write: (s: string) => { output.push(s); return true } }
+
+    await streamAnswer(gen(), (md) => md.trim(), stdout)
+
+    const joined = output.join('')
+    assert.ok(joined.includes('Answer'))
+    assert.ok(!joined.includes('<!--'))
+    assert.ok(!joined.includes('"url"'))
+  })
+
+  it('status events update the spinner phase without affecting output', async () => {
+    const phases: string[] = []
+    const spinner = { setPhase: (p: string) => { phases.push(p) }, stop: () => {} }
+    const output: string[] = []
+
+    async function* gen (): AsyncGenerator<AskStreamEvent> {
+      yield { kind: 'status', message: 'Searching: foo…' }
+      yield { kind: 'status', message: 'Generating answer…' }
+      yield { kind: 'chunk', text: 'The answer' }
+    }
+
+    await streamAnswer(gen(), (md) => md.trim(), { write: (s) => { output.push(s); return true } }, spinner)
+
+    assert.deepEqual(phases, ['Searching: foo…', 'Generating answer…'])
+    assert.ok(output.join('').includes('The answer'))
+  })
+
+  it('stops the spinner when output begins', async () => {
+    let stopped = false
+    const spinner = { setPhase: () => {}, stop: () => { stopped = true } }
+
+    await streamAnswer(chunks('Some content'), (md) => md, { write: () => true }, spinner)
+
+    assert.ok(stopped)
+  })
+
+  it('handles an empty stream without error', async () => {
+    const output: string[] = []
+    await streamAnswer((async function* () {})(), (md) => md, { write: (s) => { output.push(s); return true } })
+    assert.equal(output.length, 0)
+  })
+})

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -196,6 +196,60 @@ describe('defineCommand', () => {
     })
   })
 
+  describe('positionalArg', () => {
+    it('registers a required positional argument', () => {
+      const cmd = defineCommand({
+        name: 'search',
+        description: 'Search docs',
+        positionalArg: { name: 'query', description: 'Search query', required: true },
+        handler: () => ({}),
+      })
+      const args = cmd.registeredArguments
+      assert.equal(args.length, 1)
+      assert.equal(args[0].name(), 'query')
+      assert.ok(args[0].required)
+    })
+
+    it('registers an optional positional argument', () => {
+      const cmd = defineCommand({
+        name: 'read',
+        description: 'Read a page',
+        positionalArg: { name: 'path', description: 'Docs path', required: false },
+        handler: () => ({}),
+      })
+      const args = cmd.registeredArguments
+      assert.equal(args.length, 1)
+      assert.equal(args[0].required, false)
+    })
+
+    it('populates parsed.arg with the positional value', async () => {
+      const received: ParsedResult[] = []
+      const cmd = defineCommand({
+        name: 'search',
+        description: 'Search docs',
+        positionalArg: { name: 'query', description: 'Search query', required: true },
+        handler: (parsed) => { received.push(parsed); return {} },
+      })
+      cmd.exitOverride()
+      await cmd.parseAsync(['ingest pipelines'], { from: 'user' })
+      assert.equal(received.length, 1)
+      assert.equal(received[0].arg, 'ingest pipelines')
+    })
+
+    it('sets parsed.arg to undefined when no positionalArg is declared', async () => {
+      const received: ParsedResult[] = []
+      const cmd = defineCommand({
+        name: 'health',
+        description: 'Health check',
+        handler: (parsed) => { received.push(parsed); return {} },
+      })
+      cmd.exitOverride()
+      await cmd.parseAsync([], { from: 'user' })
+      assert.equal(received.length, 1)
+      assert.equal(received[0].arg, undefined)
+    })
+  })
+
   describe('boolean flag parsing', () => {
     function invoke(handle: OpaqueCommandHandle, argv: string[]): void {
       handle.exitOverride()


### PR DESCRIPTION
Reimplementation of #1 

Add four subcommands under `elastic docs` for interacting with the
Elastic documentation directly from the CLI. No Elasticsearch context or
API key is required — these commands use the public elastic.co docs APIs.

```
elastic docs [command]

Available Commands:
  search   Search Elastic documentation
  ask      Ask a question about Elastic documentation using AI
  chat     Ask with interactive follow-up conversation
  read     Read an Elastic documentation page
```

## `elastic docs search <query>`

Search results rendered as styled markdown — title, product, URL, and
AI summary. Defaults to 5 results.

```
elastic docs search "ingest pipelines"
elastic docs search "machine learning" --size 10
elastic docs search "ingest pipelines" --json
```

![docs-search](https://github.com/user-attachments/assets/73adc7ca-9896-4512-b6af-be9e326fd9d4)


## `elastic docs ask <question>`

Single-shot AI answer with live spinner phases (Thinking → Searching → Generating).
Paragraphs are rendered incrementally as they complete via paragraph-aware buffering.

```
elastic docs ask "What is Elasticsearch?"
```

![docs-ask](https://github.com/user-attachments/assets/6624c53a-478c-41a3-bae7-63896e18f965)


## `elastic docs chat <question>`

Same as `ask` but loops for follow-up questions; shares a `conversationId`
so the AI retains context across the conversation.

```
elastic docs chat "How do ingest pipelines work?"
```

![docs-chat](https://github.com/user-attachments/assets/46eae9b6-a929-44e9-b196-a328828464e2)


## `elastic docs read <path|url|query>`

Fetch any Elastic docs page rendered with colours and formatting.
Accepts a docs path, a full elastic.co URL, or a free-text query
(searches and reads the first result). Use `--raw` for unrendered markdown.

```
elastic docs read /reference/elasticsearch
elastic docs read "ingest pipelines"
elastic docs read https://www.elastic.co/docs/reference/elasticsearch --raw
```

![docs-read](https://github.com/user-attachments/assets/c098cff6-0854-4451-8f9b-e4a59ef59208)


## Implementation details

- **`src/docs/client.ts`** — `fetch`-based client for the search, read, and
  ask-ai SSE endpoints. SSE parsing uses a line buffer that persists across
  HTTP body chunks so split `data:` lines never produce malformed JSON and
  silently drop content.
- **`src/docs/stream.ts`** — paragraph-buffering streamer: accumulates chunks,
  only flushes at `` ` ``-fence-aware `\n\n` boundaries, strips `<!--REFERENCES-->`
  silently, surfaces real API phases (Searching / Generating answer) via the spinner.
- **`marked` + `marked-terminal`** for terminal markdown rendering. A blank
  `cli-highlight` theme prevents per-token syntax colours from conflicting
  with terminal themes.
- **`src/factory.ts`** — adds optional `positionalArg` to `CommandConfig` /
  `ParsedResult` so commands can declare a single positional argument.
  All four `docs` commands use this (`elastic docs search <query>`, etc.).
- Config loading is skipped in `preAction` for `docs` subcommands — no
  Elasticsearch credentials needed.
