### PR TITLE
refactor: deduplicate loadConfig by delegating to resolveContext

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -230,13 +230,11 @@ export async function loadConfig (options: LoadConfigOptions = {}): Promise<Load
     commands = commandsParsed.data
   }
 
-  // Step 6: build and return ResolvedConfig
-  const ctx = contextParsed.data
-  const resolved: ResolvedContext = {}
-  if (ctx.elasticsearch != null) resolved.elasticsearch = ctx.elasticsearch
-  if (ctx.kibana != null) resolved.kibana = ctx.kibana
-  if (ctx.cloud != null) resolved.cloud = ctx.cloud
-  const result: ResolvedConfig = { context: resolved }
-  if (commands != null) result.commands = commands
-  return { ok: true, value: result }
+  // Step 6: build and return ResolvedConfig (delegate to resolveContext)
+  const config: ConfigFile = {
+    current_context: resolvedContextName,
+    contexts: { [resolvedContextName]: contextParsed.data },
+    ...(commands != null && { commands }),
+  }
+  return { ok: true, value: resolveContext(config, resolvedContextName) }
 }


### PR DESCRIPTION
## Summary

Sorry @margaretjgu, I was trigger happy merging #148 before addressing your feedback. This follows up on your [review comment](https://github.com/elastic/cli/pull/148#discussion_r3081519875).

- `loadConfig` now delegates to `resolveContext` instead of duplicating the context-to-`ResolvedConfig` mapping
- Builds a minimal `ConfigFile` from the already-validated pieces and passes it through

## Test plan

- [x] All 49 existing loader tests pass with no changes
