### PR TITLE
fix: Render API errors as human-readable messages in text mode

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -11,7 +11,7 @@ import type { ResolvedConfig, CommandPolicy } from './config/types.ts'
 import { getResolvedConfig } from './config/store.ts'
 import { extractSchemaArgs, validateSchemaArgs } from './lib/schema-args.ts'
 import type { SchemaArgDefinition } from './lib/schema-args.ts'
-import { renderText } from './output.ts'
+import { renderText, formatHandlerError } from './output.ts'
 
 /** pre-built schema for coercing string → number, reused per option invocation */
 const numberSchema = z.coerce.number()
@@ -703,7 +703,7 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
       if (jsonFormat === true) {
         process.stderr.write(JSON.stringify(handlerResult) + '\n')
       } else {
-        process.stderr.write(renderText(handlerResult))
+        process.stderr.write(`Error: ${formatHandlerError(handlerResult)}\n`)
       }
       process.exitCode = 1
     } else if (jsonFormat === true) {

--- a/src/output.ts
+++ b/src/output.ts
@@ -83,3 +83,40 @@ export function renderText(value: JsonValue): string {
 
   return JSON.stringify(value, null, 2) + '\n'
 }
+
+/**
+ * Extracts a concise human-readable message from a handler error payload.
+ *
+ * Assumes `isHandlerError(value)` is `true`. Extraction rules (first match wins):
+ *
+ * - **`transport_error` with ES body** (`body.error.type` + `body.error.reason`):
+ *   `"index_not_found_exception: no such index [foo]"`
+ * - **`transport_error` with string body error** (`body.error` is a string):
+ *   that string
+ * - **`transport_error` with `status_code`** (no parseable body):
+ *   `"request failed with status 404"`
+ * - **Any error with `message`** (`missing_config`, `cloud_api_error`, generic):
+ *   that message
+ * - **Fallback**: `"unknown error (code: <code>)"`
+ */
+export function formatHandlerError (value: JsonValue): string {
+  const err = (value as Record<string, JsonValue>).error as Record<string, JsonValue>
+  const code = err.code as string
+
+  if (code === 'transport_error') {
+    const body = err.body
+    if (body !== null && typeof body === 'object' && !Array.isArray(body)) {
+      const nested = (body as Record<string, JsonValue>).error
+      if (nested !== null && typeof nested === 'object' && !Array.isArray(nested)) {
+        const t = (nested as Record<string, JsonValue>).type
+        const r = (nested as Record<string, JsonValue>).reason
+        if (typeof t === 'string' && typeof r === 'string') return `${t}: ${r}`
+      }
+      if (typeof nested === 'string') return nested
+    }
+    if (typeof err.status_code === 'number') return `request failed with status ${err.status_code}`
+  }
+
+  if (typeof err.message === 'string') return err.message
+  return `unknown error (code: ${code})`
+}

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -3295,7 +3295,7 @@ describe('error result detection', () => {
     assert.equal(exitCode, 1)
   })
 
-  it('error result in text mode goes to stderr with non-zero exit', async () => {
+  it('error result in text mode renders human-readable message to stderr', async () => {
     const cmd = defineCommand({
       name: 'fail',
       description: 'Fail',
@@ -3303,8 +3303,25 @@ describe('error result detection', () => {
     })
     const { stdout, stderr, exitCode } = await invokeCapturingStreams(cmd, [], [])
     assert.equal(stdout, '', 'stdout should be empty for error results')
-    assert.ok(stderr.length > 0, 'stderr should contain error output')
-    assert.match(stderr, /missing_config/)
+    assert.equal(stderr, 'Error: No ES configured\n')
+    assert.equal(exitCode, 1)
+  })
+
+  it('text mode extracts type and reason from transport_error with ES body', async () => {
+    const cmd = defineCommand({
+      name: 'fail',
+      description: 'Fail',
+      handler: () => ({
+        error: {
+          code: 'transport_error',
+          status_code: 404,
+          body: { error: { type: 'index_not_found_exception', reason: 'no such index [foo]' } },
+        },
+      }),
+    })
+    const { stdout, stderr, exitCode } = await invokeCapturingStreams(cmd, [], [])
+    assert.equal(stdout, '')
+    assert.equal(stderr, 'Error: index_not_found_exception: no such index [foo]\n')
     assert.equal(exitCode, 1)
   })
 

--- a/test/output.test.ts
+++ b/test/output.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { renderText, renderTable } from '../src/output.ts'
+import { renderText, renderTable, formatHandlerError } from '../src/output.ts'
 
 describe('renderTable', () => {
   it('returns empty string for an empty array', () => {
@@ -145,5 +145,48 @@ describe('renderText', () => {
       const val = { status: 'ok', count: 3 }
       assert.equal(renderText(val), JSON.stringify(val, null, 2) + '\n')
     })
+  })
+})
+
+describe('formatHandlerError', () => {
+  it('extracts type and reason from transport_error with ES body', () => {
+    const val = {
+      error: {
+        code: 'transport_error',
+        status_code: 404,
+        body: { error: { type: 'index_not_found_exception', reason: 'no such index [foo]', root_cause: [] } }
+      }
+    }
+    assert.equal(formatHandlerError(val), 'index_not_found_exception: no such index [foo]')
+  })
+
+  it('returns string body.error when body.error is a string', () => {
+    const val = { error: { code: 'transport_error', status_code: 500, body: { error: 'internal failure' } } }
+    assert.equal(formatHandlerError(val), 'internal failure')
+  })
+
+  it('falls back to status_code when body has no parseable error', () => {
+    const val = { error: { code: 'transport_error', status_code: 503, body: { ok: false } } }
+    assert.equal(formatHandlerError(val), 'request failed with status 503')
+  })
+
+  it('returns message for missing_config', () => {
+    const val = { error: { code: 'missing_config', message: 'No Elasticsearch connection configured' } }
+    assert.equal(formatHandlerError(val), 'No Elasticsearch connection configured')
+  })
+
+  it('returns message for cloud_api_error', () => {
+    const val = { error: { code: 'cloud_api_error', message: 'Cloud API error 404: not found' } }
+    assert.equal(formatHandlerError(val), 'Cloud API error 404: not found')
+  })
+
+  it('returns message for transport_error without body', () => {
+    const val = { error: { code: 'transport_error', message: 'Connection refused' } }
+    assert.equal(formatHandlerError(val), 'Connection refused')
+  })
+
+  it('returns fallback for unknown code without message', () => {
+    const val = { error: { code: 'weird_error' } }
+    assert.equal(formatHandlerError(val), 'unknown error (code: weird_error)')
   })
 })


### PR DESCRIPTION
## Summary

- API errors in text mode are now rendered as concise `Error: <message>` lines to stderr with exit code 1, instead of pretty-printed JSON to stdout
- ES transport errors with a body extract the `type: reason` fields (e.g. `Error: index_not_found_exception: no such index [foo]`)
- JSON mode is unchanged — structured error payloads are still written to stdout for machine consumption

Closes #100