### PR TITLE
ci: add catalog-info.yaml to register Buildkite pipeline

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,5 +1,16 @@
 ---
-# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+# yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: elastic-cli
+spec:
+  type: library
+  owner: group:devtools-team
+  lifecycle: production
+
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/e57ee3bed7a6f73077a3f55a38e76e40ec87a7cf/rre.schema.json
 apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
@@ -22,6 +33,12 @@ spec:
       repository: elastic/cli
       pipeline_file: ".buildkite/pipeline.yml"
       teams:
-        devtools-team: {}
+        devtools-team:
+          access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
+      provider_settings:
+        build_pull_requests: true
+        build_branches: false
+        separate_pull_request_statuses: true
+      cancel_intermediate_builds: true

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://gist.githubusercontent.com/elasticmachine/988b80dae436cafea07d9a4a460a011d/raw/rre.schema.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: buildkite-pipeline-elastic-cli
+  description: Buildkite Pipeline for elastic-cli
+  links:
+    - title: Pipeline
+      url: https://buildkite.com/elastic/elastic-cli
+spec:
+  type: buildkite-pipeline
+  owner: group:devtools-team
+  system: buildkite
+  implementation:
+    apiVersion: buildkite.elastic.dev/v1
+    kind: Pipeline
+    metadata:
+      description: Elastic CLI
+      name: elastic-cli
+    spec:
+      repository: elastic/cli
+      pipeline_file: ".buildkite/pipeline.yml"
+      teams:
+        devtools-team: {}
+        everyone:
+          access_level: READ_ONLY


### PR DESCRIPTION
Part of https://github.com/elastic/agentic-interface-program/issues/80

## Summary

Adds a `catalog-info.yaml` declaring a Buildkite Pipeline RRE for `elastic/cli`. This is needed so Terrazzo can:

1. Create the `elastic-cli` Buildkite pipeline
2. Auto-generate Vault policies (`elastic-cli-ro` / `elastic-cli-rw`) for `secret/ci/elastic-cli/*`

I think without this file, Terrazzo doesn't know the repo has a pipeline, which is why the Vault policies were never created (the repo was created by hand, not through Backstage).

Modeled on `elastic/elasticsearch-java`'s `catalog-info.yaml`.

## Context

Confirmed that repos with a `catalog-info.yaml` (e.g. `elasticsearch-java`) have working Vault policies, while `elastic/cli` (missing this file) gets 403 on `vault list secret/ci/elastic-cli/`.

