### PR TITLE
fix: add shorthand es query

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -680,12 +680,28 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
     if (inputValue !== undefined) {
       assert(config.input instanceof z.ZodType, `command ${JSON.stringify(config.name)}: input must be a Zod schema`)
       // apply strict mode to reject unknown keys, unless the author explicitly used .passthrough()
-      const validationSchema = (
+      let validationSchema: z.ZodType = (
         config.input instanceof z.ZodObject &&
         (config.input.def as unknown as { catchall?: { type: string } }).catchall?.type !== 'unknown'
       )
         ? config.input.strict()
         : config.input
+
+      // Relax validation for object/array body fields. These contain user-provided
+      // JSON (e.g. --query, --mappings) whose full DSL (including shorthand forms)
+      // is too complex for client-side Zod schemas. The CLI already validates that the
+      // JSON is syntactically correct; Elasticsearch validates the semantics server-side.
+      const jsonBodyFields = schemaArgs.filter(
+        a => (a.type === 'object' || a.type === 'array') && a.foundIn === 'body'
+      )
+      if (jsonBodyFields.length > 0 && validationSchema instanceof z.ZodObject) {
+        const overrides: Record<string, z.ZodType> = {}
+        for (const f of jsonBodyFields) {
+          overrides[f.schemaKey] = z.any()
+        }
+        validationSchema = (validationSchema as z.ZodObject<z.ZodRawShape>).extend(overrides)
+      }
+
       const result = validationSchema.safeParse(inputValue)
       if (result.success) {
         parsed.input = result.data as z.infer<T>

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -1420,6 +1420,78 @@ describe('defineCommand', () => {
     })
   })
 
+  describe('relaxed validation for JSON body fields (#156)', () => {
+    let origIsTTY: boolean | undefined
+
+    beforeEach(() => {
+      origIsTTY = process.stdin.isTTY
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true, writable: true })
+    })
+    afterEach(() => {
+      Object.defineProperty(process.stdin, 'isTTY', { value: origIsTTY, configurable: true, writable: true })
+    })
+
+    it('accepts object-typed body fields that fail strict Zod validation', async () => {
+      const strictQuery = z.object({
+        term: z.object({ value: z.string() })
+      })
+      const schema = z.object({
+        index: z.string().optional().meta({ found_in: 'path' }),
+        query: strictQuery.optional().meta({ found_in: 'body' }),
+      })
+      const received: unknown[] = []
+      const cmd = defineCommand({
+        name: 'search',
+        description: 'Search',
+        input: schema,
+        handler: (parsed) => { received.push(parsed.input); return {} },
+      })
+      // Shorthand {"term":"canyon"} would fail strictQuery validation,
+      // but the factory should relax it and pass through
+      await invokeAsync(cmd, ['--query', '{"term":"canyon"}'])
+      assert.equal(received.length, 1)
+      const input = received[0] as Record<string, unknown>
+      assert.deepEqual(input.query, { term: 'canyon' })
+    })
+
+    it('still validates path and query params strictly', async () => {
+      const schema = z.object({
+        index: z.string().meta({ found_in: 'path' }),
+        size: z.number().optional().meta({ found_in: 'query' }),
+      })
+      const received: unknown[] = []
+      const cmd = defineCommand({
+        name: 'search',
+        description: 'Search',
+        input: schema,
+        handler: (parsed) => { received.push(parsed.input); return {} },
+      })
+      await invokeAsync(cmd, ['--index', 'logs', '--size', '5'])
+      const input = received[0] as Record<string, unknown>
+      assert.equal(input.index, 'logs')
+      assert.equal(input.size, 5)
+    })
+
+    it('relaxes array-typed body fields too', async () => {
+      const strictItem = z.object({ action: z.string() })
+      const schema = z.object({
+        operations: z.array(strictItem).optional().meta({ found_in: 'body' }),
+      })
+      const received: unknown[] = []
+      const cmd = defineCommand({
+        name: 'bulk',
+        description: 'Bulk',
+        input: schema,
+        handler: (parsed) => { received.push(parsed.input); return {} },
+      })
+      // Pass items that don't match strictItem schema
+      await invokeAsync(cmd, ['--operations', '[{"index":{}},{"name":"doc"}]'])
+      assert.equal(received.length, 1)
+      const input = received[0] as Record<string, unknown>
+      assert.deepEqual(input.operations, [{ index: {} }, { name: 'doc' }])
+    })
+  })
+
   describe('commands without input schema', () => {
     it('command with no input does not register --input-file option', () => {
       const cmd = defineCommand({


### PR DESCRIPTION
The CLI was rejecting valid Elasticsearch queries like {"term":{"category":"canyon"}} because it was trying to validate the JSON structure before sending it to ES. ES has many shorthand forms that the CLI's validation didn't have.

did a fix to stop deeply validating JSON body fields (e.g. --query, --mappings) on the client side. The CLI still checks that the input is valid JSON, but lets Elasticsearch handle the rest. If you pass bad JSON structure, Elasticsearch will return a clear error

closes https://github.com/elastic/cli/issues/156

testing of shorthand 
<img width="973" height="718" alt="image" src="https://github.com/user-attachments/assets/f1e5d736-127c-4ac7-928e-bf3826b0d41e" />
