### PR TITLE
chore: fix eslint linter errors

### DIFF
--- a/codegen/functional/index.ts
+++ b/codegen/functional/index.ts
@@ -4,7 +4,7 @@
  */
 
 import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'node:fs'
-import { join, relative, dirname, basename } from 'node:path'
+import { join, relative, dirname } from 'node:path'
 import { parseArgs } from 'node:util'
 import { allApis } from '../../src/es/apis.ts'
 import { parseTestFile, isServerless } from './parser.ts'

--- a/test/es/helpers/bulk-ingest.test.ts
+++ b/test/es/helpers/bulk-ingest.test.ts
@@ -11,7 +11,6 @@ import { tmpdir } from 'node:os'
 import type { Transport, TransportRequestParams, TransportRequestOptions } from '@elastic/transport'
 import { createBulkIngestCommand } from '../../../src/es/helpers/bulk-ingest.ts'
 import type { BulkIngestDeps } from '../../../src/es/helpers/bulk-ingest.ts'
-import { _testSetStdinReader } from '../../../src/factory.ts'
 import { Command } from 'commander'
 
 /** Creates a mock transport that records requests and returns configurable responses. */

--- a/test/es/helpers/scroll-search.test.ts
+++ b/test/es/helpers/scroll-search.test.ts
@@ -128,7 +128,7 @@ describe('scroll-search command', () => {
       {}
     ])
 
-    const { result } = await runCommand(
+    await runCommand(
       ['--index', 'test-idx', '--query', '{}', '--json'],
       makeDeps(transport, output)
     )

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -3298,7 +3298,7 @@ async function invokeUnderRoot(cmd: OpaqueCommandHandle, rootArgv: string[], cmd
 async function captureStreams(fn: () => Promise<void>): Promise<{ stdout: string, stderr: string, exitCode: number }> {
   let stdout = ''
   let stderr = ''
-  let exitCode = 0
+  let exitCode: number
   const origOut = process.stdout.write.bind(process.stdout)
   const origErr = process.stderr.write.bind(process.stderr)
   const origExitCode = process.exitCode


### PR DESCRIPTION
## Summary
- Remove unused `basename` import in `codegen/functional/index.ts`
- Remove unused `_testSetStdinReader` import in `test/es/helpers/bulk-ingest.test.ts`
- Drop unused `result` destructuring in `test/es/helpers/scroll-search.test.ts`
- Fix useless assignment of `exitCode` in `test/factory.test.ts`

## Test plan
- [x] MegaLinter pre-commit hook passes
