### PR TITLE
ci: bootstrap nvm via Buildkite pre-command hook

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Buildkite repository pre-command hook.
+# Runs automatically on the agent before every step's command.
+# Bootstraps nvm and the requested Node.js version when NODE_VERSION is set.
+
+set -euo pipefail
+
+if [ -z "${NODE_VERSION:-}" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+echo "--- Setting up Node.js ${NODE_VERSION}"
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+  echo "nvm not found, installing"
+  curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+fi
+# shellcheck source=/dev/null
+. "$NVM_DIR/nvm.sh"
+nvm install "$NODE_VERSION"
+nvm use "$NODE_VERSION"

--- a/.buildkite/run-cloud-tests.sh
+++ b/.buildkite/run-cloud-tests.sh
@@ -7,13 +7,6 @@
 
 set -euo pipefail
 
-echo "--- Setting up Node.js ${NODE_VERSION}"
-export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-# shellcheck source=/dev/null
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-nvm install "$NODE_VERSION"
-nvm use "$NODE_VERSION"
-
 echo "--- Installing dependencies"
 npm ci
 

--- a/.buildkite/run-es-tests.sh
+++ b/.buildkite/run-es-tests.sh
@@ -27,6 +27,9 @@ npm ci
 echo "--- Building CLI"
 npm run build
 
+echo "--- Linking elastic binary onto PATH"
+npm link
+
 echo "--- Cloning elasticsearch-clients-tests"
 git clone --depth 1 "$TESTS_REPO"
 

--- a/.buildkite/run-es-tests.sh
+++ b/.buildkite/run-es-tests.sh
@@ -21,13 +21,6 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "--- Setting up Node.js ${NODE_VERSION}"
-export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
-# shellcheck source=/dev/null
-[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"
-nvm install "$NODE_VERSION"
-nvm use "$NODE_VERSION"
-
 echo "--- Installing dependencies"
 npm ci
 


### PR DESCRIPTION
## Summary
- Buildkite jobs fail with `./.buildkite/run-cloud-tests.sh: line 14: nvm: command not found` because the GCP agents don't ship nvm.
- Move Node.js bootstrap into a repository `pre-command` hook that installs nvm if missing, then sources it and runs `nvm install`/`nvm use` — the hook is Buildkite-native and runs automatically before every step.
- Hook no-ops when `NODE_VERSION` is unset, so it's safe for future non-Node steps. Both runner scripts are stripped of the duplicated setup block.

## Test plan
- [ ] Buildkite pipeline green on a push (both ES functional and Cloud smoke matrices across Node 20/22/24).
- [ ] Re-run a job on an agent that already has nvm cached — confirm no reinstall.
- [ ] Re-run a job on a fresh agent — confirm the `nvm not found, installing` path succeeds.
