### PR TITLE
fix(codegen): skip assertions that depend on an unmapped do-step

### DIFF
--- a/codegen/functional/generator.ts
+++ b/codegen/functional/generator.ts
@@ -140,11 +140,25 @@ function renderSteps (
   skippedActions: string[],
   indent: string
 ): void {
+  // Assertions and set-steps read $RESPONSE, which is written by the most
+  // recent successful `do`. If the last `do` was skipped (unmapped action,
+  // unsupported catch, etc.) $RESPONSE is stale or empty, so any assertion
+  // that follows would assert against the wrong data — skip those too
+  // until the next executed `do` resets the response.
+  let responseFromLastDo = false
   for (const step of steps) {
+    if (step.kind === 'do') {
+      responseFromLastDo = renderDo(step, actionMap, lines, skippedActions, indent)
+      continue
+    }
+    if (step.kind === 'skip') continue
+
+    if (!responseFromLastDo) {
+      lines.push(`${indent}# SKIPPED: ${step.kind} assertion follows skipped do-step`)
+      continue
+    }
+
     switch (step.kind) {
-      case 'do':
-        renderDo(step, actionMap, lines, skippedActions, indent)
-        break
       case 'set':
         renderSet(step, lines, indent)
         break
@@ -169,22 +183,26 @@ function renderSteps (
       case 'contains':
         renderContains(step, lines, indent)
         break
-      case 'skip':
-        break
     }
   }
 }
 
+/**
+ * Render a do-step. Returns true if an executable command was emitted and
+ * $RESPONSE will hold the result afterwards; false when the step was
+ * skipped (unsupported catch or unmapped action) and $RESPONSE is now
+ * stale/empty.
+ */
 function renderDo (
   step: DoStep,
   actionMap: Map<string, EsApiDefinition>,
   lines: string[],
   skippedActions: string[],
   indent: string
-): void {
+): boolean {
   if (step.catch != null) {
     lines.push(`${indent}# SKIPPED: catch not supported in MVP (catch: ${step.catch})`)
-    return
+    return false
   }
 
   if (step.headers != null) {
@@ -195,7 +213,7 @@ function renderDo (
   if (mapped == null) {
     skippedActions.push(step.action)
     lines.push(`${indent}# SKIPPED: action "${step.action}" not registered in CLI`)
-    return
+    return false
   }
 
   const cmd = buildCommand(mapped, step)
@@ -205,6 +223,7 @@ function renderDo (
   } else {
     lines.push(`${indent}RESPONSE=$(${cmd})`)
   }
+  return true
 }
 
 function buildCommand (mapped: MappedAction, step: DoStep): string {

--- a/codegen/functional/test/fixtures/skipped-do-then-assert.yml
+++ b/codegen/functional/test/fixtures/skipped-do-then-assert.yml
@@ -1,0 +1,15 @@
+---
+requires:
+  serverless: true
+  stack: true
+---
+'skipped do then assertion should not run':
+  - do:
+      unregistered.action: { x: 'y' }
+  - match: { acknowledged: true }
+  - is_true: some.field
+  - set: { _id: id }
+
+  - do:
+      indices.create: { index: 'realindex' }
+  - match: { acknowledged: true }

--- a/codegen/functional/test/generator.test.ts
+++ b/codegen/functional/test/generator.test.ts
@@ -173,6 +173,38 @@ describe('generateScript', () => {
     assert.equal(parsed.status, 0, `bash -n failed: ${parsed.stderr.toString()}`)
   })
 
+  it('skips assertions that follow an unmapped do-step', () => {
+    const content = readFileSync(join(fixturesDir, 'skipped-do-then-assert.yml'), 'utf-8')
+    const testFile = parseTestFile(content, 'skipped-do-then-assert.yml')
+    const result = generateScript(testFile, testDefs)
+
+    const matches = result.script.match(/assertion follows skipped do-step/g) ?? []
+    assert.ok(
+      matches.length >= 3,
+      `expected at least 3 skip-comments for match/is_true/set after unmapped do, got ${matches.length}`
+    )
+
+    // Assertions that follow a mapped do (indices.create) should still render.
+    assert.ok(
+      result.script.includes('FAIL: expected acknowledged = true'),
+      'assertion after a mapped do should still emit'
+    )
+  })
+
+  it('still emits assertions after a successful do resets the response', () => {
+    const content = readFileSync(join(fixturesDir, 'skipped-do-then-assert.yml'), 'utf-8')
+    const testFile = parseTestFile(content, 'skipped-do-then-assert.yml')
+    const result = generateScript(testFile, testDefs)
+
+    // Exactly one `match` should render as an actual assertion line — the
+    // one after indices.create. The earlier `match` after the unmapped do
+    // must not produce an executable comparison.
+    const emittedAssertions = result.script
+      .split('\n')
+      .filter((l) => l.includes('FAIL: expected acknowledged'))
+    assert.equal(emittedAssertions.length, 1)
+  })
+
   it('prints PASS on success', () => {
     const content = readFileSync(join(fixturesDir, 'get.yml'), 'utf-8')
     const testFile = parseTestFile(content, 'get.yml')


### PR DESCRIPTION
## Summary
- Fixes the `FAIL: expected queries = [object Object]` and `FAIL: expected acknowledged = true` failures in the ES functional matrix.
- Root cause: when a `do` step is skipped because the CLI action isn't registered (or its `catch` clause is unsupported), `$RESPONSE` is stale or empty — but the generator still rendered the downstream `match` / `is_true` / `set` / comparison steps, which then asserted against wrong data.
- `renderSteps` now tracks whether the most recent `do` produced a response. Assertions/`set` steps that follow a skipped `do` are emitted as skip-comments instead of real commands, until the next executed `do` resets the response. `renderDo` returns a boolean so the caller knows whether to trust `$RESPONSE`.

Closes #189.

## Scripts previously failing, now clean
- `test/functional/es/esql/30_queries.sh` — the lone `match` after the unmapped `esql.list_queries` is now commented out.
- `test/functional/es/ingest/10_basic.sh` — four orphan assertions are skipped; the real `ingest simulate` step and its `.docs` check still run.

## Stack
Based on [#190](https://github.com/elastic/cli/pull/190) which is based on [#187](https://github.com/elastic/cli/pull/187). Merge order: 187 → 190 → this.

## Test plan
- [ ] `npm run test:unit` green (two new tests: one asserts orphan assertions are skipped, one asserts assertions after a mapped `do` still render)
- [ ] Regenerate against ES 9.1.0 locally and confirm both target scripts no longer emit the spurious FAIL lines
- [ ] Buildkite ES matrix shows zero `expected queries = [object Object]` or `expected acknowledged = true` failures
