### PR TITLE
ci: add shellcheck to mega-linter (warn-only)

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -3,6 +3,7 @@ ENABLE_LINTERS:
   - YAML_YAMLLINT
   - ACTION_ACTIONLINT
   - DOCKERFILE_HADOLINT
+  - BASH_SHELLCHECK
   - COPYPASTE_JSCPD
   - REPOSITORY_GIT_DIFF
   - REPOSITORY_GITLEAKS
@@ -40,3 +41,6 @@ YAML_YAMLLINT_CONFIG_FILE: .yamllint.yml
 YAML_YAMLLINT_FILTER_REGEX_EXCLUDE: "(codegen/functional/test/fixtures/|node_modules/)"
 
 COPYPASTE_JSCPD_CONFIG_FILE: .jscpd.json
+
+# shellcheck: warn only until active script work stabilises
+BASH_SHELLCHECK_DISABLE_ERRORS: true


### PR DESCRIPTION
## Summary

- Adds `BASH_SHELLCHECK` to the `ENABLE_LINTERS` list in `.mega-linter.yml`
- Sets `BASH_SHELLCHECK_DISABLE_ERRORS: true` so findings are reported but don't fail CI

## Why

Shellcheck found ~30 issues across the `.buildkite/` and `.specify/scripts/bash/` shell scripts. Since those scripts are actively being worked on, this PR opts for warn-only to surface findings without causing merge conflicts or blocking in-flight work. The `DISABLE_ERRORS` flag can be removed once the script work lands.

## Reviewer notes

The only file changed is `.mega-linter.yml`. No shell scripts were modified.