### PR TITLE
refactor(cloud): unify cloud and serverless under single `cloud` namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,55 +224,69 @@ elastic es update --index my-index --id abc123
 
 Run `elastic es <command> --help` for all available options on any command.
 
-### `cloud` - Elastic Cloud (hosted)
+### `cloud` - Elastic Cloud
 
-Manage Elastic Cloud hosted deployments.
+Manage Elastic Cloud: Hosted deployments and Serverless projects.
 Requires a `cloud` service block in the active context.
 
-#### `cloud deployments`
+The tree has three kinds of children:
+
+- Cross-cutting namespaces as direct children of `cloud` (APIs that apply to
+  both Hosted and Serverless).
+- `cloud hosted …` for Hosted-Deployment APIs.
+- `cloud serverless …` for Serverless-Project APIs.
+
+#### Cross-cutting (account, auth, orgs, roles)
 
 ```bash
-elastic cloud deployments list-deployments
-elastic cloud deployments get-deployment --id <id>
-elastic cloud deployments shutdown-deployment --id <id>
-elastic cloud deployments create-deployment <<< '{"name":"my-deployment",...}'
+elastic cloud accounts get-current-account
+elastic cloud authentication get-api-keys
+elastic cloud organizations list-organizations
+elastic cloud organizations get-organization --organization-id <id>
+elastic cloud user-role-assignments add-role-assignments --user-id <id> <<< '{...}'
 ```
 
-Run `elastic cloud --help` for all available namespace groups (accounts,
-billing-costs-analysis, deployment-templates, extensions, organizations, etc.).
-
-### `serverless` - Elastic Serverless
-
-Manage Elastic Serverless projects and resources.
-Requires a `cloud` service block in the active context.
-
-#### `serverless es projects` - Elasticsearch projects
+#### `cloud hosted` - Hosted Deployments
 
 ```bash
-elastic serverless es projects list
-elastic serverless es projects create <<< '{"name":"demo","region_id":"aws-us-east-1"}'
-elastic serverless es projects create --wait <<< '{"name":"demo","region_id":"aws-us-east-1"}'
-elastic serverless es projects get --id <id>
-elastic serverless es projects delete --id <id>
-elastic serverless es projects get-status --id <id>
-elastic serverless es projects get-roles --id <id>
-elastic serverless es projects reset-credentials --id <id>
+elastic cloud hosted deployments list-deployments
+elastic cloud hosted deployments get-deployment --id <id>
+elastic cloud hosted deployments shutdown-deployment --id <id>
+elastic cloud hosted deployments create-deployment <<< '{"name":"my-deployment",...}'
+elastic cloud hosted deployment-templates list-deployment-templates
+elastic cloud hosted extensions list-extensions
+elastic cloud hosted stack get-version-stacks
 ```
 
-#### `serverless observability projects` / `serverless security projects`
+Run `elastic cloud hosted --help` for all available namespace groups
+(billing-costs-analysis, deployment-templates, deployments, deployments-traffic-filter,
+extensions, stack, trusted-environments).
 
-Same commands as `es projects` but for Observability and Security project types:
+#### `cloud serverless` - Serverless Projects
 
 ```bash
-elastic serverless observability projects list
-elastic serverless security projects create --wait <<< '{"name":"demo","region_id":"aws-us-east-1"}'
+elastic cloud serverless es projects list
+elastic cloud serverless es projects create <<< '{"name":"demo","region_id":"aws-us-east-1"}'
+elastic cloud serverless es projects create --wait <<< '{"name":"demo","region_id":"aws-us-east-1"}'
+elastic cloud serverless es projects get --id <id>
+elastic cloud serverless es projects delete --id <id>
+elastic cloud serverless es projects get-status --id <id>
+elastic cloud serverless es projects get-roles --id <id>
+elastic cloud serverless es projects reset-credentials --id <id>
 ```
 
-#### Other serverless resources
+Same commands are available under `observability` and `security`:
 
 ```bash
-elastic serverless regions list-regions
-elastic serverless traffic-filters list-traffic-filters
+elastic cloud serverless observability projects list
+elastic cloud serverless security projects create --wait <<< '{"name":"demo","region_id":"aws-us-east-1"}'
 ```
 
-Run `elastic serverless --help` for all available groups.
+Other serverless resources:
+
+```bash
+elastic cloud serverless regions list-regions
+elastic cloud serverless traffic-filters list-traffic-filters
+```
+
+Run `elastic cloud serverless --help` for all available groups.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,14 +71,7 @@ if (firstArg === 'cloud') {
   const { registerCloudCommands } = await import('./cloud/register.ts')
   program.addCommand(registerCloudCommands())
 } else {
-  program.addCommand(defineGroup({ name: 'cloud', description: 'Manage Elastic Cloud deployments' }))
-}
-
-if (firstArg === 'serverless') {
-  const { registerServerlessCommands } = await import('./cloud/register.ts')
-  program.addCommand(registerServerlessCommands())
-} else {
-  program.addCommand(defineGroup({ name: 'serverless', description: 'Manage Elastic Serverless projects and resources' }))
+  program.addCommand(defineGroup({ name: 'cloud', description: 'Manage Elastic Cloud (hosted deployments and serverless projects)' }))
 }
 
 if (firstArg === 'docs') {

--- a/src/cloud/register.ts
+++ b/src/cloud/register.ts
@@ -63,13 +63,39 @@ function queryParamToZod(q: CloudQueryParam): z.ZodType {
 /**
  * Maps project-type namespaces from codegen to short CLI group names.
  * E.g. `elasticsearch-projects` → `es`, used to build
- * `elastic serverless es projects <action>`.
+ * `elastic cloud serverless es projects <action>`.
  */
 const PROJECT_NAMESPACES: Record<string, string> = {
   'elasticsearch-projects': 'es',
   'observability-projects': 'observability',
   'security-projects': 'security',
 }
+
+/**
+ * Cross-cutting namespaces promoted to direct children of `cloud` because their APIs
+ * apply to both Hosted deployments and Serverless projects.
+ */
+const PROMOTED_NAMESPACES = new Set<string>([
+  'accounts',
+  'authentication',
+  'organizations',
+  'user-role-assignments',
+])
+
+/**
+ * Namespaces that belong under `cloud serverless`. Enumerated rather than derived
+ * from `allServerlessApis` so callers passing synthetic definitions to
+ * `registerCloudCommands` still partition deterministically.
+ */
+const SERVERLESS_NAMESPACES = new Set<string>([
+  'elasticsearch-projects',
+  'observability-projects',
+  'security-projects',
+  'regions',
+  'traffic-filters',
+  'linked-projects',
+  'linked-candidate-projects',
+])
 
 /**
  * Strips the project-type identifier from a codegen command name to produce
@@ -111,75 +137,77 @@ function checkDuplicates (defs: CloudApiDefinition[], namespace: string): void {
   }
 }
 
-/**
- * Registers Cloud Hosted (non-serverless) API commands under a top-level `cloud` group.
- *
- * For each definition:
- * 1. A unified flat Zod schema is built from `pathParams` + `queryParams` + optional `body`.
- * 2. `defineCommand` is called with that schema as `input`.
- * 3. Commands are grouped by namespace (e.g. `deployments`, `accounts`).
- *
- * @param definitions - flat array of API definitions; defaults to the hosted cloud registry
- * @returns an `OpaqueCommandHandle` for the top-level `cloud` group
- */
-export function registerCloudCommands(
-  definitions: CloudApiDefinition[] = allCloudApis,
-): OpaqueCommandHandle {
-  for (const def of definitions) {
-    validateCloudApiDefinition(def)
-  }
-
-  const byNamespace = groupByNamespace(definitions)
-  const namespaceHandles: OpaqueCommandHandle[] = []
-
-  for (const [namespace, defs] of byNamespace) {
-    checkDuplicates(defs, namespace)
-
-    const leafHandles = defs.map((def) => {
-      const schema = buildCommandSchema(def)
-      return defineCommand({
-        name: def.name,
-        description: def.description,
-        input: schema,
-        handler: createCloudHandler(def),
-      })
-    })
-
-    namespaceHandles.push(
-      defineGroup({ name: namespace, description: `Cloud ${namespace} commands` }, ...leafHandles)
-    )
-  }
-
-  return defineGroup({ name: 'cloud', description: 'Manage Elastic Cloud deployments' }, ...namespaceHandles)
+function buildFlatLeaf (def: CloudApiDefinition): OpaqueCommandHandle {
+  const schema = buildCommandSchema(def)
+  return defineCommand({
+    name: def.name,
+    description: def.description,
+    input: schema,
+    handler: createCloudHandler(def),
+  })
 }
 
-/**
- * Registers Serverless API commands under a top-level `serverless` group.
- *
- * Project namespaces (`elasticsearch-projects`, `observability-projects`,
- * `security-projects`) are restructured into a cleaner hierarchy:
- *
- *   elastic serverless es projects list
- *   elastic serverless observability projects create
- *   elastic serverless security projects get --id <id>
- *
- * Other serverless namespaces (regions, traffic-filters, etc.) are kept as
- * direct children of the `serverless` group with their original command names.
- *
- * @param definitions - flat array of API definitions; defaults to the serverless registry
- * @returns an `OpaqueCommandHandle` for the top-level `serverless` group
- */
-export function registerServerlessCommands(
-  definitions: CloudApiDefinition[] = allServerlessApis,
-): OpaqueCommandHandle {
-  for (const def of definitions) {
-    validateCloudApiDefinition(def)
+function buildFlatNamespaceGroups (
+  defsByNamespace: Map<string, CloudApiDefinition[]>,
+  descriptionPrefix: string,
+): OpaqueCommandHandle[] {
+  const handles: OpaqueCommandHandle[] = []
+  for (const [namespace, defs] of defsByNamespace) {
+    checkDuplicates(defs, namespace)
+    const leaves = defs.map(buildFlatLeaf)
+    handles.push(
+      defineGroup({ name: namespace, description: `${descriptionPrefix} ${namespace} commands` }, ...leaves),
+    )
   }
+  return handles
+}
 
+function buildServerlessProjectGroup (
+  namespace: string,
+  defs: CloudApiDefinition[],
+): OpaqueCommandHandle {
+  const typeShort = PROJECT_NAMESPACES[namespace]!
+  const typeLabel = namespace.replace(/-projects$/, '')
+
+  const leaves = defs.map((def) => {
+    const shortName = simplifyProjectCommandName(def.name, namespace)
+    const schema = buildCommandSchema(def)
+    const cmd = defineCommand({
+      name: shortName,
+      description: def.description,
+      input: schema,
+      handler: createCloudHandler(def),
+    })
+    if (isCreateProjectCommand(def.name)) {
+      (cmd as Command).option('--wait', 'Wait for the project to reach "initialized" phase before returning')
+    }
+    return cmd
+  })
+
+  const projectsGroup = defineGroup(
+    { name: 'projects', description: `Manage ${typeLabel} projects` },
+    ...leaves,
+  )
+  return defineGroup(
+    { name: typeShort, description: `Elastic Serverless ${typeLabel} commands` },
+    projectsGroup,
+  )
+}
+
+function buildHostedGroup (defs: CloudApiDefinition[]): OpaqueCommandHandle {
+  const byNamespace = groupByNamespace(defs)
+  const namespaceHandles = buildFlatNamespaceGroups(byNamespace, 'Cloud hosted')
+  return defineGroup(
+    { name: 'hosted', description: 'Manage Elastic Cloud Hosted deployments' },
+    ...namespaceHandles,
+  )
+}
+
+function buildServerlessGroup (defs: CloudApiDefinition[]): OpaqueCommandHandle {
   const projectDefs = new Map<string, CloudApiDefinition[]>()
   const otherDefs = new Map<string, CloudApiDefinition[]>()
 
-  for (const def of definitions) {
+  for (const def of defs) {
     const target = PROJECT_NAMESPACES[def.namespace] != null ? projectDefs : otherDefs
     let group = target.get(def.namespace)
     if (group == null) {
@@ -189,58 +217,82 @@ export function registerServerlessCommands(
     group.push(def)
   }
 
-  const topLevelHandles: OpaqueCommandHandle[] = []
-
-  for (const [namespace, defs] of projectDefs) {
-    const typeShort = PROJECT_NAMESPACES[namespace]!
-    const typeLabel = namespace.replace(/-projects$/, '')
-
-    const leafHandles = defs.map((def) => {
-      const shortName = simplifyProjectCommandName(def.name, namespace)
-      const schema = buildCommandSchema(def)
-      const cmd = defineCommand({
-        name: shortName,
-        description: def.description,
-        input: schema,
-        handler: createCloudHandler(def),
-      })
-      if (isCreateProjectCommand(def.name)) {
-        (cmd as Command).option('--wait', 'Wait for the project to reach "initialized" phase before returning')
-      }
-      return cmd
-    })
-
-    const projectsGroup = defineGroup(
-      { name: 'projects', description: `Manage ${typeLabel} projects` },
-      ...leafHandles,
-    )
-    const typeGroup = defineGroup(
-      { name: typeShort, description: `Elastic Serverless ${typeLabel} commands` },
-      projectsGroup,
-    )
-    topLevelHandles.push(typeGroup)
+  const children: OpaqueCommandHandle[] = []
+  for (const [namespace, nsDefs] of projectDefs) {
+    children.push(buildServerlessProjectGroup(namespace, nsDefs))
   }
-
-  for (const [namespace, defs] of otherDefs) {
-    checkDuplicates(defs, namespace)
-
-    const leafHandles = defs.map((def) => {
-      const schema = buildCommandSchema(def)
-      return defineCommand({
-        name: def.name,
-        description: def.description,
-        input: schema,
-        handler: createCloudHandler(def),
-      })
-    })
-
-    topLevelHandles.push(
-      defineGroup({ name: namespace, description: `Serverless ${namespace} commands` }, ...leafHandles)
-    )
-  }
+  children.push(...buildFlatNamespaceGroups(otherDefs, 'Serverless'))
 
   return defineGroup(
     { name: 'serverless', description: 'Manage Elastic Serverless projects and resources' },
-    ...topLevelHandles,
+    ...children,
+  )
+}
+
+interface PartitionedDefinitions {
+  promoted: Map<string, CloudApiDefinition[]>
+  hosted: CloudApiDefinition[]
+  serverless: CloudApiDefinition[]
+}
+
+function partitionDefinitions (definitions: CloudApiDefinition[]): PartitionedDefinitions {
+  const promoted = new Map<string, CloudApiDefinition[]>()
+  const hosted: CloudApiDefinition[] = []
+  const serverless: CloudApiDefinition[] = []
+
+  for (const def of definitions) {
+    if (PROMOTED_NAMESPACES.has(def.namespace)) {
+      let group = promoted.get(def.namespace)
+      if (group == null) {
+        group = []
+        promoted.set(def.namespace, group)
+      }
+      group.push(def)
+    } else if (SERVERLESS_NAMESPACES.has(def.namespace)) {
+      serverless.push(def)
+    } else {
+      hosted.push(def)
+    }
+  }
+
+  return { promoted, hosted, serverless }
+}
+
+/**
+ * Registers the unified Cloud command tree under a top-level `cloud` group.
+ *
+ * The tree has three kinds of children:
+ * - **Promoted cross-cutting namespaces** (`account`, `authentication`, `organizations`,
+ *   `user-role-assignments`) as direct children of `cloud`, since their APIs apply to
+ *   both Hosted and Serverless.
+ * - **`cloud hosted <namespace> <command>`** for Hosted-specific APIs (deployments,
+ *   deployment-templates, extensions, stack versions, etc.).
+ * - **`cloud serverless <...>`** for Serverless APIs. Project namespaces are
+ *   restructured into `serverless <type> projects <action>` (e.g.
+ *   `serverless es projects list`); other namespaces (regions, traffic-filters, …)
+ *   remain as flat groups with their codegen command names.
+ *
+ * @param definitions - flat array of API definitions; defaults to the full built-in
+ *   registry (hosted + serverless APIs combined).
+ * @returns an `OpaqueCommandHandle` for the top-level `cloud` group.
+ */
+export function registerCloudCommands(
+  definitions: CloudApiDefinition[] = [...allCloudApis, ...allServerlessApis],
+): OpaqueCommandHandle {
+  for (const def of definitions) {
+    validateCloudApiDefinition(def)
+  }
+
+  const { promoted, hosted, serverless } = partitionDefinitions(definitions)
+
+  const promotedGroups = buildFlatNamespaceGroups(promoted, 'Cloud')
+  const hostedGroup = buildHostedGroup(hosted)
+  const serverlessGroup = buildServerlessGroup(serverless)
+
+  return defineGroup(
+    { name: 'cloud', description: 'Manage Elastic Cloud (hosted deployments and serverless projects)' },
+    ...promotedGroups,
+    hostedGroup,
+    serverlessGroup,
   )
 }

--- a/test/cloud/register.test.ts
+++ b/test/cloud/register.test.ts
@@ -201,11 +201,16 @@ describe('registerCloudCommands', () => {
   describe('default command aliases', () => {
     it('no commands have aliases', () => {
       const group = registerCloudCommands()
-      const visit = (cmd: { name(): string, aliases(): string[], commands: any[] }) => {
+      interface CommandNode {
+        name(): string
+        aliases(): string[]
+        commands: CommandNode[]
+      }
+      const visit = (cmd: CommandNode): void => {
         assert.deepEqual(cmd.aliases(), [], `${cmd.name()} should have no alias`)
         for (const child of cmd.commands) visit(child)
       }
-      for (const child of group.commands) visit(child)
+      for (const child of group.commands as unknown as CommandNode[]) visit(child)
     })
   })
 })

--- a/test/cloud/register.test.ts
+++ b/test/cloud/register.test.ts
@@ -5,36 +5,171 @@
 
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
-import { registerCloudCommands, registerServerlessCommands, simplifyProjectCommandName } from '../../src/cloud/register.ts'
+import { registerCloudCommands, simplifyProjectCommandName } from '../../src/cloud/register.ts'
 import type { CloudApiDefinition } from '../../src/cloud/types.ts'
 
 describe('registerCloudCommands', () => {
-  describe('command tree structure', () => {
+  describe('top-level tree', () => {
     it('returns a top-level "cloud" group', () => {
       const group = registerCloudCommands([])
       assert.equal(group.name(), 'cloud')
     })
 
-    it('creates namespace subgroups from definitions', () => {
-      const defs: CloudApiDefinition[] = [
-        { name: 'list', namespace: 'deployments', description: 'List', method: 'GET', path: '/api/v1/deployments' },
-        { name: 'list', namespace: 'accounts', description: 'List', method: 'GET', path: '/api/v1/accounts' },
-      ]
-      const group = registerCloudCommands(defs)
+    it('has promoted, hosted, and serverless subgroups with default definitions', () => {
+      const group = registerCloudCommands()
       const subcommands = group.commands.map((c) => c.name())
-      assert.ok(subcommands.includes('deployments'))
-      assert.ok(subcommands.includes('accounts'))
+      assert.ok(subcommands.includes('accounts'), 'should have promoted "accounts"')
+      assert.ok(subcommands.includes('authentication'), 'should have promoted "authentication"')
+      assert.ok(subcommands.includes('organizations'), 'should have promoted "organizations"')
+      assert.ok(subcommands.includes('user-role-assignments'), 'should have promoted "user-role-assignments"')
+      assert.ok(subcommands.includes('hosted'), 'should have "hosted" subgroup')
+      assert.ok(subcommands.includes('serverless'), 'should have "serverless" subgroup')
     })
 
-    it('registers leaf commands under their namespace', () => {
+    it('does not expose hosted or serverless namespaces at the top level', () => {
+      const group = registerCloudCommands()
+      const subcommands = group.commands.map((c) => c.name())
+      assert.ok(!subcommands.includes('deployments'), 'deployments must live under hosted')
+      assert.ok(!subcommands.includes('extensions'), 'extensions must live under hosted')
+      assert.ok(!subcommands.includes('stack'), 'stack must live under hosted')
+      assert.ok(!subcommands.includes('regions'), 'regions must live under serverless')
+      assert.ok(!subcommands.includes('traffic-filters'), 'traffic-filters must live under serverless')
+      assert.ok(!subcommands.includes('elasticsearch-projects'), 'elasticsearch-projects must live under serverless es')
+    })
+  })
+
+  describe('promoted namespaces (cloud level)', () => {
+    it('accounts has its codegen command names preserved', () => {
+      const group = registerCloudCommands()
+      const accountsGroup = group.commands.find((c) => c.name() === 'accounts')!
+      const leafNames = accountsGroup.commands.map((c) => c.name())
+      assert.ok(leafNames.includes('get-current-account'))
+      assert.ok(leafNames.includes('update-current-account'))
+    })
+
+    it('organizations has its codegen command names preserved', () => {
+      const group = registerCloudCommands()
+      const orgsGroup = group.commands.find((c) => c.name() === 'organizations')!
+      const leafNames = orgsGroup.commands.map((c) => c.name())
+      assert.ok(leafNames.includes('list-organizations'))
+      assert.ok(leafNames.includes('get-organization'))
+    })
+
+    it('promoted synthetic defs are lifted out of hosted', () => {
       const defs: CloudApiDefinition[] = [
-        { name: 'list', namespace: 'deployments', description: 'List', method: 'GET', path: '/api/v1/deployments' },
-        { name: 'get', namespace: 'deployments', description: 'Get', method: 'GET', path: '/api/v1/deployments/{deployment_id}', pathParams: [{ name: 'deployment_id', description: 'ID', required: true }] },
+        { name: 'get-current-account', namespace: 'accounts', description: 'Get', method: 'GET', path: '/api/v1/account' },
+        { name: 'list-deployments', namespace: 'deployments', description: 'List', method: 'GET', path: '/api/v1/deployments' },
       ]
       const group = registerCloudCommands(defs)
-      const deploymentsGroup = group.commands.find((c) => c.name() === 'deployments')!
-      const leafNames = deploymentsGroup.commands.map((c) => c.name())
-      assert.deepEqual(leafNames, ['list', 'get'])
+      const top = group.commands.map((c) => c.name())
+      assert.ok(top.includes('accounts'))
+      assert.ok(top.includes('hosted'))
+      const hostedChildren = group.commands.find((c) => c.name() === 'hosted')!.commands.map((c) => c.name())
+      assert.ok(!hostedChildren.includes('accounts'), 'accounts must not appear under hosted')
+      assert.ok(hostedChildren.includes('deployments'))
+    })
+  })
+
+  describe('hosted subgroup', () => {
+    it('contains hosted-specific namespaces', () => {
+      const group = registerCloudCommands()
+      const hosted = group.commands.find((c) => c.name() === 'hosted')!
+      const namespaces = hosted.commands.map((c) => c.name())
+      assert.ok(namespaces.includes('deployments'))
+      assert.ok(namespaces.includes('deployment-templates'))
+      assert.ok(namespaces.includes('deployments-traffic-filter'))
+      assert.ok(namespaces.includes('extensions'))
+      assert.ok(namespaces.includes('stack'))
+      assert.ok(namespaces.includes('trusted-environments'))
+      assert.ok(namespaces.includes('billing-costs-analysis'))
+    })
+
+    it('does not contain promoted namespaces', () => {
+      const group = registerCloudCommands()
+      const hosted = group.commands.find((c) => c.name() === 'hosted')!
+      const namespaces = hosted.commands.map((c) => c.name())
+      assert.ok(!namespaces.includes('accounts'))
+      assert.ok(!namespaces.includes('authentication'))
+      assert.ok(!namespaces.includes('organizations'))
+      assert.ok(!namespaces.includes('user-role-assignments'))
+    })
+
+    it('deployments namespace has list, get, and shutdown commands', () => {
+      const group = registerCloudCommands()
+      const deployments = group.commands.find((c) => c.name() === 'hosted')!
+        .commands.find((c) => c.name() === 'deployments')!
+      const leafNames = deployments.commands.map((c) => c.name())
+      assert.ok(leafNames.includes('list-deployments'))
+      assert.ok(leafNames.includes('get-deployment'))
+      assert.ok(leafNames.includes('shutdown-deployment'))
+    })
+  })
+
+  describe('serverless subgroup', () => {
+    it('contains project-type groups and flat serverless namespaces', () => {
+      const group = registerCloudCommands()
+      const serverless = group.commands.find((c) => c.name() === 'serverless')!
+      const namespaces = serverless.commands.map((c) => c.name())
+      assert.ok(namespaces.includes('es'), 'should have "es" project-type group')
+      assert.ok(namespaces.includes('observability'))
+      assert.ok(namespaces.includes('security'))
+      assert.ok(namespaces.includes('regions'))
+      assert.ok(namespaces.includes('traffic-filters'))
+    })
+
+    it('es projects has CRUD commands with short names', () => {
+      const group = registerCloudCommands()
+      const projects = group.commands.find((c) => c.name() === 'serverless')!
+        .commands.find((c) => c.name() === 'es')!
+        .commands.find((c) => c.name() === 'projects')!
+      const leafNames = projects.commands.map((c) => c.name())
+      assert.ok(leafNames.includes('list'), 'should have list')
+      assert.ok(leafNames.includes('create'), 'should have create')
+      assert.ok(leafNames.includes('get'), 'should have get')
+      assert.ok(leafNames.includes('delete'), 'should have delete')
+      assert.ok(leafNames.includes('patch'), 'should have patch')
+      assert.ok(leafNames.includes('resume'), 'should have resume')
+      assert.ok(leafNames.includes('get-status'))
+      assert.ok(leafNames.includes('get-roles'))
+      assert.ok(leafNames.includes('reset-credentials'))
+    })
+
+    it('restructures synthetic project defs under serverless > <type> > projects', () => {
+      const defs: CloudApiDefinition[] = [
+        { name: 'list-observability-projects', namespace: 'observability-projects', description: 'List', method: 'GET', path: '/api/v1/serverless/projects/observability' },
+        { name: 'get-observability-project', namespace: 'observability-projects', description: 'Get', method: 'GET', path: '/api/v1/serverless/projects/observability/{id}', pathParams: [{ name: 'id', description: 'ID', required: true }] },
+      ]
+      const group = registerCloudCommands(defs)
+      const projects = group.commands.find((c) => c.name() === 'serverless')!
+        .commands.find((c) => c.name() === 'observability')!
+        .commands.find((c) => c.name() === 'projects')!
+      assert.deepEqual(projects.commands.map((c) => c.name()), ['list', 'get'])
+    })
+
+    it('keeps non-project serverless namespaces flat with codegen names', () => {
+      const defs: CloudApiDefinition[] = [
+        { name: 'list-regions', namespace: 'regions', description: 'List', method: 'GET', path: '/api/v1/serverless/regions' },
+        { name: 'get-region', namespace: 'regions', description: 'Get', method: 'GET', path: '/api/v1/serverless/regions/{id}', pathParams: [{ name: 'id', description: 'ID', required: true }] },
+      ]
+      const group = registerCloudCommands(defs)
+      const regions = group.commands.find((c) => c.name() === 'serverless')!
+        .commands.find((c) => c.name() === 'regions')!
+      assert.deepEqual(regions.commands.map((c) => c.name()), ['list-regions', 'get-region'])
+    })
+
+    it('adds --wait flag to create project commands only', () => {
+      const defs: CloudApiDefinition[] = [
+        { name: 'create-elasticsearch-project', namespace: 'elasticsearch-projects', description: 'Create', method: 'POST', path: '/api/v1/serverless/projects/elasticsearch' },
+        { name: 'list-elasticsearch-projects', namespace: 'elasticsearch-projects', description: 'List', method: 'GET', path: '/api/v1/serverless/projects/elasticsearch' },
+      ]
+      const group = registerCloudCommands(defs)
+      const projects = group.commands.find((c) => c.name() === 'serverless')!
+        .commands.find((c) => c.name() === 'es')!
+        .commands.find((c) => c.name() === 'projects')!
+      const createCmd = projects.commands.find((c) => c.name() === 'create')!
+      const listCmd = projects.commands.find((c) => c.name() === 'list')!
+      assert.ok(createCmd.options.map((o) => o.long).includes('--wait'))
+      assert.ok(!listCmd.options.map((o) => o.long).includes('--wait'))
     })
   })
 
@@ -46,162 +181,31 @@ describe('registerCloudCommands', () => {
       assert.throws(() => registerCloudCommands(defs), /invalid name/)
     })
 
-    it('throws on duplicate command names within a namespace', () => {
+    it('throws on duplicate command names within a hosted namespace', () => {
       const defs: CloudApiDefinition[] = [
         { name: 'list', namespace: 'deployments', description: 'List 1', method: 'GET', path: '/a' },
         { name: 'list', namespace: 'deployments', description: 'List 2', method: 'GET', path: '/b' },
       ]
       assert.throws(() => registerCloudCommands(defs), /duplicate/)
     })
+
+    it('throws on duplicate command names within a promoted namespace', () => {
+      const defs: CloudApiDefinition[] = [
+        { name: 'get-current-account', namespace: 'accounts', description: '1', method: 'GET', path: '/a' },
+        { name: 'get-current-account', namespace: 'accounts', description: '2', method: 'GET', path: '/b' },
+      ]
+      assert.throws(() => registerCloudCommands(defs), /duplicate/)
+    })
   })
 
-  describe('default API definitions (hosted cloud only)', () => {
-    it('includes hosted cloud namespaces', () => {
-      const group = registerCloudCommands()
-      const subcommands = group.commands.map((c) => c.name())
-      assert.ok(subcommands.includes('deployments'), 'should have deployments')
-      assert.ok(subcommands.includes('accounts'), 'should have accounts')
-      assert.ok(subcommands.includes('extensions'), 'should have extensions')
-    })
-
-    it('does not include serverless namespaces', () => {
-      const group = registerCloudCommands()
-      const subcommands = group.commands.map((c) => c.name())
-      assert.ok(!subcommands.includes('elasticsearch-projects'), 'should not have elasticsearch-projects')
-      assert.ok(!subcommands.includes('regions'), 'should not have regions')
-      assert.ok(!subcommands.includes('traffic-filters'), 'should not have traffic-filters')
-    })
-
-    it('deployments namespace has list, get, and shutdown commands', () => {
-      const group = registerCloudCommands()
-      const deploymentsGroup = group.commands.find((c) => c.name() === 'deployments')!
-      const leafNames = deploymentsGroup.commands.map((c) => c.name())
-      assert.ok(leafNames.includes('list-deployments'))
-      assert.ok(leafNames.includes('get-deployment'))
-      assert.ok(leafNames.includes('shutdown-deployment'))
-    })
-
-    it('accounts namespace has get and update commands', () => {
-      const group = registerCloudCommands()
-      const accountsGroup = group.commands.find((c) => c.name() === 'accounts')!
-      const leafNames = accountsGroup.commands.map((c) => c.name())
-      assert.ok(leafNames.includes('get-current-account'))
-      assert.ok(leafNames.includes('update-current-account'))
-    })
-
+  describe('default command aliases', () => {
     it('no commands have aliases', () => {
       const group = registerCloudCommands()
-      for (const ns of group.commands) {
-        for (const cmd of ns.commands) {
-          assert.deepEqual(cmd.aliases(), [], `${cmd.name()} should have no alias`)
-        }
+      const visit = (cmd: { name(): string, aliases(): string[], commands: any[] }) => {
+        assert.deepEqual(cmd.aliases(), [], `${cmd.name()} should have no alias`)
+        for (const child of cmd.commands) visit(child)
       }
-    })
-  })
-})
-
-describe('registerServerlessCommands', () => {
-  describe('command tree structure', () => {
-    it('returns a top-level "serverless" group', () => {
-      const group = registerServerlessCommands([])
-      assert.equal(group.name(), 'serverless')
-    })
-
-    it('restructures elasticsearch-projects under serverless > es > projects', () => {
-      const defs: CloudApiDefinition[] = [
-        { name: 'list-elasticsearch-projects', namespace: 'elasticsearch-projects', description: 'List', method: 'GET', path: '/api/v1/serverless/projects/elasticsearch' },
-        { name: 'create-elasticsearch-project', namespace: 'elasticsearch-projects', description: 'Create', method: 'POST', path: '/api/v1/serverless/projects/elasticsearch' },
-      ]
-      const group = registerServerlessCommands(defs)
-      const esGroup = group.commands.find((c) => c.name() === 'es')!
-      assert.ok(esGroup, 'should have "es" subgroup')
-      const projectsGroup = esGroup.commands.find((c) => c.name() === 'projects')!
-      assert.ok(projectsGroup, 'should have "projects" under "es"')
-      const leafNames = projectsGroup.commands.map((c) => c.name())
-      assert.deepEqual(leafNames, ['list', 'create'])
-    })
-
-    it('restructures observability-projects under serverless > observability > projects', () => {
-      const defs: CloudApiDefinition[] = [
-        { name: 'list-observability-projects', namespace: 'observability-projects', description: 'List', method: 'GET', path: '/api/v1/serverless/projects/observability' },
-        { name: 'get-observability-project', namespace: 'observability-projects', description: 'Get', method: 'GET', path: '/api/v1/serverless/projects/observability/{id}', pathParams: [{ name: 'id', description: 'ID', required: true }] },
-      ]
-      const group = registerServerlessCommands(defs)
-      const obsGroup = group.commands.find((c) => c.name() === 'observability')!
-      const projectsGroup = obsGroup.commands.find((c) => c.name() === 'projects')!
-      const leafNames = projectsGroup.commands.map((c) => c.name())
-      assert.deepEqual(leafNames, ['list', 'get'])
-    })
-
-    it('restructures security-projects under serverless > security > projects', () => {
-      const defs: CloudApiDefinition[] = [
-        { name: 'delete-security-project', namespace: 'security-projects', description: 'Delete', method: 'DELETE', path: '/api/v1/serverless/projects/security/{id}', pathParams: [{ name: 'id', description: 'ID', required: true }] },
-      ]
-      const group = registerServerlessCommands(defs)
-      const secGroup = group.commands.find((c) => c.name() === 'security')!
-      const projectsGroup = secGroup.commands.find((c) => c.name() === 'projects')!
-      const leafNames = projectsGroup.commands.map((c) => c.name())
-      assert.deepEqual(leafNames, ['delete'])
-    })
-
-    it('keeps non-project namespaces as direct children of serverless', () => {
-      const defs: CloudApiDefinition[] = [
-        { name: 'list-regions', namespace: 'regions', description: 'List', method: 'GET', path: '/api/v1/serverless/regions' },
-        { name: 'get-region', namespace: 'regions', description: 'Get', method: 'GET', path: '/api/v1/serverless/regions/{id}', pathParams: [{ name: 'id', description: 'ID', required: true }] },
-      ]
-      const group = registerServerlessCommands(defs)
-      const regionsGroup = group.commands.find((c) => c.name() === 'regions')!
-      assert.ok(regionsGroup, 'should have "regions" subgroup')
-      const leafNames = regionsGroup.commands.map((c) => c.name())
-      assert.deepEqual(leafNames, ['list-regions', 'get-region'])
-    })
-
-    it('adds --wait flag to create project commands', () => {
-      const defs: CloudApiDefinition[] = [
-        { name: 'create-elasticsearch-project', namespace: 'elasticsearch-projects', description: 'Create', method: 'POST', path: '/api/v1/serverless/projects/elasticsearch' },
-        { name: 'list-elasticsearch-projects', namespace: 'elasticsearch-projects', description: 'List', method: 'GET', path: '/api/v1/serverless/projects/elasticsearch' },
-      ]
-      const group = registerServerlessCommands(defs)
-      const projectsGroup = group.commands.find((c) => c.name() === 'es')!.commands.find((c) => c.name() === 'projects')!
-      const createCmd = projectsGroup.commands.find((c) => c.name() === 'create')!
-      const listCmd = projectsGroup.commands.find((c) => c.name() === 'list')!
-      const createOpts = createCmd.options.map((o) => o.long)
-      const listOpts = listCmd.options.map((o) => o.long)
-      assert.ok(createOpts.includes('--wait'), 'create should have --wait')
-      assert.ok(!listOpts.includes('--wait'), 'list should not have --wait')
-    })
-  })
-
-  describe('default API definitions', () => {
-    it('includes project types as restructured groups', () => {
-      const group = registerServerlessCommands()
-      const subcommands = group.commands.map((c) => c.name())
-      assert.ok(subcommands.includes('es'), 'should have "es" group')
-      assert.ok(subcommands.includes('observability'), 'should have "observability" group')
-      assert.ok(subcommands.includes('security'), 'should have "security" group')
-    })
-
-    it('includes non-project serverless namespaces', () => {
-      const group = registerServerlessCommands()
-      const subcommands = group.commands.map((c) => c.name())
-      assert.ok(subcommands.includes('regions'), 'should have regions')
-      assert.ok(subcommands.includes('traffic-filters'), 'should have traffic-filters')
-    })
-
-    it('es projects has CRUD commands with short names', () => {
-      const group = registerServerlessCommands()
-      const esGroup = group.commands.find((c) => c.name() === 'es')!
-      const projectsGroup = esGroup.commands.find((c) => c.name() === 'projects')!
-      const leafNames = projectsGroup.commands.map((c) => c.name())
-      assert.ok(leafNames.includes('list'), 'should have list')
-      assert.ok(leafNames.includes('create'), 'should have create')
-      assert.ok(leafNames.includes('get'), 'should have get')
-      assert.ok(leafNames.includes('delete'), 'should have delete')
-      assert.ok(leafNames.includes('patch'), 'should have patch')
-      assert.ok(leafNames.includes('resume'), 'should have resume')
-      assert.ok(leafNames.includes('get-status'), 'should have get-status')
-      assert.ok(leafNames.includes('get-roles'), 'should have get-roles')
-      assert.ok(leafNames.includes('reset-credentials'), 'should have reset-credentials')
+      for (const child of group.commands) visit(child)
     })
   })
 })

--- a/test/functional/cloud/smoke.sh
+++ b/test/functional/cloud/smoke.sh
@@ -121,11 +121,11 @@ fi
 
 echo ""
 
-# ── Cloud Hosted ─────────────────────────────────────────────────────
+# ── Cross-cutting ────────────────────────────────────────────────────
 
-echo "Cloud Hosted API:"
+echo "Cross-cutting API:"
 
-# accounts get-current-account
+# accounts get-current-account (promoted to cloud level)
 output=$(retry_with_backoff $CLI cloud accounts get-current-account --json 2>&1) || true
 if [ -n "$output" ]; then
   assert_exit_zero "accounts get-current-account" $CLI cloud accounts get-current-account --json
@@ -134,20 +134,26 @@ else
   fail "accounts get-current-account" "empty response"
 fi
 
-# deployments list-deployments
-output=$(retry_with_backoff $CLI cloud deployments list-deployments --json 2>&1) || true
+echo ""
+
+# ── Cloud Hosted ─────────────────────────────────────────────────────
+
+echo "Cloud Hosted API:"
+
+# hosted deployments list-deployments
+output=$(retry_with_backoff $CLI cloud hosted deployments list-deployments --json 2>&1) || true
 if [ -n "$output" ]; then
-  assert_exit_zero "deployments list-deployments" $CLI cloud deployments list-deployments --json
+  assert_exit_zero "hosted deployments list-deployments" $CLI cloud hosted deployments list-deployments --json
 else
-  fail "deployments list-deployments" "empty response"
+  fail "hosted deployments list-deployments" "empty response"
 fi
 
-# stack get-version-stacks
-output=$(retry_with_backoff $CLI cloud stack get-version-stacks --json 2>&1) || true
+# hosted stack get-version-stacks
+output=$(retry_with_backoff $CLI cloud hosted stack get-version-stacks --json 2>&1) || true
 if [ -n "$output" ]; then
-  assert_exit_zero "stack get-version-stacks" $CLI cloud stack get-version-stacks --json
+  assert_exit_zero "hosted stack get-version-stacks" $CLI cloud hosted stack get-version-stacks --json
 else
-  fail "stack get-version-stacks" "empty response"
+  fail "hosted stack get-version-stacks" "empty response"
 fi
 
 echo ""
@@ -156,18 +162,18 @@ echo ""
 
 echo "Serverless API:"
 
-# elasticsearch-projects list-elasticsearch-projects
-output=$(retry_with_backoff $CLI cloud elasticsearch-projects list-elasticsearch-projects --json 2>&1) || true
+# serverless es projects list
+output=$(retry_with_backoff $CLI cloud serverless es projects list --json 2>&1) || true
 if [ -n "$output" ]; then
-  assert_exit_zero "elasticsearch-projects list" $CLI cloud elasticsearch-projects list-elasticsearch-projects --json
+  assert_exit_zero "serverless es projects list" $CLI cloud serverless es projects list --json
 else
-  fail "elasticsearch-projects list" "empty response"
+  fail "serverless es projects list" "empty response"
 fi
 
-# regions list-regions
-output=$(retry_with_backoff $CLI cloud regions list-regions --json 2>&1) || true
+# serverless regions list-regions
+output=$(retry_with_backoff $CLI cloud serverless regions list-regions --json 2>&1) || true
 if [ -n "$output" ]; then
-  assert_exit_zero "regions list-regions" $CLI cloud regions list-regions --json
+  assert_exit_zero "serverless regions list-regions" $CLI cloud serverless regions list-regions --json
 else
-  fail "regions list-regions" "empty response"
+  fail "serverless regions list-regions" "empty response"
 fi


### PR DESCRIPTION
Closes #193. Partial revert of #131.

## Summary

Unifies `elastic cloud` and `elastic serverless` under a single top-level `cloud` namespace to match how customers actually think about the product (Elastic Cloud at `cloud.elastic.co`, with two offerings: Hosted Deployments and Serverless Projects).

**New tree:**

```
elastic cloud
├── accounts                       promoted — current-user account
├── authentication                 promoted — Cloud API keys
├── organizations                  promoted — org management
├── user-role-assignments          promoted — user role assignments
├── hosted
│   ├── deployments
│   ├── deployment-templates
│   ├── deployments-traffic-filter
│   ├── extensions
│   ├── stack                      stack versions
│   ├── trusted-environments
│   └── billing-costs-analysis
└── serverless
    ├── es/projects { list, create, get, delete, patch, resume, get-status, get-roles, reset-credentials }
    ├── observability/projects { … }
    ├── security/projects { … }
    ├── regions
    ├── traffic-filters
    ├── linked-projects
    └── linked-candidate-projects
```

## Design notes

- **Promoted to direct `cloud` children** because they apply to both Hosted and Serverless: `accounts` (current-user account), `authentication` (Cloud API keys), `organizations` (org/IdP/domain-claims/invitations), `user-role-assignments`.
- **Kept under `cloud hosted`**: `billing-costs-analysis` (today's endpoints are deployment-indexed), `trusted-environments` (ECE/ESS-only concept).
- **Codegen unchanged.** `src/cloud/apis/*.ts`, `src/cloud/apis.ts`, and `src/cloud/serverless-apis.ts` are untouched. The restructure happens at tree-assembly time in `src/cloud/register.ts`.
- **Clean break, no aliases.** Project is `0.1.0-alpha.1` and the misleading split landed recently in #131. Partitioning in `register.ts` uses two hardcoded namespace sets (`PROMOTED_NAMESPACES`, `SERVERLESS_NAMESPACES`) so synthetic-def tests partition deterministically.
- **`elastic es` → `elastic stack` rename is deferred** to a follow-up (orthogonal change, different codepath).

## Migration

| Before | After |
| --- | --- |
| `elastic serverless es projects list` | `elastic cloud serverless es projects list` |
| `elastic cloud deployments list-deployments` | `elastic cloud hosted deployments list-deployments` |
| `elastic cloud stack get-version-stacks` | `elastic cloud hosted stack get-version-stacks` |
| `elastic cloud accounts get-current-account` | unchanged (promoted) |
| `elastic cloud organizations list-organizations` | unchanged (promoted) |

## Files changed

- `src/cli.ts` — dropped the top-level `serverless` branch; updated `cloud` description.
- `src/cloud/register.ts` — single public `registerCloudCommands` that partitions defs into promoted / hosted / serverless and composes the tree. `registerServerlessCommands` removed from the public API.
- `test/cloud/register.test.ts` — rewritten for the unified tree; `simplifyProjectCommandName` unit tests retained.
- `README.md` — `cloud` and `serverless` sections collapsed into one `cloud` section.
- `test/functional/cloud/smoke.sh` — paths updated to new tree (the file was also out of sync with post-#131 paths).

## Test plan

- [x] `npx tsc --noEmit` passes.
- [x] `npm run test:unit` — 797/797 passing (24 register-specific tests cover top-level tree, promoted namespaces, hosted subgroup, serverless subgroup, synthetic-def partitioning, validation, duplicate detection, `--wait` on create-project, absence of aliases).
- [x] `npm run test:lint` clean.
- [x] `elastic cloud --help` lists `accounts`, `authentication`, `organizations`, `user-role-assignments`, `hosted`, `serverless` and nothing else.
- [x] `elastic cloud serverless es projects --help` shows short-name leaves (`list`, `create`, `get`, `delete`, `patch`, `resume`, `get-status`, `get-roles`, `reset-credentials`).
- [x] Top-level help no longer shows `serverless`.
- [ ] Functional smoke (`npm run test:functional:cloud`) against a real Cloud context — reviewer with creds to verify.
