### PR TITLE
refactor(stack): rename top-level `es` to `stack es`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Elastic CLI
 
-Interact with Elasticsearch, Elastic Serverless and Elastic Cloud APIs from the command line.
+Interact with the Elastic Stack and Elastic Cloud from the command line.
 
 ## Installation
 
@@ -169,15 +169,21 @@ elastic version
 elastic --json version
 ```
 
-### `es` - Elasticsearch API
+### `stack` - Elastic Stack
+
+Interact with Elastic Stack components. Today only `stack es` (Elasticsearch) is
+wired up; `stack kibana` and `stack fleet` are reserved for future work.
+
+```bash
+elastic stack --help
+elastic stack es --help
+```
+
+#### `stack es` - Elasticsearch API
 
 Run Elasticsearch API calls. Commands map directly to Elasticsearch API endpoints.
 
-```bash
-elastic es --help
-```
-
-All `es` subcommands support:
+All `stack es` subcommands support:
 
 | Option | Description |
 |---|---|
@@ -208,21 +214,21 @@ All `es` subcommands support:
 - `tasks` - task management
 - `transform` - transforms
 
-**Top-level `es` commands** (examples):
+**Top-level `stack es` commands** (examples):
 
 ```bash
-elastic es search --index my-index
-elastic es get --index my-index --id abc123
-elastic es index --index my-index --id abc123
-elastic es delete --index my-index --id abc123
-elastic es count --index my-index
-elastic es info
-elastic es bulk
-elastic es reindex
-elastic es update --index my-index --id abc123
+elastic stack es search --index my-index
+elastic stack es get --index my-index --id abc123
+elastic stack es index --index my-index --id abc123
+elastic stack es delete --index my-index --id abc123
+elastic stack es count --index my-index
+elastic stack es info
+elastic stack es bulk
+elastic stack es reindex
+elastic stack es update --index my-index --id abc123
 ```
 
-Run `elastic es <command> --help` for all available options on any command.
+Run `elastic stack es <command> --help` for all available options on any command.
 
 ### `cloud` - Elastic Cloud (hosted)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@elastic/cli",
   "version": "0.1.0-alpha.1",
-  "description": "Interact with Elasticsearch, Elastic Serverless and Elastic Cloud APIs from the command line.",
+  "description": "Interact with the Elastic Stack and Elastic Cloud from the command line.",
   "main": "dist/cli.js",
   "bin": {
     "elastic": "dist/cli.js"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ const program = new Command()
 
 program
   .name('elastic')
-  .description('Interface with Elasticsearch, Elastic Serverless and Elastic Cloud APIs from the command line.')
+  .description('Interface with the Elastic Stack and Elastic Cloud from the command line.')
   .option('--config-file <path>', 'path to a config file (default: ~/.elasticrc.yml)')
   .option('--use-context <name>', 'override the active context from the config file')
   .option('--json', 'output as JSON')
@@ -60,11 +60,14 @@ program.addCommand(versionCmd)
 const { operands } = program.parseOptions(process.argv.slice(2))
 const firstArg = operands[0]
 
-if (firstArg === 'es') {
+if (firstArg === 'stack') {
   const { registerEsCommands } = await import('./es/register.ts')
-  program.addCommand(registerEsCommands())
+  program.addCommand(defineGroup(
+    { name: 'stack', description: 'Interact with Elastic Stack components (Elasticsearch, Kibana, Fleet)' },
+    registerEsCommands()
+  ))
 } else {
-  program.addCommand(defineGroup({ name: 'es', description: 'Interact with the Elasticsearch API' }))
+  program.addCommand(defineGroup({ name: 'stack', description: 'Interact with Elastic Stack components (Elasticsearch, Kibana, Fleet)' }))
 }
 
 if (firstArg === 'cloud') {

--- a/src/es/register.ts
+++ b/src/es/register.ts
@@ -29,10 +29,11 @@ function buildLeafHandle (
 }
 
 /**
- * Registers all Elasticsearch API commands under a top-level `es` group.
+ * Registers all Elasticsearch API commands under an `es` group, intended to be
+ * nested under the top-level `stack` group by the CLI entrypoint.
  *
- * Definitions with a `namespace` are grouped into a sub-group (`elastic es <namespace> <name>`).
- * Definitions without a `namespace` are registered as direct leaves (`elastic es <name>`).
+ * Definitions with a `namespace` are grouped into a sub-group (`elastic stack es <namespace> <name>`).
+ * Definitions without a `namespace` are registered as direct leaves (`elastic stack es <name>`).
  *
  * For each definition:
  * 1. `def.input` is passed directly to `defineCommand` as the `input` schema, so the

--- a/src/es/types.ts
+++ b/src/es/types.ts
@@ -25,7 +25,7 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD'
  *
  * @example
  * ```ts
- * // namespaced: registers as `elastic es indices create`
+ * // namespaced: registers as `elastic stack es indices create`
  * const createDef: EsApiDefinition = {
  *   name: 'create',
  *   namespace: 'indices',
@@ -39,7 +39,7 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD'
  *   }),
  * }
  *
- * // namespace-less: registers as `elastic es search`
+ * // namespace-less: registers as `elastic stack es search`
  * const searchDef: EsApiDefinition = {
  *   name: 'search',
  *   description: 'Run a search',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -109,7 +109,7 @@ describe('elastic CLI -- preAction config error handling', () => {
   it('exits with error when no config file is found', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-noconfig-'))
     try {
-      const { code, stderr } = await runCli(['es', 'info'], { cwd: dir, env: { HOME: dir, XDG_CONFIG_HOME: dir } })
+      const { code, stderr } = await runCli(['stack', 'es', 'info'], { cwd: dir, env: { HOME: dir, XDG_CONFIG_HOME: dir } })
       assert.equal(code, 1, `expected exit code 1, got ${code}`)
       assert.ok(stderr.includes('Error:'), `expected stderr to contain "Error:", got: ${stderr}`)
       assert.ok(stderr.includes('No configuration file found'), `expected config error message, got: ${stderr}`)
@@ -122,7 +122,7 @@ describe('elastic CLI -- preAction config error handling', () => {
     const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-badconfig-'))
     try {
       const { code, stderr } = await runCli(
-        ['es', 'info', '--config-file', '/nonexistent/path.yml'],
+        ['stack', 'es', 'info', '--config-file', '/nonexistent/path.yml'],
         { cwd: dir, env: { HOME: dir, XDG_CONFIG_HOME: dir } }
       )
       assert.equal(code, 1, `expected exit code 1, got ${code}`)
@@ -141,6 +141,44 @@ describe('elastic CLI -- config-free commands', () => {
       assert.equal(code, 0, `expected exit code 0, got ${code}`)
       const parsed = JSON.parse(stdout)
       assert.ok('version' in parsed)
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+})
+
+describe('elastic CLI -- stack command tree', () => {
+  it('top-level help lists `stack` and not `es`', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-help-'))
+    try {
+      const { code, stdout } = await runCli(['--help'], { cwd: dir, env: { HOME: dir } })
+      assert.equal(code, 0, `expected exit code 0, got ${code}`)
+      assert.match(stdout, /^\s*stack\s/m, 'expected `stack` in top-level help')
+      assert.doesNotMatch(stdout, /^\s*es\s/m, '`es` must not appear as a top-level command')
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
+  it('`elastic stack --help` lists the `es` sub-group', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-stack-help-'))
+    try {
+      const { code, stdout } = await runCli(['stack', '--help'], { cwd: dir, env: { HOME: dir } })
+      assert.equal(code, 0, `expected exit code 0, got ${code}`)
+      assert.match(stdout, /^\s*es\s/m, 'expected `es` under stack')
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
+  it('`elastic stack es --help` lists namespace groups (indices, cluster, ml)', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-stack-es-help-'))
+    try {
+      const { code, stdout } = await runCli(['stack', 'es', '--help'], { cwd: dir, env: { HOME: dir } })
+      assert.equal(code, 0, `expected exit code 0, got ${code}`)
+      assert.match(stdout, /^\s*indices\s/m, 'expected `indices` group')
+      assert.match(stdout, /^\s*cluster\s/m, 'expected `cluster` group')
+      assert.match(stdout, /^\s*ml\s/m, 'expected `ml` group')
     } finally {
       await rm(dir, { recursive: true })
     }


### PR DESCRIPTION
Closes part of #193. Sibling to #199.

## Summary

Renames the top-level `elastic es` command to `elastic stack`, with the existing Elasticsearch tree nested underneath as `elastic stack es …`. This aligns the CLI with how the product is organized around the Elastic Stack (Elasticsearch, Kibana, Fleet) and leaves a clean scaffold for future `stack kibana` and `stack fleet` groups.

## New tree

```
elastic stack
└── es <namespace> <command>       (verbatim content from today's `elastic es …`)
```

The `es` sub-tree itself is unchanged. Codegen output (`src/es/apis/**/*.ts`, `src/es/apis.ts`) is untouched. `registerEsCommands()` still returns a group named `es` — the re-parenting happens at registration time in `src/cli.ts` by wrapping it in a `stack` group. Adding `stack kibana` / `stack fleet` later is a one-liner next to the existing `registerEsCommands()` call.

## Design notes

- **Clean break, no aliases.** Project is `0.1.0-alpha.1`, so I'm not keeping `elastic es …` around.
- **Scaffold only for kibana/fleet.** #193 mentions `stack kibana` and `stack fleet` as future groups; those APIs don't exist yet, so I only added the top-level `stack` container and didn't prematurely wire up empty sub-groups.
- **Directory names unchanged.** `src/es/` and `registerEsCommands` stay as-is. The content is still ES-specific, and renaming is churn without payoff — the directory name is an implementation detail of a module that composes into the larger tree.

## Migration

| Before | After |
| --- | --- |
| `elastic es search --index my-index` | `elastic stack es search --index my-index` |
| `elastic es indices create --index foo` | `elastic stack es indices create --index foo` |
| `elastic es cat health` | `elastic stack es cat health` |
| `elastic es helpers scroll-search …` | `elastic stack es helpers scroll-search …` |

## Out of scope

- `elastic stack kibana …` and `elastic stack fleet …` — not implemented; the top-level scaffold is in place so these can be added as one-liners when their APIs land.
- Cloud/serverless tree restructuring — handled by #199.

## Files changed

- `src/cli.ts` — replaced the lazy-load branch for `es` with one for `stack`; wraps `registerEsCommands()` in a `stack` group. Updated the top-level program description.
- `src/es/register.ts`, `src/es/types.ts` — doc comments updated to show `elastic stack es …` in examples.
- `README.md` — `### es` section renamed to `### stack`, examples updated.
- `package.json` — `description` updated to match the new top-level tagline.
- `test/cli.test.ts` — updated the two `['es', 'info']` preAction-error invocations to `['stack', 'es', 'info']`; added three new smoke tests covering top-level help, `elastic stack --help`, and `elastic stack es --help`.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm run test:unit` — 862/862 passing (includes 3 new stack command-tree smoke tests).
- [x] `npm run test:lint` clean.
- [x] `node dist/cli.js --help` shows `stack` and no longer shows `es` at the top level.
- [x] `node dist/cli.js stack --help` lists `es` as the only sub-group.
- [x] `node dist/cli.js stack es --help` shows the full namespace tree (`indices`, `cluster`, `ml`, `cat`, …) and top-level leaves (`search`, `bulk`, `reindex`, …).
- [x] `node dist/cli.js stack es search --help` shows a real leaf command with all its flags.
