### PR TITLE
fix: Cache early config load to avoid redundant double load

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,14 +22,21 @@ program
   .option('--use-context <name>', 'override the active context from the config file')
   .option('--json', 'output as JSON')
 
-// Before every sub-command action, load and resolve the config file.
-// On error, print a structured message and exit -- never let a config failure
-// silently propagate into the command handler.
+// Cached result from the early load.
+//  The preAction hook reuses this when no --config-file or --use-context 
+// overrides are specified avoiding a redundant load+resolve cycle.
+let earlyConfig: import('./config/loader.ts').LoadConfigResult | undefined
+
 program.hook('preAction', async (thisCommand, actionCommand) => {
   if (actionCommand.name() === 'version') return
-  // docs commands use public elastic.co APIs — no config required
   if (actionCommand.parent?.name() === 'docs') return
   const { configFile: configPath, useContext: contextName } = thisCommand.opts()
+
+  if (configPath == null && contextName == null && earlyConfig?.ok === true) {
+    setResolvedConfig(earlyConfig.value)
+    return
+  }
+
   const result = await loadConfig({
     ...(configPath != null && { configPath }),
     ...(contextName != null && { contextName })
@@ -86,11 +93,12 @@ if (firstArg === 'docs') {
 
 // Load config early so --help can hide blocked commands. Skip for commands
 // that don't need config (e.g. `version`) to avoid unnecessary file I/O.
+// The result is cached in earlyConfig so the preAction hook can reuse it.
 if (firstArg !== 'version') {
-  const earlyResult = await loadConfig({})
-  if (earlyResult.ok) {
-    setResolvedConfig(earlyResult.value)
-    hideBlockedCommands(program, earlyResult.value.commands)
+  earlyConfig = await loadConfig({})
+  if (earlyConfig.ok) {
+    setResolvedConfig(earlyConfig.value)
+    hideBlockedCommands(program, earlyConfig.value.commands)
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,7 +6,7 @@
 
 import { Command } from 'commander'
 import { defineCommand, defineGroup, hideBlockedCommands } from './factory.js'
-import { loadConfig } from './config/loader.ts'
+import { loadConfig, type LoadConfigResult } from './config/loader.ts'
 import { setResolvedConfig } from './config/store.ts'
 
 // x-release-please-start-version
@@ -22,13 +22,17 @@ program
   .option('--use-context <name>', 'override the active context from the config file')
   .option('--json', 'output as JSON')
 
-// Cached result from the early load.
-//  The preAction hook reuses this when no --config-file or --use-context 
-// overrides are specified avoiding a redundant load+resolve cycle.
-let earlyConfig: import('./config/loader.ts').LoadConfigResult | undefined
+// Before every sub-command action, load and resolve the config file.
+// On error, print a structured message and exit -- never let a config failure
+// silently propagate into the command handler.
+//
+// When no --config-file or --use-context overrides are specified, the hook
+// reuses the cached earlyConfig to avoid a redundant load+resolve cycle.
+let earlyConfig: LoadConfigResult | undefined
 
 program.hook('preAction', async (thisCommand, actionCommand) => {
   if (actionCommand.name() === 'version') return
+  // docs commands use public elastic.co APIs — no config required
   if (actionCommand.parent?.name() === 'docs') return
   const { configFile: configPath, useContext: contextName } = thisCommand.opts()
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -133,6 +133,61 @@ describe('elastic CLI -- preAction config error handling', () => {
   })
 })
 
+describe('elastic CLI -- config caching (preAction reuse)', () => {
+  it('loads config once when no overrides are specified', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-cache-'))
+    const counterFile = join(dir, 'load-count.txt')
+    const configYaml = [
+      'current_context: local',
+      'contexts:',
+      '  local:',
+      '    elasticsearch:',
+      '      url: http://localhost:9200',
+      '      auth:',
+      `        api_key: "$(cmd:echo invoked >> ${counterFile} && echo test-key)"`,
+    ].join('\n')
+    const configPath = join(dir, '.elasticrc.yml')
+    const { writeFile, readFile } = await import('node:fs/promises')
+    await writeFile(configPath, configYaml)
+
+    try {
+      await runCli(['stack', 'es', 'info', '--json'], { cwd: dir, env: { HOME: dir, XDG_CONFIG_HOME: dir } })
+      const content = await readFile(counterFile, 'utf-8')
+      const invocations = content.trim().split('\n').length
+      assert.equal(invocations, 1, `expected resolver to run once, but ran ${invocations} times`)
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
+  it('loads config twice when --config-file override is specified', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-cache-override-'))
+    const counterFile = join(dir, 'load-count.txt')
+    const configYaml = [
+      'current_context: local',
+      'contexts:',
+      '  local:',
+      '    elasticsearch:',
+      '      url: http://localhost:9200',
+      '      auth:',
+      `        api_key: "$(cmd:echo invoked >> ${counterFile} && echo test-key)"`,
+    ].join('\n')
+    const configPath = join(dir, 'custom.yml')
+    const { writeFile, readFile } = await import('node:fs/promises')
+    await writeFile(join(dir, '.elasticrc.yml'), configYaml)
+    await writeFile(configPath, configYaml)
+
+    try {
+      await runCli(['stack', 'es', 'info', '--json', '--config-file', configPath], { cwd: dir, env: { HOME: dir, XDG_CONFIG_HOME: dir } })
+      const content = await readFile(counterFile, 'utf-8')
+      const invocations = content.trim().split('\n').length
+      assert.equal(invocations, 2, `expected resolver to run twice (early + override), but ran ${invocations} times`)
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+})
+
 describe('elastic CLI -- config-free commands', () => {
   it('`elastic version` succeeds without a config file', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-noconfig-'))

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -153,7 +153,7 @@ describe('elastic CLI -- config caching (preAction reuse)', () => {
     await writeFile(configPath, configYaml)
 
     try {
-      await runCli(['stack', 'es', 'info', '--json'], { cwd: dir, env: { HOME: dir, XDG_CONFIG_HOME: dir } })
+      await runCli(['stack', 'es', 'info', '--json'], { cwd: dir, env: { HOME: dir, USERPROFILE: dir, XDG_CONFIG_HOME: dir } })
       const content = await readFile(counterFile, 'utf-8')
       const invocations = content.trim().split('\n').length
       assert.equal(invocations, 1, `expected resolver to run once, but ran ${invocations} times`)
@@ -182,7 +182,7 @@ describe('elastic CLI -- config caching (preAction reuse)', () => {
     await writeFile(configPath, configYaml)
 
     try {
-      await runCli(['stack', 'es', 'info', '--json', '--config-file', configPath], { cwd: dir, env: { HOME: dir, XDG_CONFIG_HOME: dir } })
+      await runCli(['stack', 'es', 'info', '--json', '--config-file', configPath], { cwd: dir, env: { HOME: dir, USERPROFILE: dir, XDG_CONFIG_HOME: dir } })
       const content = await readFile(counterFile, 'utf-8')
       const invocations = content.trim().split('\n').length
       assert.equal(invocations, 2, `expected resolver to run twice (early + override), but ran ${invocations} times`)

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -137,6 +137,9 @@ describe('elastic CLI -- config caching (preAction reuse)', () => {
   it('loads config once when no overrides are specified', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-cache-'))
     const counterFile = join(dir, 'load-count.txt')
+    const scriptFile = join(dir, 'counter.js')
+    const { writeFile, readFile } = await import('node:fs/promises')
+    await writeFile(scriptFile, `require("fs").appendFileSync(${JSON.stringify(counterFile)},"x\\n");process.stdout.write("test-key")`)
     const configYaml = [
       'current_context: local',
       'contexts:',
@@ -144,10 +147,9 @@ describe('elastic CLI -- config caching (preAction reuse)', () => {
       '    elasticsearch:',
       '      url: http://localhost:9200',
       '      auth:',
-      `        api_key: "$(cmd:echo invoked >> ${counterFile} && echo test-key)"`,
+      `        api_key: "$(cmd:node ${scriptFile.replace(/\\/g, '/')})"`,
     ].join('\n')
     const configPath = join(dir, '.elasticrc.yml')
-    const { writeFile, readFile } = await import('node:fs/promises')
     await writeFile(configPath, configYaml)
 
     try {
@@ -163,6 +165,9 @@ describe('elastic CLI -- config caching (preAction reuse)', () => {
   it('loads config twice when --config-file override is specified', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-cache-override-'))
     const counterFile = join(dir, 'load-count.txt')
+    const scriptFile = join(dir, 'counter.js')
+    const { writeFile, readFile } = await import('node:fs/promises')
+    await writeFile(scriptFile, `require("fs").appendFileSync(${JSON.stringify(counterFile)},"x\\n");process.stdout.write("test-key")`)
     const configYaml = [
       'current_context: local',
       'contexts:',
@@ -170,10 +175,9 @@ describe('elastic CLI -- config caching (preAction reuse)', () => {
       '    elasticsearch:',
       '      url: http://localhost:9200',
       '      auth:',
-      `        api_key: "$(cmd:echo invoked >> ${counterFile} && echo test-key)"`,
+      `        api_key: "$(cmd:node ${scriptFile.replace(/\\/g, '/')})"`,
     ].join('\n')
     const configPath = join(dir, 'custom.yml')
-    const { writeFile, readFile } = await import('node:fs/promises')
     await writeFile(join(dir, '.elasticrc.yml'), configYaml)
     await writeFile(configPath, configYaml)
 


### PR DESCRIPTION
Closes https://github.com/elastic/cli/issues/163

```
➜  cli git:(fix-config-double-load) time node dist/cli.js stack es info --json

...
node dist/cli.js stack es info --json  0.89s user 0.19s system 66% cpu **1.630 total**
➜  cli git:(fix-config-double-load) 
```

and on main branch:
```
➜  cli git:(main) time node dist/cli.js stack es info --json

..
node dist/cli.js stack es info --json  0.72s user 0.17s system 34% cpu 2.585 total
➜  cli git:(main) 
```
