### PR TITLE
fix: buffer scroll-search documents into single JSON object when --json is active

### DIFF
--- a/src/es/helpers/scroll-search.ts
+++ b/src/es/helpers/scroll-search.ts
@@ -81,6 +81,8 @@ function createScrollSearchHandler (deps: ScrollSearchDeps = defaultDeps) {
       }
     }
 
+    const jsonMode = parsed.options['json'] === true
+    const documents: JsonValue[] = []
     const startTime = Date.now()
     let scrollId: string | undefined
     let totalDocs = 0
@@ -105,7 +107,11 @@ function createScrollSearchHandler (deps: ScrollSearchDeps = defaultDeps) {
       while (hits.length > 0 && totalDocs < maxDocs) {
         for (const hit of hits) {
           if (totalDocs >= maxDocs) break
-          deps.stdout.write(JSON.stringify(hit._source) + '\n')
+          if (jsonMode) {
+            documents.push(hit._source as JsonValue)
+          } else {
+            deps.stdout.write(JSON.stringify(hit._source) + '\n')
+          }
           totalDocs++
         }
 
@@ -141,6 +147,9 @@ function createScrollSearchHandler (deps: ScrollSearchDeps = defaultDeps) {
     const elapsed_ms = Date.now() - startTime
     deps.stderr.write(`Fetched ${totalDocs} documents in ${elapsed_ms}ms\n`)
 
+    if (jsonMode) {
+      return { documents, total_docs: totalDocs, elapsed_ms }
+    }
     return { total_docs: totalDocs, elapsed_ms }
   }
 }

--- a/src/es/helpers/scroll-search.ts
+++ b/src/es/helpers/scroll-search.ts
@@ -108,6 +108,7 @@ function createScrollSearchHandler (deps: ScrollSearchDeps = defaultDeps) {
         for (const hit of hits) {
           if (totalDocs >= maxDocs) break
           if (jsonMode) {
+            // _source is user-defined JSON — always a valid JsonValue at runtime
             documents.push(hit._source as JsonValue)
           } else {
             deps.stdout.write(JSON.stringify(hit._source) + '\n')
@@ -157,7 +158,7 @@ function createScrollSearchHandler (deps: ScrollSearchDeps = defaultDeps) {
 export function createScrollSearchCommand (deps?: ScrollSearchDeps): OpaqueCommandHandle {
   return defineCommand({
     name: 'scroll-search',
-    description: 'Scroll through all search results, streaming documents as NDJSON to stdout.',
+    description: 'Scroll through all search results, streaming documents as NDJSON to stdout, or returning a single JSON object when --json is set.',
     options: [
       { long: 'index', short: 'i', description: 'Target index', type: 'string', required: true },
       { long: 'query', short: 'q', description: 'Search query body as JSON string', type: 'string' },

--- a/test/es/helpers/scroll-search.test.ts
+++ b/test/es/helpers/scroll-search.test.ts
@@ -129,7 +129,7 @@ describe('scroll-search command', () => {
     ])
 
     await runCommand(
-      ['--index', 'test-idx', '--query', '{}', '--json'],
+      ['--index', 'test-idx', '--query', '{}'],
       makeDeps(transport, output)
     )
 
@@ -158,7 +158,7 @@ describe('scroll-search command', () => {
     ])
 
     await runCommand(
-      ['--index', 'test-idx', '--query', '{}', '--max-docs', '2', '--json'],
+      ['--index', 'test-idx', '--query', '{}', '--max-docs', '2'],
       makeDeps(transport, output)
     )
 
@@ -276,6 +276,34 @@ describe('scroll-search command', () => {
     const r = result as Record<string, unknown>
     const error = r.error as Record<string, unknown>
     assert.equal(error.code, 'missing_config')
+  })
+
+  it('returns all documents in a single JSON object when --json is active', async () => {
+    const output = captureOutput()
+    const { transport } = mockTransport([
+      {
+        _scroll_id: 'scroll-1',
+        hits: { hits: [{ _source: { id: 1 } }, { _source: { id: 2 } }] }
+      },
+      {
+        _scroll_id: 'scroll-1',
+        hits: { hits: [{ _source: { id: 3 } }] }
+      },
+      { hits: { hits: [] } },
+      {}
+    ])
+
+    const { result } = await runCommand(
+      ['--index', 'test-idx', '--query', '{}', '--json'],
+      makeDeps(transport, output)
+    )
+
+    const r = result as Record<string, unknown>
+    assert.ok(Array.isArray(r.documents), 'result should have a documents array')
+    assert.equal((r.documents as unknown[]).length, 3)
+    assert.equal(r.total_docs, 3)
+    assert.ok(typeof r.elapsed_ms === 'number')
+    assert.equal(output.stdout.chunks.length, 0, 'should not stream NDJSON to deps.stdout in --json mode')
   })
 
   it('writes summary to stderr', async () => {

--- a/test/es/helpers/scroll-search.test.ts
+++ b/test/es/helpers/scroll-search.test.ts
@@ -300,10 +300,31 @@ describe('scroll-search command', () => {
 
     const r = result as Record<string, unknown>
     assert.ok(Array.isArray(r.documents), 'result should have a documents array')
-    assert.equal((r.documents as unknown[]).length, 3)
+    assert.deepStrictEqual(r.documents, [{ id: 1 }, { id: 2 }, { id: 3 }])
     assert.equal(r.total_docs, 3)
     assert.ok(typeof r.elapsed_ms === 'number')
     assert.equal(output.stdout.chunks.length, 0, 'should not stream NDJSON to deps.stdout in --json mode')
+  })
+
+  it('respects --max-docs in --json mode', async () => {
+    const output = captureOutput()
+    const { transport } = mockTransport([
+      {
+        _scroll_id: 'scroll-1',
+        hits: { hits: [{ _source: { a: 1 } }, { _source: { a: 2 } }, { _source: { a: 3 } }] }
+      },
+      {}
+    ])
+
+    const { result } = await runCommand(
+      ['--index', 'test-idx', '--query', '{}', '--max-docs', '2', '--json'],
+      makeDeps(transport, output)
+    )
+
+    const r = result as Record<string, unknown>
+    assert.deepStrictEqual(r.documents, [{ a: 1 }, { a: 2 }])
+    assert.equal(r.total_docs, 2)
+    assert.equal(output.stdout.chunks.length, 0)
   })
 
   it('writes summary to stderr', async () => {


### PR DESCRIPTION
Closes https://github.com/elastic/cli/issues/161

`es helpers scroll-search --json` was streaming NDJSON document lines to stdout and then the factory appended a `{"total_docs", "elapsed_ms"}` summary and so producing output that's neither valid JSON nor valid NDJSON.

Now when `--json` is active, documents are buffered and returned as a single JSON object:

`{"documents":[...],"total_docs":3,"elapsed_ms":24}`
Without `--json`, behavior is unchanged so NDJSON streaming with one doc per line.