### PR TITLE
fix: wrap scroll-search --query under "query" in request body

### DIFF
--- a/src/es/helpers/scroll-search.ts
+++ b/src/es/helpers/scroll-search.ts
@@ -56,11 +56,15 @@ function createScrollSearchHandler (deps: ScrollSearchDeps = defaultDeps) {
       return missingConfigError(err)
     }
 
-    // Parse query body from --query flag, --input-file, or stdin (in that priority order)
+    // Build the search request body:
+    //   --query     → a Query DSL clause, wrapped as { query: <parsed> }
+    //   --input-file → a full search body (may contain query, sort, aggs, ...)
+    //   stdin        → a full search body (same as --input-file)
     let queryBody: Record<string, unknown> = {}
     try {
       if (opts.query != null) {
-        queryBody = JSON.parse(opts.query) as Record<string, unknown>
+        const parsed = JSON.parse(opts.query) as Record<string, unknown>
+        queryBody = { query: parsed }
       } else if (opts['input-file'] != null) {
         const raw = readRawInput(opts['input-file'])
         if (raw != null && raw.trim().length > 0) {
@@ -161,8 +165,8 @@ export function createScrollSearchCommand (deps?: ScrollSearchDeps): OpaqueComma
     description: 'Scroll through all search results, streaming documents as NDJSON to stdout, or returning a single JSON object when --json is set.',
     options: [
       { long: 'index', short: 'i', description: 'Target index', type: 'string', required: true },
-      { long: 'query', short: 'q', description: 'Search query body as JSON string', type: 'string' },
-      { long: 'input-file', description: 'Path to file containing search body JSON', type: 'string' },
+      { long: 'query', short: 'q', description: 'Query DSL clause as JSON (wrapped under "query"), e.g. \'{"match_all":{}}\'', type: 'string' },
+      { long: 'input-file', description: 'Path to a file containing the full search body JSON (may include query, sort, aggs, ...)', type: 'string' },
       { long: 'scroll', description: 'Scroll keep-alive duration', type: 'string', defaultValue: '1m' },
       { long: 'size', description: 'Documents per scroll batch', type: 'number', defaultValue: 1000 },
       { long: 'max-docs', description: 'Maximum total documents to fetch (default: unlimited)', type: 'number', defaultValue: Infinity },

--- a/test/es/helpers/scroll-search.test.ts
+++ b/test/es/helpers/scroll-search.test.ts
@@ -182,7 +182,7 @@ describe('scroll-search command', () => {
     assert.equal(qs.size, 500)
   })
 
-  it('passes query body from --query flag', async () => {
+  it('wraps --query value under "query" in the request body', async () => {
     const output = captureOutput()
     const { transport, requests } = mockTransport([
       { _scroll_id: 'scroll-1', hits: { hits: [] } },
@@ -195,13 +195,13 @@ describe('scroll-search command', () => {
     )
 
     const body = requests[0]!.params.body as Record<string, unknown>
-    assert.deepStrictEqual(body, { match: { title: 'test' } })
+    assert.deepStrictEqual(body, { query: { match: { title: 'test' } } })
   })
 
-  it('reads query from --input-file', async () => {
+  it('treats --input-file contents as the full search body', async () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'scroll-test-'))
-    const filePath = join(tmpDir, 'query.json')
-    writeFileSync(filePath, '{"match_all":{}}')
+    const filePath = join(tmpDir, 'body.json')
+    writeFileSync(filePath, '{"query":{"match_all":{}},"sort":[{"_doc":"asc"}]}')
 
     const output = captureOutput()
     const { transport, requests } = mockTransport([
@@ -215,7 +215,7 @@ describe('scroll-search command', () => {
     )
 
     const body = requests[0]!.params.body as Record<string, unknown>
-    assert.deepStrictEqual(body, { match_all: {} })
+    assert.deepStrictEqual(body, { query: { match_all: {} }, sort: [{ _doc: 'asc' }] })
   })
 
   it('clears scroll context on completion', async () => {


### PR DESCRIPTION
## Summary

Fixes #169.

`elastic es helpers scroll-search --query '{"match_all":{}}'` was failing with `parsing_exception: Unknown key for a START_OBJECT in [match_all]` because the helper sent the raw parsed `--query` JSON as the entire request body. Elasticsearch expects the query clause wrapped under `"query"`.

This aligns `--query` semantics with the generated `es search --query` command and the help text example users would reasonably try.

## Changes

- `src/es/helpers/scroll-search.ts`: `--query` contents are now wrapped as `{ query: <parsed> }` before being sent. `--input-file` and stdin continue to be treated as a full search body so callers can still include `query` + `sort` + `aggs` together. Updated flag descriptions to make the distinction explicit.
- `test/es/helpers/scroll-search.test.ts`: updated the two flag-semantics tests to assert the new body shapes (`--query` wraps; `--input-file` is passed through verbatim). The other 10 tests are unchanged.

## Test plan

- [x] `node --import tsx/esm --test test/es/helpers/scroll-search.test.ts` — 12/12 pass
- [x] `npx tsc --noEmit` — clean
- [ ] Manual repro from the issue against a local ES 9.x:
  ```bash
  elastic es helpers scroll-search --index test-scroll --query '{"match_all":{}}'
  ```
  returns the document and the `Fetched N documents in Xms` summary instead of `parsing_exception`.
- [ ] `--input-file` with `{"query":{"match_all":{}},"sort":[{"_doc":"asc"}]}` still works.
