### PR TITLE
feat: `elastic config` command group + credential-safe project create

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,40 @@ Override `current_context` for a single command with `--use-context <name>`.
 Each context can have any combination of service blocks (`elasticsearch`, `kibana`, `cloud`).
 Authentication can also use `username` + `password` instead of `api_key`.
 
+### Authoring the config from the CLI
+
+Instead of hand-editing YAML, the `elastic config` command group creates and
+maintains contexts and stores secrets in the OS keychain when available
+(macOS Keychain, Linux libsecret, `pass`, Windows Credential Manager). The YAML
+then holds a `$(keychain:...)` / `$(secret_service:...)` / etc. resolver
+expression rather than the raw secret.
+
+```bash
+# Add a new context (API key goes to the keychain; YAML gets $(keychain:...))
+elastic config context add local \
+  --es-url http://localhost:9200 \
+  --es-api-key your-api-key
+
+# List contexts (the current one is marked)
+elastic config context list
+
+# Switch the active context
+elastic config current-context set staging
+
+# Flag-patch an existing context
+elastic config context edit local --es-url http://localhost:9201
+
+# Open the context as YAML in $EDITOR for free-form edits
+elastic config context edit local
+
+# Remove a context (keychain entries are cleaned up)
+elastic config context remove old-lab
+```
+
+If no OS keychain is available (or you pass `--inline-secrets`), the secret is
+written inline and the file is `chmod 0600`. A warning is emitted whenever a
+loaded config has inline secrets at looser-than-0600 permissions.
+
 ### External credentials
 
 Instead of storing secrets in plaintext, any string value in the config file can

--- a/README.md
+++ b/README.md
@@ -101,6 +101,28 @@ If no OS keychain is available (or you pass `--inline-secrets`), the secret is
 written inline and the file is `chmod 0600`. A warning is emitted whenever a
 loaded config has inline secrets at looser-than-0600 permissions.
 
+### Credential-safe project creation
+
+For agent/LLM workflows, `serverless projects create` and `reset-credentials`
+accept `--save-as <context>` to avoid leaking admin credentials through stdout:
+
+```bash
+elastic cloud serverless es projects create --wait --save-as scratch \
+  --name scratch-es --region-id aws-us-east-1
+
+# stdout has endpoints + a `savedAs: scratch` marker, password is redacted.
+# The keychain now holds scratch:elasticsearch.auth.password etc.
+elastic --use-context scratch stack es indices list
+
+# Rotate creds; URL stays, only the password moves.
+elastic cloud serverless es projects reset-credentials --id <id> \
+  --save-as scratch --force
+```
+
+`--credentials-file <path>` is an alternative that writes a standalone YAML
+config fragment (0600) at `<path>` instead of mutating the main config. Either
+flag makes stdout safe to capture into an LLM transcript.
+
 ### External credentials
 
 Instead of storing secrets in plaintext, any string value in the config file can

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,6 +37,11 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
   if (actionCommand.name() === 'version') return
   // docs commands use public elastic.co APIs — no config required
   if (actionCommand.parent?.name() === 'docs') return
+  // `config` commands author the config file itself — loading it would be
+  // circular (and must tolerate the absence of a file)
+  for (let c = actionCommand.parent; c != null; c = c.parent) {
+    if (c.name() === 'config') return
+  }
   const { configFile: configPath, useContext: contextName } = thisCommand.opts()
 
   if (configPath == null && contextName == null && earlyConfig?.ok === true) {
@@ -134,10 +139,17 @@ if (firstArg === 'docs') {
   program.addCommand(defineGroup({ name: 'docs', description: 'Search, read, and ask questions about Elastic documentation' }))
 }
 
+if (firstArg === 'config') {
+  const { registerConfigCommands } = await import('./config/commands.ts')
+  program.addCommand(registerConfigCommands())
+} else {
+  program.addCommand(defineGroup({ name: 'config', description: 'Author and maintain the elastic config file' }))
+}
 // Load config early so --help can hide blocked commands. Skip for commands
-// that don't need config (e.g. `version`) to avoid unnecessary file I/O.
+// that don't need config (e.g. `version`, or `config` which authors the file)
+// to avoid unnecessary file I/O and a confusing "no config found" path.
 // The result is cached in earlyConfig so the preAction hook can reuse it.
-if (firstArg !== 'version') {
+if (firstArg !== 'version' && firstArg !== 'config') {
   earlyConfig = await loadConfig({})
   if (earlyConfig.ok) {
     setResolvedConfig(earlyConfig.value)

--- a/src/cloud/credentials.ts
+++ b/src/cloud/credentials.ts
@@ -1,0 +1,410 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Credential-safe handling for serverless project create / reset-credentials.
+ *
+ * The underlying cloud API returns admin credentials in the response body.
+ * When the user passes `--save-as <context>` or `--credentials-file <path>`,
+ * this module:
+ *
+ *   1. Extracts the credential fields (username/password).
+ *   2. For `--save-as`: upserts a context in the main config and stores
+ *      secrets in the OS keychain (via SecretStore). Redacts the credential
+ *      fields in the returned JSON so they never reach stdout.
+ *   3. For `--credentials-file`: writes a standalone single-context YAML
+ *      fragment to the given path (0600 perms) and redacts stdout.
+ *
+ * Without those flags, behaviour is unchanged for backwards compatibility.
+ */
+
+import {
+  readRawConfig,
+  writeConfig,
+  upsertContext,
+  hasInlineSecrets,
+  resolveConfigPath,
+  type RawConfig,
+  type RawContext,
+} from '../config/writer.ts'
+import { getSecretStore, type SecretStore } from '../config/secret-store.ts'
+import type { JsonValue } from '../factory.ts'
+
+const KEYCHAIN_SERVICE = 'elastic-cli'
+
+const CREATE_PROJECT_RE = /^create-(?:elasticsearch|observability|security)-project$/
+const RESET_CREDENTIALS_RE = /^reset-(?:elasticsearch|observability|security)-project-credentials$/
+
+/** Returns true when `cmdName` is a serverless command that returns credentials. */
+export function isCredentialCommand (cmdName: string): boolean {
+  return CREATE_PROJECT_RE.test(cmdName) || RESET_CREDENTIALS_RE.test(cmdName)
+}
+
+/** Returns true when `cmdName` is reset-credentials (URL endpoints are absent). */
+export function isResetCredentialsCommand (cmdName: string): boolean {
+  return RESET_CREDENTIALS_RE.test(cmdName)
+}
+
+/** The flags this module cares about, pulled out of `parsed.options`. */
+export interface CredentialPolicyOptions {
+  saveAs?: string
+  credentialsFile?: string
+  force?: boolean
+  configFile?: string
+}
+
+export function readCredentialPolicyOptions (
+  options: Record<string, string | number | boolean>,
+): CredentialPolicyOptions {
+  const out: CredentialPolicyOptions = {}
+  const saveAs = options['save-as']
+  if (typeof saveAs === 'string' && saveAs.length > 0) out.saveAs = saveAs
+  const credFile = options['credentials-file']
+  if (typeof credFile === 'string' && credFile.length > 0) out.credentialsFile = credFile
+  if (options['force'] === true) out.force = true
+  const cfg = options['config-file']
+  if (typeof cfg === 'string' && cfg.length > 0) out.configFile = cfg
+  return out
+}
+
+/**
+ * Shape of the response fields we care about. Everything is optional because
+ * the API contract is schema-less at this layer and we handle what we find.
+ */
+interface CredentialFields {
+  username?: string
+  password?: string
+}
+
+interface EndpointFields {
+  elasticsearch?: string
+  kibana?: string
+}
+
+interface ExtractedProject {
+  id?: string
+  credentials: CredentialFields
+  endpoints: EndpointFields
+}
+
+function isObj (v: unknown): v is Record<string, unknown> {
+  return v != null && typeof v === 'object' && !Array.isArray(v)
+}
+
+function asString (v: unknown): string | undefined {
+  return typeof v === 'string' ? v : undefined
+}
+
+export function extractProjectFields (body: JsonValue): ExtractedProject {
+  const out: ExtractedProject = { credentials: {}, endpoints: {} }
+  if (!isObj(body)) return out
+  const id = asString(body.id)
+  if (id != null) out.id = id
+
+  const credsSrc = isObj(body.credentials) ? body.credentials : body
+  const u = asString(credsSrc.username)
+  const p = asString(credsSrc.password)
+  if (u != null) out.credentials.username = u
+  if (p != null) out.credentials.password = p
+
+  if (isObj(body.endpoints)) {
+    const es = asString(body.endpoints.elasticsearch)
+    const kb = asString(body.endpoints.kibana)
+    if (es != null) out.endpoints.elasticsearch = es
+    if (kb != null) out.endpoints.kibana = kb
+  }
+
+  return out
+}
+
+/**
+ * Returns a new response with credential fields replaced by a short marker,
+ * preserving the rest of the body (so callers still see endpoint URLs, ids,
+ * and any other fields the API happens to return).
+ */
+export function redactCredentials (body: JsonValue, marker: string): JsonValue {
+  if (!isObj(body)) return body
+  const next: Record<string, JsonValue> = { ...body as Record<string, JsonValue> }
+  if (isObj(next.credentials)) {
+    const creds: Record<string, JsonValue> = { ...next.credentials as Record<string, JsonValue> }
+    if (typeof creds.password === 'string') creds.password = marker
+    next.credentials = creds
+  }
+  // top-level flattened shape
+  if (typeof next.password === 'string') next.password = marker
+  return next
+}
+
+/**
+ * Builds a RawContext for a newly-created project from its endpoints +
+ * credentials. Stores secrets in the keychain (or leaves them inline when
+ * no store is available).
+ */
+interface BuildContextResult {
+  context: RawContext
+  inline: boolean
+  storageKind: SecretStore['kind']
+}
+
+async function buildProjectContext (
+  extracted: ExtractedProject,
+  contextName: string,
+  store: SecretStore,
+): Promise<BuildContextResult> {
+  const ctx: Record<string, unknown> = {}
+  const { username, password } = extracted.credentials
+  const storeAvailable = await store.isAvailable()
+
+  const authForService = async (serviceFieldPath: string): Promise<Record<string, unknown> | undefined> => {
+    if (username == null || password == null) return undefined
+    const auth: Record<string, unknown> = { username }
+    if (storeAvailable) {
+      const account = `${contextName}:${serviceFieldPath}.auth.password`
+      await store.put(KEYCHAIN_SERVICE, account, password)
+      auth.password = store.resolverExpr(KEYCHAIN_SERVICE, account)
+    } else {
+      auth.password = password
+    }
+    return auth
+  }
+
+  if (extracted.endpoints.elasticsearch != null) {
+    const block: Record<string, unknown> = { url: extracted.endpoints.elasticsearch }
+    const auth = await authForService('elasticsearch')
+    if (auth != null) block.auth = auth
+    ctx.elasticsearch = block
+  }
+  if (extracted.endpoints.kibana != null) {
+    const block: Record<string, unknown> = { url: extracted.endpoints.kibana }
+    const auth = await authForService('kibana')
+    if (auth != null) block.auth = auth
+    ctx.kibana = block
+  }
+
+  return {
+    context: ctx as RawContext,
+    inline: !storeAvailable,
+    storageKind: storeAvailable ? store.kind : 'none',
+  }
+}
+
+/**
+ * Updates an existing context's auth.password fields after a
+ * reset-credentials call (which doesn't return endpoints).
+ * Returns undefined if the context has no service blocks to update.
+ */
+async function replaceContextPasswords (
+  existing: RawContext,
+  contextName: string,
+  credentials: CredentialFields,
+  store: SecretStore,
+): Promise<RawContext | undefined> {
+  const { username, password } = credentials
+  if (username == null || password == null) return undefined
+  const storeAvailable = await store.isAvailable()
+  const next: Record<string, unknown> = { ...existing as Record<string, unknown> }
+
+  let touched = false
+  for (const serviceKey of ['elasticsearch', 'kibana'] as const) {
+    const block = next[serviceKey]
+    if (!isObj(block)) continue
+    const auth: Record<string, unknown> = { username }
+    if (storeAvailable) {
+      const account = `${contextName}:${serviceKey}.auth.password`
+      await store.put(KEYCHAIN_SERVICE, account, password)
+      auth.password = store.resolverExpr(KEYCHAIN_SERVICE, account)
+    } else {
+      auth.password = password
+    }
+    next[serviceKey] = { ...block, auth }
+    touched = true
+  }
+
+  return touched ? (next as RawContext) : undefined
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface ApplyCredentialPolicyResult {
+  body: JsonValue
+  /** Non-stdout telemetry for human-friendly logging. */
+  log: {
+    mode: 'save-as' | 'credentials-file' | 'passthrough'
+    contextName?: string
+    credentialsFile?: string
+    storage: SecretStore['kind']
+    warnings: string[]
+  }
+}
+
+/**
+ * Applies the configured credential policy to a cloud API response.
+ *
+ * Preconditions:
+ *   - `cmdName` must be a credential-bearing command (checked by the caller
+ *     via {@link isCredentialCommand}); passing a non-matching name is a bug.
+ *
+ * Error semantics:
+ *   - Context name collisions on `--save-as` without `--force` throw (the
+ *     caller converts the throw to a structured JsonValue).
+ *   - OS-level failures (keychain write, file write) propagate.
+ */
+export async function applyCredentialPolicy (
+  cmdName: string,
+  body: JsonValue,
+  opts: CredentialPolicyOptions,
+): Promise<ApplyCredentialPolicyResult> {
+  if (opts.saveAs == null && opts.credentialsFile == null) {
+    return {
+      body,
+      log: { mode: 'passthrough', storage: 'none', warnings: [] },
+    }
+  }
+
+  const extracted = extractProjectFields(body)
+  if (extracted.credentials.password == null) {
+    // Nothing to redact or save; pass through untouched.
+    return {
+      body,
+      log: { mode: 'passthrough', storage: 'none', warnings: [] },
+    }
+  }
+
+  const store = await getSecretStore()
+  const warnings: string[] = []
+  const storeAvailable = await store.isAvailable()
+  if (!storeAvailable) {
+    warnings.push(
+      'No OS secret store is available; credentials will be written inline to the config file (chmod 0600).'
+    )
+  }
+
+  if (opts.saveAs != null) {
+    return saveAsContext(cmdName, body, extracted, opts, store, warnings)
+  }
+
+  // opts.credentialsFile != null
+  return saveAsCredentialsFile(cmdName, body, extracted, opts, store, warnings)
+}
+
+async function saveAsContext (
+  cmdName: string,
+  body: JsonValue,
+  extracted: ExtractedProject,
+  opts: CredentialPolicyOptions,
+  store: SecretStore,
+  warnings: string[],
+): Promise<ApplyCredentialPolicyResult> {
+  const contextName = opts.saveAs!
+  const configPath = resolveConfigPath(opts.configFile)
+  const config = await readRawConfig(configPath)
+
+  let nextContext: RawContext | undefined
+  if (isResetCredentialsCommand(cmdName)) {
+    const existing = config.contexts[contextName]
+    if (existing == null) {
+      throw new Error(
+        `--save-as requires an existing context for reset-credentials; context "${contextName}" not found in ${configPath}`
+      )
+    }
+    nextContext = await replaceContextPasswords(existing, contextName, extracted.credentials, store)
+    if (nextContext == null) {
+      throw new Error(
+        `context "${contextName}" has no elasticsearch/kibana service block to update with new credentials`
+      )
+    }
+  } else {
+    if (contextName in config.contexts && opts.force !== true) {
+      throw new Error(`context "${contextName}" already exists. Pass --force to overwrite.`)
+    }
+    const built = await buildProjectContext(extracted, contextName, store)
+    nextContext = built.context
+  }
+
+  let next = upsertContext(config, contextName, nextContext)
+  if (next.current_context === '') {
+    // First context ever; point current_context at it.
+    next = { ...next, current_context: contextName }
+  }
+
+  const writeResult = await writeConfig(configPath, next, { restrictPermissions: hasInlineSecrets(next) })
+  const storeAvailable = await store.isAvailable()
+
+  const marker = storeAvailable ? `(saved to ${store.kind})` : '(saved inline to config)'
+  const redacted = redactCredentials(body, marker)
+  const annotated = annotateBody(redacted, { savedAs: contextName, configFile: writeResult.path })
+
+  return {
+    body: annotated,
+    log: {
+      mode: 'save-as',
+      contextName,
+      storage: storeAvailable ? store.kind : 'none',
+      warnings: [...warnings, ...writeResult.warnings],
+    },
+  }
+}
+
+async function saveAsCredentialsFile (
+  cmdName: string,
+  body: JsonValue,
+  extracted: ExtractedProject,
+  opts: CredentialPolicyOptions,
+  store: SecretStore,
+  warnings: string[],
+): Promise<ApplyCredentialPolicyResult> {
+  const credentialsFile = opts.credentialsFile!
+  // For reset-credentials without endpoints, we cannot build a complete
+  // single-context fragment; refuse rather than write something broken.
+  if (isResetCredentialsCommand(cmdName) && extracted.endpoints.elasticsearch == null && extracted.endpoints.kibana == null) {
+    throw new Error(
+      '--credentials-file is not supported for reset-credentials (response contains no endpoints). Use --save-as to update an existing context.'
+    )
+  }
+
+  // The fragment is a single-context, self-contained config file.
+  const contextName = opts.saveAs ?? (extracted.id ?? 'project')
+  const built = await buildProjectContext(extracted, contextName, store)
+
+  const fragment: RawConfig = {
+    current_context: contextName,
+    contexts: { [contextName]: built.context },
+  }
+
+  const { stat } = await import('node:fs/promises')
+  if (opts.force !== true) {
+    try {
+      await stat(credentialsFile)
+      throw new Error(`credentials file "${credentialsFile}" already exists. Pass --force to overwrite.`)
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err
+    }
+  }
+
+  const writeResult = await writeConfig(credentialsFile, fragment, { restrictPermissions: true })
+  const storeAvailable = await store.isAvailable()
+
+  const redacted = redactCredentials(body, '(saved to file)')
+  const annotated = annotateBody(redacted, { credentialsFile: writeResult.path })
+
+  return {
+    body: annotated,
+    log: {
+      mode: 'credentials-file',
+      credentialsFile: writeResult.path,
+      storage: storeAvailable ? store.kind : 'none',
+      warnings: [...warnings, ...writeResult.warnings],
+    },
+  }
+}
+
+function annotateBody (body: JsonValue, extras: Record<string, string>): JsonValue {
+  if (!isObj(body)) {
+    return { result: body as JsonValue, ...(extras as Record<string, JsonValue>) }
+  }
+  return { ...(body as Record<string, JsonValue>), ...(extras as Record<string, JsonValue>) }
+}

--- a/src/cloud/register.ts
+++ b/src/cloud/register.ts
@@ -12,6 +12,12 @@ import { validateCloudApiDefinition } from './types.ts'
 import { allCloudApis } from './apis.ts'
 import { allServerlessApis } from './serverless-apis.ts'
 import { createCloudHandler, isCreateProjectCommand } from './handler.ts'
+import {
+  applyCredentialPolicy,
+  isCredentialCommand,
+  readCredentialPolicyOptions,
+} from './credentials.ts'
+import type { JsonValue, ParsedResult } from '../factory.ts'
 
 /**
  * Builds the unified flat Zod schema for a Cloud API command.
@@ -172,14 +178,25 @@ function buildServerlessProjectGroup (
   const leaves = defs.map((def) => {
     const shortName = simplifyProjectCommandName(def.name, namespace)
     const schema = buildCommandSchema(def)
+    const baseHandler = createCloudHandler(def)
+    const handler: (parsed: ParsedResult) => Promise<JsonValue> = isCredentialCommand(def.name)
+      ? async (parsed) => wrapWithCredentialPolicy(def.name, baseHandler, parsed)
+      : baseHandler
     const cmd = defineCommand({
       name: shortName,
       description: def.description,
       input: schema,
-      handler: createCloudHandler(def),
+      handler,
     })
     if (isCreateProjectCommand(def.name)) {
       (cmd as Command).option('--wait', 'Wait for the project to reach "initialized" phase before returning')
+    }
+    if (isCredentialCommand(def.name)) {
+      (cmd as Command)
+        .option('--save-as <name>', 'store returned credentials in the OS keychain and upsert a context of this name')
+        .option('--credentials-file <path>', 'write credentials to a standalone YAML config fragment at this path (0600)')
+        .option('--config-file <path>', 'override the config file written by --save-as (defaults to ~/.elasticrc.yml)')
+        .option('--force', 'overwrite an existing context (--save-as) or file (--credentials-file)')
     }
     return cmd
   })
@@ -276,6 +293,36 @@ function partitionDefinitions (definitions: CloudApiDefinition[]): PartitionedDe
  *   registry (hosted + serverless APIs combined).
  * @returns an `OpaqueCommandHandle` for the top-level `cloud` group.
  */
+/**
+ * Runs the base cloud handler, then applies the credential-saving policy if
+ * the user passed `--save-as` / `--credentials-file`. Passthrough otherwise.
+ * Policy errors (name collisions, missing contexts) are converted to the
+ * factory's structured error shape so the CLI exits non-zero cleanly.
+ */
+async function wrapWithCredentialPolicy (
+  cmdName: string,
+  baseHandler: (parsed: ParsedResult) => Promise<JsonValue>,
+  parsed: ParsedResult,
+): Promise<JsonValue> {
+  const body = await baseHandler(parsed)
+  // If the base handler itself returned an error envelope, don't touch it.
+  if (body != null && typeof body === 'object' && !Array.isArray(body) && 'error' in body) {
+    return body
+  }
+  const opts = readCredentialPolicyOptions(parsed.options)
+  if (opts.saveAs == null && opts.credentialsFile == null) return body
+  try {
+    const result = await applyCredentialPolicy(cmdName, body, opts)
+    if (result.log.warnings.length > 0) {
+      for (const w of result.log.warnings) process.stderr.write(`Warning: ${w}\n`)
+    }
+    return result.body
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { error: { code: 'credential_policy_error', message } }
+  }
+}
+
 export function registerCloudCommands(
   definitions: CloudApiDefinition[] = [...allCloudApis, ...allServerlessApis],
 ): OpaqueCommandHandle {

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -1,0 +1,583 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * `elastic config ...` command tree.
+ *
+ * Unlike the cloud/stack commands, these do not require a resolved config; they
+ * *author* it. The CLI entrypoint skips the config-loading preAction hook for
+ * any command whose ancestor group is "config" (see {@link ../cli.ts}).
+ *
+ * Secrets are stored in the OS keychain (via {@link SecretStore}) when one is
+ * available. The YAML then contains `$(keychain:...)` resolver expressions
+ * rather than the raw secret. If no keychain is available, or the user passes
+ * `--inline-secrets`, the secret is written inline and the file is chmod'd to
+ * 0600 with a warning surfaced to the user.
+ */
+
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mkdtemp, readFile, rm, unlink, writeFile } from 'node:fs/promises'
+import { spawn } from 'node:child_process'
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml'
+import { defineCommand, defineGroup } from '../factory.ts'
+import type { JsonValue, OpaqueCommandHandle } from '../factory.ts'
+import {
+  readRawConfig,
+  writeConfig,
+  upsertContext,
+  removeContext,
+  setCurrentContext,
+  extractContext,
+  hasInlineSecrets,
+  resolveConfigPath,
+  type RawContext,
+} from './writer.ts'
+import { getSecretStore, type SecretStore } from './secret-store.ts'
+import { ContextSchema } from './schema.ts'
+
+const KEYCHAIN_SERVICE = 'elastic-cli'
+
+/** Secret flags supported on `context add` / `context edit --set`. */
+interface SecretField {
+  /** CLI flag name (no leading --) */
+  flag: string
+  /** Dotted path in the context where the secret lives (e.g. `elasticsearch.auth.api_key`) */
+  path: string[]
+  description: string
+}
+
+/** Non-secret URL / username flags. */
+interface PlainField {
+  flag: string
+  path: string[]
+  description: string
+}
+
+const SECRET_FIELDS: SecretField[] = [
+  { flag: 'es-api-key',      path: ['elasticsearch', 'auth', 'api_key'],  description: 'Elasticsearch API key' },
+  { flag: 'es-password',     path: ['elasticsearch', 'auth', 'password'], description: 'Elasticsearch password' },
+  { flag: 'kb-api-key',      path: ['kibana', 'auth', 'api_key'],         description: 'Kibana API key' },
+  { flag: 'kb-password',     path: ['kibana', 'auth', 'password'],        description: 'Kibana password' },
+  { flag: 'cloud-api-key',   path: ['cloud', 'auth', 'api_key'],          description: 'Elastic Cloud API key' },
+]
+
+const PLAIN_FIELDS: PlainField[] = [
+  { flag: 'es-url',       path: ['elasticsearch', 'url'],           description: 'Elasticsearch URL' },
+  { flag: 'es-username',  path: ['elasticsearch', 'auth', 'username'], description: 'Elasticsearch username (pair with --es-password)' },
+  { flag: 'kb-url',       path: ['kibana', 'url'],                  description: 'Kibana URL' },
+  { flag: 'kb-username',  path: ['kibana', 'auth', 'username'],     description: 'Kibana username (pair with --kb-password)' },
+  { flag: 'cloud-url',    path: ['cloud', 'url'],                   description: 'Elastic Cloud API URL' },
+]
+
+/**
+ * Pulls the `--config-file` flag out of the command's parsed options and
+ * feeds it to the shared {@link resolveConfigPath}.
+ */
+function configPathFromOptions (options: Record<string, string | number | boolean>): string {
+  const flag = options['config-file']
+  return resolveConfigPath(typeof flag === 'string' ? flag : undefined)
+}
+
+/** Sets a dotted path on an object immutably, creating intermediate objects as needed. */
+function setPath (obj: Record<string, unknown>, path: string[], value: unknown): Record<string, unknown> {
+  if (path.length === 0) return obj
+  const [head, ...rest] = path
+  const headKey = head!
+  if (rest.length === 0) {
+    return { ...obj, [headKey]: value }
+  }
+  const child = obj[headKey]
+  const next = (child != null && typeof child === 'object' && !Array.isArray(child))
+    ? child as Record<string, unknown>
+    : {}
+  return { ...obj, [headKey]: setPath(next, rest, value) }
+}
+
+interface FieldUpdate {
+  secrets: Array<{ field: SecretField; value: string }>
+  plains: Array<{ field: PlainField; value: string }>
+}
+
+/**
+ * Reads all secret/plain flags from `options` (skipping undefined ones) and
+ * returns them partitioned. Values passed as `""` are treated as unset.
+ */
+function collectFieldUpdates (options: Record<string, string | number | boolean>): FieldUpdate {
+  const secrets: FieldUpdate['secrets'] = []
+  const plains: FieldUpdate['plains'] = []
+  for (const field of SECRET_FIELDS) {
+    const raw = options[field.flag]
+    if (typeof raw === 'string' && raw.length > 0) {
+      secrets.push({ field, value: raw })
+    }
+  }
+  for (const field of PLAIN_FIELDS) {
+    const raw = options[field.flag]
+    if (typeof raw === 'string' && raw.length > 0) {
+      plains.push({ field, value: raw })
+    }
+  }
+  return { secrets, plains }
+}
+
+/**
+ * Applies `FieldUpdate` on top of `baseContext`, storing secrets via the
+ * provided {@link SecretStore} (or inline when unavailable / `inlineSecrets`).
+ * Returns the new context plus a log of what happened with each secret.
+ */
+interface ApplyFieldUpdatesResult {
+  context: RawContext
+  secretsLog: Array<{ path: string; storage: 'keychain' | 'secret_service' | 'pass' | 'credential_manager' | 'inline' }>
+  warnings: string[]
+}
+
+async function applyFieldUpdates (
+  baseContext: RawContext,
+  updates: FieldUpdate,
+  contextName: string,
+  store: SecretStore,
+  inlineSecrets: boolean
+): Promise<ApplyFieldUpdatesResult> {
+  let ctx = baseContext as Record<string, unknown>
+  const secretsLog: ApplyFieldUpdatesResult['secretsLog'] = []
+  const warnings: string[] = []
+
+  for (const { field, value } of updates.plains) {
+    ctx = setPath(ctx, field.path, value)
+  }
+
+  const storeAvailable = await store.isAvailable()
+  if (updates.secrets.length > 0 && !storeAvailable && !inlineSecrets) {
+    warnings.push(
+      'No OS secret store is available; secrets will be written inline to the config file. ' +
+      'The file will be chmod 0600 on Unix. Pass --inline-secrets to suppress this warning.'
+    )
+  }
+
+  const useStore = storeAvailable && !inlineSecrets
+  for (const { field, value } of updates.secrets) {
+    const account = `${contextName}:${field.path.join('.')}`
+    if (useStore) {
+      await store.put(KEYCHAIN_SERVICE, account, value)
+      const expr = store.resolverExpr(KEYCHAIN_SERVICE, account)
+      ctx = setPath(ctx, field.path, expr)
+      secretsLog.push({ path: field.path.join('.'), storage: store.kind as Exclude<SecretStore['kind'], 'none'> })
+    } else {
+      ctx = setPath(ctx, field.path, value)
+      secretsLog.push({ path: field.path.join('.'), storage: 'inline' })
+    }
+  }
+
+  return { context: ctx as RawContext, secretsLog, warnings }
+}
+
+function getPath (obj: Record<string, unknown>, path: string[]): unknown {
+  let cur: unknown = obj
+  for (const key of path) {
+    if (cur == null || typeof cur !== 'object') return undefined
+    cur = (cur as Record<string, unknown>)[key]
+  }
+  return cur
+}
+
+/**
+ * Deletes all keychain entries associated with `contextName`. Best-effort:
+ * failures are swallowed so a `context remove` never fails because a specific
+ * keychain entry was already deleted.
+ */
+async function purgeContextSecrets (store: SecretStore, contextName: string, ctx: RawContext | undefined): Promise<void> {
+  if (ctx == null) return
+  for (const field of SECRET_FIELDS) {
+    const val = getPath(ctx as Record<string, unknown>, field.path)
+    if (typeof val !== 'string') continue
+    // Only delete keychain entries we wrote (resolver expressions). Inline
+    // values would require parsing, and deleting them would do nothing useful.
+    if (!val.includes('$(')) continue
+    const account = `${contextName}:${field.path.join('.')}`
+    try {
+      await store.delete(KEYCHAIN_SERVICE, account)
+    } catch {
+      // swallow
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command handlers
+// ---------------------------------------------------------------------------
+
+/** Output shape common to add/edit/remove: summary of what happened. */
+interface CommandSummary {
+  configFile: string
+  context: string
+  action: 'added' | 'updated' | 'removed'
+  current: string
+  secrets: Array<{ path: string; storage: string }>
+  warnings: string[]
+}
+
+async function handleContextList (options: Record<string, string | number | boolean>): Promise<JsonValue> {
+  const path = configPathFromOptions(options)
+  const config = await readRawConfig(path)
+  const names = Object.keys(config.contexts)
+  return {
+    configFile: path,
+    current: config.current_context,
+    contexts: names.map(name => ({ name, current: name === config.current_context })),
+  }
+}
+
+async function handleContextAdd (parsed: {
+  options: Record<string, string | number | boolean>
+  arg?: string
+}): Promise<JsonValue> {
+  const { options, arg } = parsed
+  const name = requireName(arg, 'context name')
+  const path = configPathFromOptions(options)
+  const force = options.force === true
+  const inlineSecrets = options['inline-secrets'] === true
+
+  const config = await readRawConfig(path)
+  if (name in config.contexts && !force) {
+    return errorResult('context_exists', `context "${name}" already exists. Pass --force to overwrite.`)
+  }
+
+  const updates = collectFieldUpdates(options)
+  if (updates.plains.length === 0 && updates.secrets.length === 0) {
+    return errorResult(
+      'no_fields',
+      'No context fields provided. Pass at least one of --es-url / --kb-url / --cloud-url (and auth flags).'
+    )
+  }
+
+  const store = await getSecretStore()
+  const { context: ctx, secretsLog, warnings } = await applyFieldUpdates({}, updates, name, store, inlineSecrets)
+
+  const contextValidation = ContextSchema.safeParse(resolveForValidation(ctx))
+  if (!contextValidation.success) {
+    return errorResult('invalid_context', `context validation failed: ${contextValidation.error.issues.map(i => i.message).join('; ')}`)
+  }
+
+  let next = upsertContext(config, name, ctx)
+  if (next.current_context === '') next = setCurrentContext(next, name)
+
+  const result = await writeConfig(path, next, { restrictPermissions: hasInlineSecrets(next) })
+  const summary: CommandSummary = {
+    configFile: result.path,
+    context: name,
+    action: (name in config.contexts) ? 'updated' : 'added',
+    current: next.current_context,
+    secrets: secretsLog,
+    warnings: [...warnings, ...result.warnings],
+  }
+  return summary as unknown as JsonValue
+}
+
+async function handleContextRemove (parsed: {
+  options: Record<string, string | number | boolean>
+  arg?: string
+}): Promise<JsonValue> {
+  const { options, arg } = parsed
+  const name = requireName(arg, 'context name')
+  const path = configPathFromOptions(options)
+  const force = options.force === true
+
+  const config = await readRawConfig(path)
+  if (!(name in config.contexts)) {
+    return errorResult('context_not_found', `context "${name}" not found`)
+  }
+  if (config.current_context === name && !force) {
+    return errorResult(
+      'current_context',
+      `context "${name}" is the current context. Pass --force to remove it anyway.`
+    )
+  }
+
+  const store = await getSecretStore()
+  await purgeContextSecrets(store, name, config.contexts[name])
+
+  const next = removeContext(config, name)
+  if (Object.keys(next.contexts).length === 0) {
+    try { await unlink(path) } catch { /* ignore */ }
+    return {
+      configFile: path,
+      context: name,
+      action: 'removed',
+      current: '',
+      removed_config_file: true,
+    } as JsonValue
+  }
+
+  const result = await writeConfig(path, next, { restrictPermissions: hasInlineSecrets(next) })
+  return {
+    configFile: result.path,
+    context: name,
+    action: 'removed',
+    current: next.current_context,
+    warnings: result.warnings,
+  } as JsonValue
+}
+
+async function handleContextEdit (parsed: {
+  options: Record<string, string | number | boolean>
+  arg?: string
+}): Promise<JsonValue> {
+  const { options, arg } = parsed
+  const name = requireName(arg, 'context name')
+  const path = configPathFromOptions(options)
+  const inlineSecrets = options['inline-secrets'] === true
+
+  const config = await readRawConfig(path)
+  if (!(name in config.contexts)) {
+    return errorResult('context_not_found', `context "${name}" not found`)
+  }
+
+  const updates = collectFieldUpdates(options)
+  const hasFlagEdits = updates.plains.length > 0 || updates.secrets.length > 0
+
+  if (hasFlagEdits) {
+    // Flag-patch mode
+    const store = await getSecretStore()
+    const { context: ctx, secretsLog, warnings } = await applyFieldUpdates(
+      extractContext(config, name),
+      updates,
+      name,
+      store,
+      inlineSecrets,
+    )
+    const validation = ContextSchema.safeParse(resolveForValidation(ctx))
+    if (!validation.success) {
+      return errorResult('invalid_context', `context validation failed: ${validation.error.issues.map(i => i.message).join('; ')}`)
+    }
+    const next = upsertContext(config, name, ctx)
+    const result = await writeConfig(path, next, { restrictPermissions: hasInlineSecrets(next) })
+    return {
+      configFile: result.path,
+      context: name,
+      action: 'updated',
+      current: next.current_context,
+      secrets: secretsLog,
+      warnings: [...warnings, ...result.warnings],
+    } as unknown as JsonValue
+  }
+
+  // $EDITOR mode
+  const original = extractContext(config, name)
+  const edited = await editInEditor(name, original)
+  if (edited == null) {
+    return errorResult('edit_cancelled', 'editor exited non-zero or produced empty content; config unchanged')
+  }
+  const validation = ContextSchema.safeParse(resolveForValidation(edited))
+  if (!validation.success) {
+    return errorResult('invalid_context', `edited context failed validation: ${validation.error.issues.map(i => i.message).join('; ')}`)
+  }
+  const next = upsertContext(config, name, edited)
+  const result = await writeConfig(path, next, { restrictPermissions: hasInlineSecrets(next) })
+  return {
+    configFile: result.path,
+    context: name,
+    action: 'updated',
+    current: next.current_context,
+    warnings: result.warnings,
+  } as JsonValue
+}
+
+async function handleCurrentContextGet (options: Record<string, string | number | boolean>): Promise<JsonValue> {
+  const path = configPathFromOptions(options)
+  const config = await readRawConfig(path)
+  if (!config.current_context) {
+    return errorResult('no_current_context', 'no current_context is set')
+  }
+  return { current: config.current_context } as JsonValue
+}
+
+async function handleCurrentContextSet (parsed: {
+  options: Record<string, string | number | boolean>
+  arg?: string
+}): Promise<JsonValue> {
+  const { options, arg } = parsed
+  const name = requireName(arg, 'context name')
+  const path = configPathFromOptions(options)
+  const config = await readRawConfig(path)
+  if (!(name in config.contexts)) {
+    const available = Object.keys(config.contexts).join(', ') || '(none)'
+    return errorResult('context_not_found', `context "${name}" not found. Available: ${available}`)
+  }
+  const next = setCurrentContext(config, name)
+  const result = await writeConfig(path, next, { restrictPermissions: hasInlineSecrets(next) })
+  return {
+    configFile: result.path,
+    current: name,
+    warnings: result.warnings,
+  } as JsonValue
+}
+
+// ---------------------------------------------------------------------------
+// Helpers used by handlers
+// ---------------------------------------------------------------------------
+
+function requireName (arg: string | undefined, label: string): string {
+  if (arg == null || arg.trim().length === 0) {
+    throw new Error(`${label} is required`)
+  }
+  return arg
+}
+
+/** Returns a factory error envelope (see `formatHandlerError` in output.ts). */
+function errorResult (code: string, message: string): JsonValue {
+  return { error: { code, message } }
+}
+
+/**
+ * Replaces `$(...)` resolver expressions in a context with a placeholder,
+ * so `ContextSchema` can validate the *shape* without actually resolving
+ * secrets. The placeholder is a valid non-empty string.
+ */
+function resolveForValidation (ctx: RawContext): unknown {
+  return walk(ctx) as unknown
+  function walk (v: unknown): unknown {
+    if (typeof v === 'string') return v.includes('$(') ? 'placeholder' : v
+    if (Array.isArray(v)) return v.map(walk)
+    if (v != null && typeof v === 'object') {
+      const out: Record<string, unknown> = {}
+      for (const [k, val] of Object.entries(v)) out[k] = walk(val)
+      return out
+    }
+    return v
+  }
+}
+
+/**
+ * Opens $EDITOR on a single-context YAML fragment. On clean exit, returns
+ * the parsed context; on cancel / empty / error, returns null.
+ */
+async function editInEditor (name: string, original: RawContext): Promise<RawContext | null> {
+  const editor = process.env.EDITOR ?? process.env.VISUAL ?? (process.platform === 'win32' ? 'notepad' : 'vi')
+  const header =
+    `# Editing context "${name}" -- save and exit to apply, or exit with an error to cancel.\n` +
+    `# Any $(...) expressions are preserved as-is.\n` +
+    '# This file will be deleted after editing.\n'
+  const body = stringifyYaml(original, { lineWidth: 0 })
+
+  const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-edit-'))
+  const path = join(dir, `${name}.yml`)
+  try {
+    await writeFile(path, header + body, { encoding: 'utf-8', mode: 0o600 })
+    const exitCode = await new Promise<number>((resolve, reject) => {
+      const child = spawn(editor, [path], { stdio: 'inherit', shell: true })
+      child.on('exit', code => resolve(code ?? 0))
+      child.on('error', reject)
+    })
+    if (exitCode !== 0) return null
+    const content = await readFile(path, 'utf-8')
+    const trimmed = content.replace(/^\s*#[^\n]*\n?/gm, '').trim()
+    if (trimmed.length === 0) return null
+    const parsed = parseYaml(content) as unknown
+    if (parsed == null || typeof parsed !== 'object' || Array.isArray(parsed)) return null
+    return parsed as RawContext
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Command tree
+// ---------------------------------------------------------------------------
+
+const CONFIG_FILE_OPT = {
+  long: 'config-file',
+  type: 'string' as const,
+  description: 'path to the config file to edit (defaults to ~/.elasticrc.yml)',
+}
+
+function fieldOptions (): Array<{ long: string; type: 'string'; description: string }> {
+  return [
+    ...PLAIN_FIELDS.map(f => ({ long: f.flag, type: 'string' as const, description: f.description })),
+    ...SECRET_FIELDS.map(f => ({ long: f.flag, type: 'string' as const, description: `${f.description} (secret -- stored in the OS keychain when available)` })),
+  ]
+}
+
+function buildContextGroup (): OpaqueCommandHandle {
+  const addCmd = defineCommand({
+    name: 'add',
+    description: 'Add a new context to the config file',
+    positionalArg: { name: 'name', description: 'context name', required: true },
+    options: [
+      CONFIG_FILE_OPT,
+      { long: 'force', type: 'boolean', description: 'overwrite an existing context with the same name' },
+      { long: 'inline-secrets', type: 'boolean', description: 'store secrets inline in the config file (instead of the OS keychain)' },
+      ...fieldOptions(),
+    ],
+    handler: async (parsed) => handleContextAdd(parsed),
+  })
+
+  const removeCmd = defineCommand({
+    name: 'remove',
+    description: 'Remove a context from the config file',
+    positionalArg: { name: 'name', description: 'context name', required: true },
+    options: [
+      CONFIG_FILE_OPT,
+      { long: 'force', type: 'boolean', description: 'allow removing the current context' },
+    ],
+    handler: async (parsed) => handleContextRemove(parsed),
+  })
+
+  const editCmd = defineCommand({
+    name: 'edit',
+    description: 'Edit an existing context (flag-patch or $EDITOR mode)',
+    positionalArg: { name: 'name', description: 'context name', required: true },
+    options: [
+      CONFIG_FILE_OPT,
+      { long: 'inline-secrets', type: 'boolean', description: 'store secrets inline in the config file (instead of the OS keychain)' },
+      ...fieldOptions(),
+    ],
+    handler: async (parsed) => handleContextEdit(parsed),
+  })
+
+  const listCmd = defineCommand({
+    name: 'list',
+    description: 'List all contexts defined in the config file',
+    options: [CONFIG_FILE_OPT],
+    handler: async (parsed) => handleContextList(parsed.options),
+  })
+
+  return defineGroup({ name: 'context', description: 'Manage contexts in the elastic config file' }, listCmd, addCmd, editCmd, removeCmd)
+}
+
+function buildCurrentContextGroup (): OpaqueCommandHandle {
+  const setCmd = defineCommand({
+    name: 'set',
+    description: 'Change the current context',
+    positionalArg: { name: 'name', description: 'context name', required: true },
+    options: [CONFIG_FILE_OPT],
+    handler: async (parsed) => handleCurrentContextSet(parsed),
+  })
+
+  const getCmd = defineCommand({
+    name: 'get',
+    description: 'Print the current context name',
+    options: [CONFIG_FILE_OPT],
+    handler: async (parsed) => handleCurrentContextGet(parsed.options),
+  })
+
+  return defineGroup(
+    { name: 'current-context', description: 'View or change the current context' },
+    getCmd,
+    setCmd,
+  )
+}
+
+/**
+ * Builds the top-level `config` command group.
+ */
+export function registerConfigCommands (): OpaqueCommandHandle {
+  return defineGroup(
+    { name: 'config', description: 'Author and maintain the elastic config file' },
+    buildContextGroup(),
+    buildCurrentContextGroup(),
+  )
+}
+

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -25,13 +25,14 @@
  * - Structured error payloads (code + message)
  */
 
-import { access, constants, readFile } from 'node:fs/promises'
+import { access, constants, readFile, stat } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { extname, join } from 'node:path'
 import { z } from 'zod'
 import { parse as parseYaml } from 'yaml'
 import { ContextSchema, CommandPolicySchema, StructuralConfigSchema } from './schema.ts'
 import { resolveExpressions } from '@elastic/config-resolver'
+import { hasInlineSecrets, type RawConfig } from './writer.ts'
 import type { ConfigFile, ResolvedConfig, ResolvedContext } from './types.ts'
 
 /** Extensions that are rejected to prevent arbitrary code execution. */
@@ -114,6 +115,35 @@ export function resolveContext (config: ConfigFile, contextName: string): Resolv
   return result
 }
 
+/**
+ * Emits a stderr warning when `path` is world/group-readable AND contains at
+ * least one unresolved inline secret (password / api_key without `$(...)`).
+ * Silent on Windows (mode bits are not meaningful). Errors are swallowed; a
+ * warning that fails to emit must not block command execution.
+ */
+async function warnOnLoosePermsIfInlineSecrets (path: string, raw: unknown): Promise<void> {
+  if (process.platform === 'win32') return
+  try {
+    const st = await stat(path)
+    const mode = st.mode & 0o777
+    if (mode === 0o600 || mode === 0o400) return
+    if (!isRawConfigLike(raw) || !hasInlineSecrets(raw)) return
+    process.stderr.write(
+      `Warning: config file "${path}" has permissions ${mode.toString(8).padStart(3, '0')} and contains inline secrets. ` +
+      'Run `chmod 0600 ' + path + '` to restrict access, or migrate secrets into the OS keychain via `elastic config context edit`.\n'
+    )
+  } catch {
+    // ignore
+  }
+}
+
+/** Narrows an unknown (just-parsed) value to something `hasInlineSecrets` can walk. */
+function isRawConfigLike (raw: unknown): raw is RawConfig {
+  if (raw == null || typeof raw !== 'object') return false
+  const contexts = (raw as Record<string, unknown>).contexts
+  return contexts != null && typeof contexts === 'object'
+}
+
 /** Options accepted by {@link loadConfig}. */
 export interface LoadConfigOptions {
   /** Explicit path to a config file. Bypasses discovery when set. */
@@ -157,9 +187,9 @@ export async function loadConfig (options: LoadConfigOptions = {}): Promise<Load
   // Step 1: load raw config
   // Precedence: --config-file flag > ELASTIC_CLI_CONFIG_FILE env var > home-directory discovery
   let raw: unknown
+  let resolvedPath: string | null
   try {
     const envConfigFile = process.env[ENV_CONFIG_FILE]
-    let resolvedPath: string | null
     if (configPath != null) {
       resolvedPath = configPath
     } else if (envConfigFile != null && envConfigFile.length > 0) {
@@ -179,6 +209,11 @@ export async function loadConfig (options: LoadConfigOptions = {}): Promise<Load
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     return { ok: false, error: { message } }
+  }
+
+  // Warn (stderr only) when the file has inline secrets AND looser-than-0600 perms.
+  if (resolvedPath != null) {
+    await warnOnLoosePermsIfInlineSecrets(resolvedPath, raw)
   }
 
   // Step 2: structural validation (shape only, no deep context validation)

--- a/src/config/secret-store.ts
+++ b/src/config/secret-store.ts
@@ -1,0 +1,367 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * OS-level secret storage abstraction.
+ *
+ * Mirrors the read-side resolvers in {@link ./resolvers.ts} but for writes.
+ * Implementations shell out to platform-native tools:
+ *   - macOS:   `security` (Keychain Access)
+ *   - Linux:   `secret-tool` (libsecret)
+ *   - pass:    `pass` (the standard unix password manager)
+ *   - Windows: PowerShell CredentialManager module
+ *
+ * Each implementation exposes `put` / `delete` / `isAvailable` and produces a
+ * resolver-expression string that, when placed in the YAML config, will be
+ * read back by the corresponding resolver.
+ */
+
+import { execSync, type ExecSyncOptionsWithStringEncoding } from 'node:child_process'
+
+/** Distinguishes between the supported secret-store implementations. */
+export type SecretStoreKind =
+  | 'keychain'
+  | 'secret_service'
+  | 'pass'
+  | 'credential_manager'
+  | 'none'
+
+/**
+ * Writeable secret store. Read is delegated to the matching resolver in
+ * `resolvers.ts`; `resolverExpr` produces the `$(...)` string to place in YAML.
+ */
+export interface SecretStore {
+  kind: SecretStoreKind
+  /** Cheap probe for the backing tool's presence. Cached per-instance. */
+  isAvailable(): Promise<boolean>
+  /**
+   * Stores `secret` under `(service, account)`. Overwrites silently on
+   * existing entries (policy lives one layer up in the command handlers).
+   */
+  put(service: string, account: string, secret: string): Promise<void>
+  /**
+   * Removes the entry. Idempotent: absent entries succeed.
+   */
+  delete(service: string, account: string): Promise<void>
+  /** YAML expression string (e.g. `$(keychain:elastic-cli/prod:es.api_key)`). */
+  resolverExpr(service: string, account: string): string
+}
+
+const PRINTABLE_ASCII_RE = /^[\x20-\x7e]+$/
+
+function validateServiceAccount (service: string, account: string, kind: SecretStoreKind): void {
+  for (const [field, value] of [['service', service], ['account', account]] as const) {
+    if (value.length === 0) {
+      throw new Error(`Invalid ${kind} ${field}: must not be empty`)
+    }
+    if (!PRINTABLE_ASCII_RE.test(value)) {
+      throw new Error(
+        `Invalid ${kind} ${field} "${value}": contains non-printable characters`
+      )
+    }
+    if (value.includes('/')) {
+      throw new Error(
+        `Invalid ${kind} ${field} "${value}": must not contain "/"`
+      )
+    }
+  }
+}
+
+function execOpts (timeoutMs: number, input?: string): ExecSyncOptionsWithStringEncoding & { input?: string } {
+  const opts: ExecSyncOptionsWithStringEncoding & { input?: string } = {
+    encoding: 'utf-8',
+    timeout: timeoutMs,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
+  }
+  if (input !== undefined) opts.input = input
+  return opts
+}
+
+function shellEscape (value: string): string {
+  return "'" + value.replace(/'/g, "'\\''") + "'"
+}
+
+function psEncodedCommand (expression: string): string {
+  const utf16le = Buffer.from(expression, 'utf16le')
+  return `powershell -NoProfile -NonInteractive -EncodedCommand ${utf16le.toString('base64')}`
+}
+
+// ---------------------------------------------------------------------------
+// Test seams
+// ---------------------------------------------------------------------------
+
+let _execSync: typeof execSync = execSync
+let _platform: string = process.platform
+
+/** @internal */
+export function _testSetExecSync (fn: typeof execSync): () => void {
+  const prev = _execSync
+  _execSync = fn
+  return () => { _execSync = prev }
+}
+
+/** @internal */
+export function _testSetPlatform (p: string): () => void {
+  const prev = _platform
+  _platform = p
+  return () => { _platform = prev }
+}
+
+// ---------------------------------------------------------------------------
+// Implementations
+// ---------------------------------------------------------------------------
+
+abstract class ShellSecretStore implements SecretStore {
+  abstract kind: SecretStoreKind
+  private availability: boolean | undefined
+
+  async isAvailable (): Promise<boolean> {
+    if (this.availability !== undefined) return this.availability
+    try {
+      this.probe()
+      this.availability = true
+    } catch {
+      this.availability = false
+    }
+    return this.availability
+  }
+
+  protected abstract probe(): void
+  abstract put(service: string, account: string, secret: string): Promise<void>
+  abstract delete(service: string, account: string): Promise<void>
+  abstract resolverExpr(service: string, account: string): string
+}
+
+class MacOSKeychainStore extends ShellSecretStore {
+  kind = 'keychain' as const
+
+  protected probe (): void {
+    _execSync('security -h', execOpts(2_000))
+  }
+
+  async put (service: string, account: string, secret: string): Promise<void> {
+    validateServiceAccount(service, account, this.kind)
+    try {
+      // -U updates an existing entry in-place instead of failing.
+      // Use -w with the value as an argument; `security` supports reading from
+      // stdin via `-w` with no value, but argv is simpler and the value is
+      // ASCII-safe after validation.
+      _execSync(
+        `security add-generic-password -U -s ${shellEscape(service)} -a ${shellEscape(account)} -w ${shellEscape(secret)}`,
+        execOpts(5_000)
+      )
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(`Keychain write failed for service="${service}", account="${account}": ${message}`, { cause: err })
+    }
+  }
+
+  async delete (service: string, account: string): Promise<void> {
+    validateServiceAccount(service, account, this.kind)
+    try {
+      _execSync(
+        `security delete-generic-password -s ${shellEscape(service)} -a ${shellEscape(account)}`,
+        execOpts(5_000)
+      )
+    } catch {
+      // Idempotent: absent entries exit non-zero but are not an error.
+    }
+  }
+
+  resolverExpr (service: string, account: string): string {
+    validateServiceAccount(service, account, this.kind)
+    return `$(keychain:${service}/${account})`
+  }
+}
+
+class LinuxSecretServiceStore extends ShellSecretStore {
+  kind = 'secret_service' as const
+
+  protected probe (): void {
+    _execSync('secret-tool --version', execOpts(2_000))
+  }
+
+  async put (service: string, account: string, secret: string): Promise<void> {
+    validateServiceAccount(service, account, this.kind)
+    try {
+      _execSync(
+        `secret-tool store --label=${shellEscape(`elastic-cli:${service}:${account}`)} service ${shellEscape(service)} account ${shellEscape(account)}`,
+        execOpts(5_000, secret)
+      )
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(`Secret Service write failed for service="${service}", account="${account}": ${message}`, { cause: err })
+    }
+  }
+
+  async delete (service: string, account: string): Promise<void> {
+    validateServiceAccount(service, account, this.kind)
+    try {
+      _execSync(
+        `secret-tool clear service ${shellEscape(service)} account ${shellEscape(account)}`,
+        execOpts(5_000)
+      )
+    } catch {
+      // Idempotent.
+    }
+  }
+
+  resolverExpr (service: string, account: string): string {
+    validateServiceAccount(service, account, this.kind)
+    return `$(secret_service:${service}/${account})`
+  }
+}
+
+class PassStore extends ShellSecretStore {
+  kind = 'pass' as const
+
+  protected probe (): void {
+    _execSync('pass version', execOpts(2_000))
+  }
+
+  private passPath (service: string, account: string): string {
+    return `${service}/${account}`
+  }
+
+  async put (service: string, account: string, secret: string): Promise<void> {
+    validateServiceAccount(service, account, this.kind)
+    const path = this.passPath(service, account)
+    try {
+      // `pass insert -m -f <path>` reads a multi-line password from stdin and
+      // overwrites any existing entry without prompting.
+      _execSync(`pass insert -m -f ${shellEscape(path)}`, execOpts(5_000, secret + '\n'))
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(`pass write failed for "${path}": ${message}`, { cause: err })
+    }
+  }
+
+  async delete (service: string, account: string): Promise<void> {
+    validateServiceAccount(service, account, this.kind)
+    const path = this.passPath(service, account)
+    try {
+      _execSync(`pass rm -f ${shellEscape(path)}`, execOpts(5_000))
+    } catch {
+      // Idempotent.
+    }
+  }
+
+  resolverExpr (service: string, account: string): string {
+    validateServiceAccount(service, account, this.kind)
+    return `$(pass:${this.passPath(service, account)})`
+  }
+}
+
+class WindowsCredentialManagerStore extends ShellSecretStore {
+  kind = 'credential_manager' as const
+
+  protected probe (): void {
+    // CredentialManager is a community PowerShell module. Probe for
+    // `Get-Command New-StoredCredential` — cheaper than loading the module.
+    _execSync(
+      psEncodedCommand('if (-not (Get-Command New-StoredCredential -ErrorAction SilentlyContinue)) { exit 1 }'),
+      execOpts(5_000)
+    )
+  }
+
+  private target (service: string, account: string): string {
+    return `${service}/${account}`
+  }
+
+  async put (service: string, account: string, secret: string): Promise<void> {
+    validateServiceAccount(service, account, this.kind)
+    const target = this.target(service, account).replace(/'/g, "''")
+    const user = account.replace(/'/g, "''")
+    const pass = secret.replace(/'/g, "''")
+    const expression =
+      `$secure = ConvertTo-SecureString -String '${pass}' -AsPlainText -Force; ` +
+      `New-StoredCredential -Target '${target}' -UserName '${user}' -SecurePassword $secure -Persist LocalMachine | Out-Null`
+    try {
+      _execSync(psEncodedCommand(expression), execOpts(10_000))
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      throw new Error(`Credential Manager write failed for service="${service}", account="${account}": ${message}`, { cause: err })
+    }
+  }
+
+  async delete (service: string, account: string): Promise<void> {
+    validateServiceAccount(service, account, this.kind)
+    const target = this.target(service, account).replace(/'/g, "''")
+    try {
+      _execSync(
+        psEncodedCommand(`Remove-StoredCredential -Target '${target}' -ErrorAction SilentlyContinue`),
+        execOpts(10_000)
+      )
+    } catch {
+      // Idempotent.
+    }
+  }
+
+  resolverExpr (service: string, account: string): string {
+    validateServiceAccount(service, account, this.kind)
+    return `$(credential_manager:${this.target(service, account)})`
+  }
+}
+
+class NoopStore implements SecretStore {
+  kind = 'none' as const
+  async isAvailable (): Promise<boolean> { return false }
+  async put (): Promise<void> {
+    throw new Error('No OS secret store is available on this system. Re-run with --inline-secrets to write credentials to the config file (they will be stored in plain text).')
+  }
+  async delete (): Promise<void> { /* nothing to delete */ }
+  resolverExpr (): string {
+    throw new Error('No OS secret store is available: cannot produce a resolver expression')
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the first available secret store for the current platform.
+ *
+ * Probe order:
+ *   - darwin: Keychain
+ *   - linux:  secret-tool → pass
+ *   - win32:  CredentialManager
+ *   - other:  pass (best effort)
+ *
+ * Falls back to a {@link NoopStore} if none are available.
+ */
+export async function getSecretStore (): Promise<SecretStore> {
+  const candidates = candidatesForPlatform(_platform)
+  for (const store of candidates) {
+    if (await store.isAvailable()) return store
+  }
+  return new NoopStore()
+}
+
+function candidatesForPlatform (platform: string): SecretStore[] {
+  switch (platform) {
+    case 'darwin':
+      return [new MacOSKeychainStore()]
+    case 'linux':
+      return [new LinuxSecretServiceStore(), new PassStore()]
+    case 'win32':
+      return [new WindowsCredentialManagerStore()]
+    default:
+      return [new PassStore()]
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Exports for tests
+// ---------------------------------------------------------------------------
+
+export const _testStores = {
+  MacOSKeychainStore,
+  LinuxSecretServiceStore,
+  PassStore,
+  WindowsCredentialManagerStore,
+  NoopStore,
+}

--- a/src/config/writer.ts
+++ b/src/config/writer.ts
@@ -1,0 +1,320 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Config file writer + pure helpers for immutable updates to a RawConfig.
+ *
+ * Loading uses {@link ./schema.ts} (two-pass: structural, then deep) and
+ * resolves `$(...)` expressions. Writing is the reverse: we author a YAML
+ * file that may contain `$(...)` expressions pointing at the secret store,
+ * validate its structure, and persist with restrictive permissions.
+ *
+ * All mutation helpers return new objects — never modify inputs.
+ */
+
+import { chmod, mkdir, rename, stat, writeFile, unlink } from 'node:fs/promises'
+import { execSync, type ExecSyncOptionsWithStringEncoding } from 'node:child_process'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { randomBytes } from 'node:crypto'
+import { stringify as stringifyYaml, parse as parseYaml } from 'yaml'
+
+/**
+ * Raw, pre-resolution shape of a config file. `unknown` leaf values are
+ * permitted so `$(...)` expression strings sit alongside real data.
+ */
+export interface RawConfig {
+  current_context: string
+  contexts: Record<string, RawContext>
+  commands?: unknown
+  [key: string]: unknown
+}
+
+/** Raw, pre-resolution shape of a single context. */
+export type RawContext = Record<string, unknown>
+
+// ---------------------------------------------------------------------------
+// Test seams
+// ---------------------------------------------------------------------------
+
+let _execSync: typeof execSync = execSync
+let _platform: string = process.platform
+
+/** @internal */
+export function _testSetExecSync (fn: typeof execSync): () => void {
+  const prev = _execSync
+  _execSync = fn
+  return () => { _execSync = prev }
+}
+
+/** @internal */
+export function _testSetPlatform (p: string): () => void {
+  const prev = _platform
+  _platform = p
+  return () => { _platform = prev }
+}
+
+function execOpts (timeoutMs: number): ExecSyncOptionsWithStringEncoding {
+  return { encoding: 'utf-8', timeout: timeoutMs, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a new config with `contextData` stored under `name` in `contexts`.
+ * Overwrite unconditional — policy (error on collision, etc.) lives in the
+ * command handler.
+ */
+export function upsertContext (config: RawConfig, name: string, contextData: RawContext): RawConfig {
+  return {
+    ...config,
+    contexts: { ...config.contexts, [name]: { ...contextData } },
+  }
+}
+
+/**
+ * Returns a new config with `name` removed from `contexts`.
+ * If the removed context was `current_context`, that field is cleared (empty
+ * string); callers are responsible for choosing a replacement or writing an
+ * empty config.
+ */
+export function removeContext (config: RawConfig, name: string): RawConfig {
+  if (!(name in config.contexts)) return config
+  const next: Record<string, RawContext> = {}
+  for (const [k, v] of Object.entries(config.contexts)) {
+    if (k !== name) next[k] = v
+  }
+  const result: RawConfig = { ...config, contexts: next }
+  if (config.current_context === name) {
+    result.current_context = ''
+  }
+  return result
+}
+
+/**
+ * Returns a new config with `current_context` set to `name`.
+ * @throws when `name` is not a known context key.
+ */
+export function setCurrentContext (config: RawConfig, name: string): RawConfig {
+  if (!(name in config.contexts)) {
+    const available = Object.keys(config.contexts).join(', ')
+    throw new Error(
+      `Cannot set current_context to "${name}": not found. Available contexts: ${available || '(none)'}`
+    )
+  }
+  return { ...config, current_context: name }
+}
+
+/**
+ * Pulls a single context out of a config. Caller mutates the returned
+ * object, then merges back via {@link upsertContext}.
+ */
+export function extractContext (config: RawConfig, name: string): RawContext {
+  const ctx = config.contexts[name]
+  if (ctx == null) {
+    const available = Object.keys(config.contexts).join(', ')
+    throw new Error(`Context "${name}" not found. Available contexts: ${available || '(none)'}`)
+  }
+  return ctx
+}
+
+/**
+ * Creates an empty-but-valid skeleton config used as the starting point
+ * when no config file exists yet.
+ */
+export function emptyConfig (): RawConfig {
+  return { current_context: '', contexts: {} }
+}
+
+/**
+ * Auth field names that hold secrets. Shared between the writer, the config
+ * command handlers, the loader (perms warning), and the cloud credential
+ * policy so new secret fields only need to be added here once.
+ */
+export const SECRET_AUTH_FIELDS = new Set(['password', 'api_key'])
+
+/**
+ * Returns true when any context in `config` holds a secret value inline
+ * (i.e. a non-empty string that is not a `$(...)` resolver expression).
+ * Walks every service block dynamically, so it stays correct as new
+ * service blocks are added to the schema.
+ */
+export function hasInlineSecrets (config: RawConfig): boolean {
+  for (const ctx of Object.values(config.contexts)) {
+    if (ctx == null || typeof ctx !== 'object') continue
+    for (const block of Object.values(ctx as Record<string, unknown>)) {
+      if (block == null || typeof block !== 'object') continue
+      const auth = (block as Record<string, unknown>).auth
+      if (auth == null || typeof auth !== 'object') continue
+      for (const [k, v] of Object.entries(auth)) {
+        if (!SECRET_AUTH_FIELDS.has(k)) continue
+        if (typeof v === 'string' && v.length > 0 && !v.includes('$(')) return true
+      }
+    }
+  }
+  return false
+}
+
+/**
+ * Resolves the path to the config file the CLI will read or write.
+ *
+ * Precedence:
+ *   1. explicit `--config-file` argument (if a non-empty string)
+ *   2. `ELASTIC_CLI_CONFIG_FILE` env var (if set and non-empty)
+ *   3. `~/.elasticrc.yml`
+ *
+ * Kept here (not in loader.ts) because write-side callers in `commands.ts`
+ * and `cloud/credentials.ts` need it without importing the full loader.
+ */
+export function resolveConfigPath (explicit?: string): string {
+  if (typeof explicit === 'string' && explicit.length > 0) return explicit
+  const env = process.env.ELASTIC_CLI_CONFIG_FILE
+  if (typeof env === 'string' && env.length > 0) return env
+  return join(homedir(), '.elasticrc.yml')
+}
+
+// ---------------------------------------------------------------------------
+// Serialization + write
+// ---------------------------------------------------------------------------
+
+export interface WriteConfigOptions {
+  /** Attempt to enforce 0600 perms (Unix chmod / Windows ACL). Default: true. */
+  restrictPermissions?: boolean
+  /** Create parent directories if missing. Default: true. */
+  createParentDirs?: boolean
+}
+
+export interface WriteConfigResult {
+  path: string
+  permsEnforced: boolean
+  warnings: string[]
+}
+
+/**
+ * Atomically writes `config` to `path` as YAML.
+ *
+ * Process:
+ *   1. Structurally validate the incoming config (so we never write junk).
+ *   2. Serialize with stable key order.
+ *   3. Write to a sibling tempfile, chmod 0600 *before* rename (Unix) so the
+ *      permissions window never exposes readable content.
+ *   4. On Unix: stat after rename; emit a warning if perms ended up wider.
+ *   5. On Windows: best-effort ACL tightening via `icacls`; warn on failure.
+ */
+export async function writeConfig (
+  path: string,
+  config: RawConfig,
+  options: WriteConfigOptions = {}
+): Promise<WriteConfigResult> {
+  const { restrictPermissions = true, createParentDirs = true } = options
+
+  // Callers (command handlers) own config validity; deep validation happens at
+  // load time via ContextSchema after expression resolution.
+
+  if (createParentDirs) {
+    await mkdir(dirname(path), { recursive: true })
+  }
+
+  const yaml = serializeConfig(config)
+  const warnings: string[] = []
+
+  const tmp = join(dirname(path), `.${basename(path)}.${randomBytes(4).toString('hex')}.tmp`)
+  let permsEnforced = false
+
+  try {
+    await writeFile(tmp, yaml, { encoding: 'utf-8', mode: 0o600 })
+    if (restrictPermissions && _platform !== 'win32') {
+      await chmod(tmp, 0o600)
+    }
+    await rename(tmp, path)
+
+    if (restrictPermissions) {
+      if (_platform === 'win32') {
+        try {
+          _execSync(
+            `icacls "${path}" /inheritance:r /grant:r "%USERNAME%":F`,
+            execOpts(5_000)
+          )
+          permsEnforced = true
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          warnings.push(`Could not restrict permissions on "${path}" via icacls: ${msg}`)
+        }
+      } else {
+        await chmod(path, 0o600)
+        const st = await stat(path)
+        const mode = st.mode & 0o777
+        if (mode === 0o600) {
+          permsEnforced = true
+        } else {
+          warnings.push(
+            `Config file "${path}" has permissions ${mode.toString(8).padStart(3, '0')} (expected 0600). ` +
+            'The filesystem may not support Unix permissions.'
+          )
+        }
+      }
+    }
+  } catch (err) {
+    try { await unlink(tmp) } catch { /* ignore */ }
+    throw err
+  }
+
+  return { path, permsEnforced, warnings }
+}
+
+function basename (p: string): string {
+  const i = p.lastIndexOf('/')
+  const j = p.lastIndexOf('\\')
+  const k = Math.max(i, j)
+  return k === -1 ? p : p.slice(k + 1)
+}
+
+/**
+ * YAML serializer. Keeps a stable top-level key order
+ * (`current_context`, `contexts`, `commands`) so round-trips produce diffs
+ * limited to the fields that actually changed.
+ */
+export function serializeConfig (config: RawConfig): string {
+  const ordered: Record<string, unknown> = {}
+  ordered.current_context = config.current_context
+  ordered.contexts = config.contexts
+  if (config.commands != null) ordered.commands = config.commands
+  for (const [k, v] of Object.entries(config)) {
+    if (k === 'current_context' || k === 'contexts' || k === 'commands') continue
+    ordered[k] = v
+  }
+  return stringifyYaml(ordered, { lineWidth: 0 })
+}
+
+/**
+ * Reads a config file from disk and returns the raw (pre-resolution) shape.
+ * Use this before calling the `upsert/remove/setCurrent/extract` helpers.
+ *
+ * Returns {@link emptyConfig} if the file does not exist, so callers can
+ * treat "no config yet" as a first-use path rather than an error.
+ */
+export async function readRawConfig (path: string): Promise<RawConfig> {
+  const { readFile } = await import('node:fs/promises')
+  let content: string
+  try {
+    content = await readFile(path, 'utf-8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return emptyConfig()
+    throw err
+  }
+  const parsed = parseYaml(content) as unknown
+  if (parsed == null || typeof parsed !== 'object') return emptyConfig()
+  // Coerce to RawConfig shape; downstream validation happens at load time.
+  const obj = parsed as Partial<RawConfig>
+  return {
+    current_context: typeof obj.current_context === 'string' ? obj.current_context : '',
+    contexts: (obj.contexts != null && typeof obj.contexts === 'object')
+      ? obj.contexts as Record<string, RawContext>
+      : {},
+    ...(obj.commands != null ? { commands: obj.commands } : {}),
+  }
+}

--- a/test/cloud/credentials.test.ts
+++ b/test/cloud/credentials.test.ts
@@ -1,0 +1,280 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, before, after, beforeEach } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { parse as parseYaml } from 'yaml'
+import {
+  applyCredentialPolicy,
+  extractProjectFields,
+  isCredentialCommand,
+  isResetCredentialsCommand,
+  readCredentialPolicyOptions,
+  redactCredentials,
+} from '../../src/cloud/credentials.ts'
+import type { JsonValue } from '../../src/factory.ts'
+import {
+  _testSetExecSync as setSecretStoreExec,
+  _testSetPlatform as setSecretStorePlatform,
+} from '../../src/config/secret-store.ts'
+
+const CREATE_RESPONSE: JsonValue = {
+  id: 'p-123',
+  name: 'scratch-es',
+  type: 'elasticsearch',
+  region_id: 'aws-us-east-1',
+  endpoints: {
+    elasticsearch: 'https://p-123.es.us-east-1.aws.elastic.cloud',
+    kibana: 'https://p-123.kb.us-east-1.aws.elastic.cloud',
+  },
+  credentials: {
+    username: 'admin',
+    password: 'super-secret-admin-pass',
+  },
+}
+
+const RESET_RESPONSE: JsonValue = {
+  credentials: {
+    username: 'admin',
+    password: 'new-rotated-password',
+  },
+}
+
+describe('isCredentialCommand / isResetCredentialsCommand', () => {
+  it('matches create + reset across all three project types', () => {
+    for (const prefix of ['elasticsearch', 'observability', 'security']) {
+      assert.equal(isCredentialCommand(`create-${prefix}-project`), true)
+      assert.equal(isCredentialCommand(`reset-${prefix}-project-credentials`), true)
+      assert.equal(isResetCredentialsCommand(`reset-${prefix}-project-credentials`), true)
+    }
+  })
+  it('does not match list / get / patch / delete', () => {
+    for (const n of ['list-elasticsearch-projects', 'get-elasticsearch-project', 'patch-elasticsearch-project', 'delete-elasticsearch-project']) {
+      assert.equal(isCredentialCommand(n), false)
+    }
+  })
+})
+
+describe('extractProjectFields', () => {
+  it('pulls id, endpoints, and credentials from a create response', () => {
+    const x = extractProjectFields(CREATE_RESPONSE)
+    assert.equal(x.id, 'p-123')
+    assert.equal(x.endpoints.elasticsearch, 'https://p-123.es.us-east-1.aws.elastic.cloud')
+    assert.equal(x.credentials.username, 'admin')
+    assert.equal(x.credentials.password, 'super-secret-admin-pass')
+  })
+
+  it('pulls only credentials from a reset response', () => {
+    const x = extractProjectFields(RESET_RESPONSE)
+    assert.equal(x.id, undefined)
+    assert.equal(x.endpoints.elasticsearch, undefined)
+    assert.equal(x.credentials.password, 'new-rotated-password')
+  })
+
+  it('tolerates flat {username, password} responses', () => {
+    const x = extractProjectFields({ username: 'admin', password: 'flat' } as JsonValue)
+    assert.equal(x.credentials.password, 'flat')
+  })
+
+  it('returns empty shape for non-objects', () => {
+    const x = extractProjectFields('not-an-object' as unknown as JsonValue)
+    assert.deepEqual(x, { credentials: {}, endpoints: {} })
+  })
+})
+
+describe('redactCredentials', () => {
+  it('replaces password with a marker and keeps username', () => {
+    const out = redactCredentials(CREATE_RESPONSE, '(saved)') as { credentials: { password: string; username: string } }
+    assert.equal(out.credentials.password, '(saved)')
+    assert.equal(out.credentials.username, 'admin')
+  })
+
+  it('handles flat-shape responses', () => {
+    const out = redactCredentials({ username: 'admin', password: 'x' } as JsonValue, '(saved)') as { password: string; username: string }
+    assert.equal(out.password, '(saved)')
+    assert.equal(out.username, 'admin')
+  })
+
+  it('is a no-op for non-objects', () => {
+    assert.equal(redactCredentials('hi' as unknown as JsonValue, '(saved)'), 'hi')
+  })
+})
+
+describe('readCredentialPolicyOptions', () => {
+  it('extracts all four flags', () => {
+    const opts = readCredentialPolicyOptions({
+      'save-as': 'prod',
+      'credentials-file': '/tmp/c.yml',
+      'force': true,
+      'config-file': '/tmp/cfg.yml',
+      'irrelevant': 'x',
+    })
+    assert.deepEqual(opts, { saveAs: 'prod', credentialsFile: '/tmp/c.yml', force: true, configFile: '/tmp/cfg.yml' })
+  })
+
+  it('skips empty strings', () => {
+    const opts = readCredentialPolicyOptions({ 'save-as': '' })
+    assert.deepEqual(opts, {})
+  })
+})
+
+describe('applyCredentialPolicy', () => {
+  let dir: string
+  const restores: Array<() => void> = []
+
+  before(async () => { dir = await mkdtemp(join(tmpdir(), 'elastic-cli-cred-policy-')) })
+  after(async () => rm(dir, { recursive: true, force: true }))
+
+  beforeEach(() => {
+    while (restores.length > 0) restores.pop()!()
+  })
+
+  function stubSecretStore (kind: 'keychain' | 'none'): Array<{ cmd: string; options: unknown }> {
+    const calls: Array<{ cmd: string; options: unknown }> = []
+    if (kind === 'keychain') {
+      restores.push(setSecretStorePlatform('darwin'))
+      restores.push(setSecretStoreExec(((cmd: string, options?: unknown) => {
+        calls.push({ cmd, options })
+        return ''
+      }) as unknown as typeof import('node:child_process').execSync))
+    } else {
+      restores.push(setSecretStorePlatform('linux'))
+      restores.push(setSecretStoreExec(((cmd: string, options?: unknown) => {
+        calls.push({ cmd, options })
+        throw new Error('not installed')
+      }) as unknown as typeof import('node:child_process').execSync))
+    }
+    return calls
+  }
+
+  it('passthrough when no relevant flags are set', async () => {
+    const res = await applyCredentialPolicy('create-elasticsearch-project', CREATE_RESPONSE, {})
+    assert.equal(res.log.mode, 'passthrough')
+    assert.deepEqual(res.body, CREATE_RESPONSE)
+  })
+
+  it('--save-as writes a context, redacts the response, and stores the password in the keychain', async () => {
+    const cfg = join(dir, 'save-as-keychain.yml')
+    const calls = stubSecretStore('keychain')
+    const res = await applyCredentialPolicy('create-elasticsearch-project', CREATE_RESPONSE, {
+      saveAs: 'scratch',
+      configFile: cfg,
+    })
+
+    // stdout redaction
+    const body = res.body as { credentials: { password: string; username: string }; savedAs: string; configFile: string }
+    assert.equal(body.credentials.password, '(saved to keychain)')
+    assert.equal(body.credentials.username, 'admin')
+    assert.equal(body.savedAs, 'scratch')
+    assert.equal(body.configFile, cfg)
+
+    // YAML written with $(keychain:...) expressions
+    const yaml = await readFile(cfg, 'utf-8')
+    const parsed = parseYaml(yaml) as { contexts: { scratch: { elasticsearch: { auth: { password: string } } } } }
+    assert.match(
+      parsed.contexts.scratch.elasticsearch.auth.password,
+      /^\$\(keychain:elastic-cli\/scratch:elasticsearch\.auth\.password\)$/
+    )
+
+    // keychain put was called for both elasticsearch + kibana passwords
+    assert.ok(calls.some(c => (c.cmd as string).includes('elasticsearch.auth.password')))
+    assert.ok(calls.some(c => (c.cmd as string).includes('kibana.auth.password')))
+  })
+
+  it('--save-as without --force on an existing context throws', async () => {
+    const cfg = join(dir, 'collision.yml')
+    stubSecretStore('keychain')
+    await applyCredentialPolicy('create-elasticsearch-project', CREATE_RESPONSE, { saveAs: 'only', configFile: cfg })
+    await assert.rejects(
+      () => applyCredentialPolicy('create-elasticsearch-project', CREATE_RESPONSE, { saveAs: 'only', configFile: cfg }),
+      /already exists/
+    )
+  })
+
+  it('--save-as --force overwrites', async () => {
+    const cfg = join(dir, 'overwrite.yml')
+    stubSecretStore('keychain')
+    await applyCredentialPolicy('create-elasticsearch-project', CREATE_RESPONSE, { saveAs: 'x', configFile: cfg })
+    const res = await applyCredentialPolicy('create-elasticsearch-project', CREATE_RESPONSE, {
+      saveAs: 'x', configFile: cfg, force: true,
+    })
+    assert.equal(res.log.mode, 'save-as')
+  })
+
+  it('reset-credentials --save-as updates an existing context', async () => {
+    const cfg = join(dir, 'reset.yml')
+    stubSecretStore('keychain')
+    // seed the context via create
+    await applyCredentialPolicy('create-elasticsearch-project', CREATE_RESPONSE, { saveAs: 'live', configFile: cfg })
+    // rotate
+    const res = await applyCredentialPolicy('reset-elasticsearch-project-credentials', RESET_RESPONSE, {
+      saveAs: 'live', configFile: cfg,
+    })
+    assert.equal(res.log.mode, 'save-as')
+    const yaml = await readFile(cfg, 'utf-8')
+    const parsed = parseYaml(yaml) as { contexts: { live: { elasticsearch: { url: string; auth: { password: string } } } } }
+    // URL unchanged, password still a $(keychain:...) expression
+    assert.equal(parsed.contexts.live.elasticsearch.url, 'https://p-123.es.us-east-1.aws.elastic.cloud')
+    assert.match(parsed.contexts.live.elasticsearch.auth.password, /^\$\(keychain:/)
+  })
+
+  it('reset-credentials --save-as on an unknown context errors clearly', async () => {
+    const cfg = join(dir, 'reset-missing.yml')
+    stubSecretStore('keychain')
+    await assert.rejects(
+      () => applyCredentialPolicy('reset-elasticsearch-project-credentials', RESET_RESPONSE, { saveAs: 'ghost', configFile: cfg }),
+      /requires an existing context/
+    )
+  })
+
+  it('--credentials-file writes a standalone fragment', async () => {
+    const cfg = join(dir, 'main.yml')
+    const frag = join(dir, 'fragment.yml')
+    stubSecretStore('keychain')
+    const res = await applyCredentialPolicy('create-elasticsearch-project', CREATE_RESPONSE, {
+      credentialsFile: frag, configFile: cfg,
+    })
+    assert.equal(res.log.mode, 'credentials-file')
+    const body = res.body as { credentialsFile: string }
+    assert.equal(body.credentialsFile, frag)
+    const yaml = await readFile(frag, 'utf-8')
+    const parsed = parseYaml(yaml) as { current_context: string; contexts: Record<string, unknown> }
+    assert.ok(parsed.current_context.length > 0)
+  })
+
+  it('falls back to inline secrets when no keychain is available and warns', async () => {
+    const cfg = join(dir, 'no-keychain.yml')
+    stubSecretStore('none')
+    const res = await applyCredentialPolicy('create-elasticsearch-project', CREATE_RESPONSE, {
+      saveAs: 'inline-fallback', configFile: cfg,
+    })
+    assert.equal(res.log.mode, 'save-as')
+    assert.ok(res.log.warnings.some(w => /No OS secret store/i.test(w)))
+    const yaml = await readFile(cfg, 'utf-8')
+    const parsed = parseYaml(yaml) as { contexts: { 'inline-fallback': { elasticsearch: { auth: { password: string } } } } }
+    assert.equal(parsed.contexts['inline-fallback'].elasticsearch.auth.password, 'super-secret-admin-pass')
+    // stdout redaction marker reflects the actual storage path — inline, not keychain
+    const body = res.body as { credentials: { password: string } }
+    assert.equal(body.credentials.password, '(saved inline to config)')
+  })
+
+  it('passthrough when response has no password field', async () => {
+    const res = await applyCredentialPolicy('create-elasticsearch-project', { id: 'no-creds' } as JsonValue, { saveAs: 'nope' })
+    assert.equal(res.log.mode, 'passthrough')
+  })
+
+  it('--credentials-file refuses existing file without --force', async () => {
+    const frag = join(dir, 'already-there.yml')
+    stubSecretStore('keychain')
+    await applyCredentialPolicy('create-elasticsearch-project', CREATE_RESPONSE, { credentialsFile: frag })
+    await assert.rejects(
+      () => applyCredentialPolicy('create-elasticsearch-project', CREATE_RESPONSE, { credentialsFile: frag }),
+      /already exists/
+    )
+  })
+})

--- a/test/config/commands.test.ts
+++ b/test/config/commands.test.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { tmpdir } from 'node:os'
+
+const CLI = resolve('dist/cli.js')
+
+interface CliResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+  json?: unknown
+}
+
+function run (args: string[], env: Record<string, string> = {}): CliResult {
+  const res = spawnSync('node', [CLI, ...args, '--json'], {
+    encoding: 'utf-8',
+    env: { ...process.env, ...env },
+  })
+  const out: CliResult = {
+    exitCode: res.status ?? 1,
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+  }
+  const body = out.stdout.trim().length > 0 ? out.stdout : out.stderr
+  if (body.trim().length > 0) {
+    try { out.json = JSON.parse(body) } catch { /* leave undefined */ }
+  }
+  return out
+}
+
+describe('elastic config (integration)', () => {
+  let dir: string
+  let cfg: string
+
+  before(async () => {
+    // Ensure dist/cli.js is built
+    try {
+      await stat(CLI)
+    } catch {
+      throw new Error(`${CLI} missing; run \`npm run build\` before these tests`)
+    }
+    dir = await mkdtemp(join(tmpdir(), 'elastic-cli-cmd-'))
+    cfg = join(dir, 'cfg.yml')
+  })
+  after(async () => rm(dir, { recursive: true, force: true }))
+
+  it('context add creates a config file with one context and sets current_context', async () => {
+    const res = run([
+      'config', 'context', 'add', 'local',
+      '--config-file', cfg,
+      '--es-url', 'http://localhost:9200',
+      '--es-api-key', 'k1',
+      '--inline-secrets',
+    ])
+    assert.equal(res.exitCode, 0, res.stderr)
+    assert.equal((res.json as { current: string }).current, 'local')
+
+    if (process.platform !== 'win32') {
+      const st = await stat(cfg)
+      assert.equal(st.mode & 0o777, 0o600, 'inline secrets must be chmod 0600')
+    }
+  })
+
+  it('context add without any service flags errors with code=no_fields', () => {
+    const res = run([
+      'config', 'context', 'add', 'barebones',
+      '--config-file', cfg,
+    ])
+    assert.equal(res.exitCode, 1)
+    assert.equal((res.json as { error?: { code: string } }).error?.code, 'no_fields')
+  })
+
+  it('context add fails with context_exists when the name already exists', () => {
+    const res = run([
+      'config', 'context', 'add', 'local',
+      '--config-file', cfg,
+      '--es-url', 'http://localhost:9200',
+      '--es-api-key', 'k1',
+      '--inline-secrets',
+    ])
+    assert.equal(res.exitCode, 1)
+    assert.equal((res.json as { error?: { code: string } }).error?.code, 'context_exists')
+  })
+
+  it('context add --force overwrites', () => {
+    const res = run([
+      'config', 'context', 'add', 'local',
+      '--config-file', cfg,
+      '--es-url', 'http://other:9200',
+      '--es-api-key', 'k1b',
+      '--inline-secrets',
+      '--force',
+    ])
+    assert.equal(res.exitCode, 0, res.stderr)
+  })
+
+  it('context list reports current marker', () => {
+    const res = run(['config', 'context', 'list', '--config-file', cfg])
+    assert.equal(res.exitCode, 0, res.stderr)
+    const out = res.json as { contexts: Array<{ name: string; current: boolean }> }
+    assert.deepEqual(out.contexts, [{ name: 'local', current: true }])
+  })
+
+  it('context add second context keeps current_context on the first', () => {
+    const res = run([
+      'config', 'context', 'add', 'staging',
+      '--config-file', cfg,
+      '--es-url', 'https://staging:9200',
+      '--es-api-key', 'k2',
+      '--inline-secrets',
+    ])
+    assert.equal(res.exitCode, 0, res.stderr)
+    assert.equal((res.json as { current: string }).current, 'local')
+  })
+
+  it('current-context set switches contexts', () => {
+    const res = run(['config', 'current-context', 'set', 'staging', '--config-file', cfg])
+    assert.equal(res.exitCode, 0, res.stderr)
+    assert.equal((res.json as { current: string }).current, 'staging')
+  })
+
+  it('current-context set errors on unknown context', () => {
+    const res = run(['config', 'current-context', 'set', 'nope', '--config-file', cfg])
+    assert.equal(res.exitCode, 1)
+    assert.equal((res.json as { error?: { code: string } }).error?.code, 'context_not_found')
+  })
+
+  it('current-context get returns the active name', () => {
+    const res = run(['config', 'current-context', 'get', '--config-file', cfg])
+    assert.equal(res.exitCode, 0, res.stderr)
+    assert.equal((res.json as { current: string }).current, 'staging')
+  })
+
+  it('context edit --set updates a URL without touching secrets', () => {
+    const res = run([
+      'config', 'context', 'edit', 'local',
+      '--config-file', cfg,
+      '--es-url', 'http://new:9200',
+      '--inline-secrets',
+    ])
+    assert.equal(res.exitCode, 0, res.stderr)
+  })
+
+  it('context remove of current without --force errors', () => {
+    const res = run(['config', 'context', 'remove', 'staging', '--config-file', cfg])
+    assert.equal(res.exitCode, 1)
+    assert.equal((res.json as { error?: { code: string } }).error?.code, 'current_context')
+  })
+
+  it('context remove of non-current succeeds', () => {
+    const res = run(['config', 'context', 'remove', 'local', '--config-file', cfg])
+    assert.equal(res.exitCode, 0, res.stderr)
+  })
+
+  it('context remove last context deletes the config file', async () => {
+    const res = run(['config', 'context', 'remove', 'staging', '--config-file', cfg, '--force'])
+    assert.equal(res.exitCode, 0, res.stderr)
+    await assert.rejects(stat(cfg), { code: 'ENOENT' })
+  })
+
+  it('context edit on unknown context errors', async () => {
+    await writeFile(cfg, 'current_context: only\ncontexts:\n  only:\n    elasticsearch:\n      url: http://x:9200\n      auth:\n        api_key: k\n')
+    const res = run([
+      'config', 'context', 'edit', 'missing',
+      '--config-file', cfg,
+      '--es-url', 'http://y:9200',
+    ])
+    assert.equal(res.exitCode, 1)
+    assert.equal((res.json as { error?: { code: string } }).error?.code, 'context_not_found')
+  })
+})

--- a/test/config/secret-store.test.ts
+++ b/test/config/secret-store.test.ts
@@ -1,0 +1,255 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import type { execSync as ExecSyncFn } from 'node:child_process'
+import {
+  getSecretStore,
+  _testSetExecSync,
+  _testSetPlatform,
+  _testStores,
+} from '../../src/config/secret-store.ts'
+
+/**
+ * Builds a fake execSync that records every invocation and returns canned
+ * output (or throws) based on a matcher over the command string.
+ */
+interface Call { cmd: string; options: Record<string, unknown> | undefined }
+function makeExec (
+  handlers: Array<{ match: RegExp | string; result: string | Error }>
+): { fn: typeof ExecSyncFn; calls: Call[] } {
+  const calls: Call[] = []
+  const fn = ((cmd: string, options?: Record<string, unknown>) => {
+    calls.push({ cmd, options })
+    for (const h of handlers) {
+      const hit = typeof h.match === 'string' ? cmd.includes(h.match) : h.match.test(cmd)
+      if (hit) {
+        if (h.result instanceof Error) throw h.result
+        return h.result
+      }
+    }
+    return ''
+  }) as unknown as typeof ExecSyncFn
+  return { fn, calls }
+}
+
+describe('getSecretStore', () => {
+  const restores: Array<() => void> = []
+  afterEach(() => {
+    while (restores.length > 0) restores.pop()!()
+  })
+
+  it('returns a keychain store on darwin when `security` is available', async () => {
+    restores.push(_testSetPlatform('darwin'))
+    const { fn } = makeExec([{ match: 'security -h', result: 'usage: security\n' }])
+    restores.push(_testSetExecSync(fn))
+
+    const store = await getSecretStore()
+    assert.equal(store.kind, 'keychain')
+  })
+
+  it('falls back to a noop store when no candidate is available', async () => {
+    restores.push(_testSetPlatform('linux'))
+    const { fn } = makeExec([
+      { match: 'secret-tool --version', result: new Error('not found') },
+      { match: 'pass version', result: new Error('not found') },
+    ])
+    restores.push(_testSetExecSync(fn))
+
+    const store = await getSecretStore()
+    assert.equal(store.kind, 'none')
+    assert.equal(await store.isAvailable(), false)
+  })
+
+  it('prefers secret_service over pass on linux', async () => {
+    restores.push(_testSetPlatform('linux'))
+    const { fn, calls } = makeExec([
+      { match: 'secret-tool --version', result: 'Secret Tool 0.21\n' },
+    ])
+    restores.push(_testSetExecSync(fn))
+
+    const store = await getSecretStore()
+    assert.equal(store.kind, 'secret_service')
+    assert.equal(calls.some(c => c.cmd.startsWith('pass')), false)
+  })
+
+  it('uses credential_manager on win32 when CredentialManager module is present', async () => {
+    restores.push(_testSetPlatform('win32'))
+    const { fn } = makeExec([{ match: 'powershell ', result: '' }])
+    restores.push(_testSetExecSync(fn))
+
+    const store = await getSecretStore()
+    assert.equal(store.kind, 'credential_manager')
+  })
+})
+
+describe('MacOSKeychainStore', () => {
+  const restores: Array<() => void> = []
+  afterEach(() => {
+    while (restores.length > 0) restores.pop()!()
+  })
+
+  it('put invokes `security add-generic-password -U` with shell-escaped values', async () => {
+    const { fn, calls } = makeExec([{ match: 'security ', result: '' }])
+    restores.push(_testSetExecSync(fn))
+    const store = new _testStores.MacOSKeychainStore()
+    await store.put('elastic-cli', 'prod:es.api_key', "it's secret")
+    const put = calls.find(c => c.cmd.includes('add-generic-password'))!
+    assert.ok(put)
+    assert.match(put.cmd, /-U /)
+    assert.match(put.cmd, /-s 'elastic-cli'/)
+    assert.match(put.cmd, /-a 'prod:es.api_key'/)
+    assert.match(put.cmd, /-w 'it'\\''s secret'/)
+  })
+
+  it('delete swallows errors (idempotent)', async () => {
+    const { fn } = makeExec([
+      { match: 'security delete-generic-password', result: new Error('not found') },
+    ])
+    restores.push(_testSetExecSync(fn))
+    const store = new _testStores.MacOSKeychainStore()
+    await store.delete('elastic-cli', 'prod:missing')
+  })
+
+  it('resolverExpr produces a keychain: expression', () => {
+    const store = new _testStores.MacOSKeychainStore()
+    assert.equal(
+      store.resolverExpr('elastic-cli', 'prod:es.api_key'),
+      '$(keychain:elastic-cli/prod:es.api_key)'
+    )
+  })
+
+  it('rejects service/account with slashes', async () => {
+    const { fn } = makeExec([])
+    restores.push(_testSetExecSync(fn))
+    const store = new _testStores.MacOSKeychainStore()
+    await assert.rejects(
+      () => store.put('elastic/cli', 'prod', 'x'),
+      /must not contain/
+    )
+  })
+
+  it('rejects empty service or account', async () => {
+    const store = new _testStores.MacOSKeychainStore()
+    await assert.rejects(() => store.put('', 'a', 'x'), /must not be empty/)
+    await assert.rejects(() => store.put('svc', '', 'x'), /must not be empty/)
+  })
+
+  it('rejects non-printable characters', async () => {
+    const store = new _testStores.MacOSKeychainStore()
+    await assert.rejects(() => store.put('svc', 'ac\u0000count', 'x'), /non-printable/)
+  })
+
+  it('wraps underlying errors with context', async () => {
+    const { fn } = makeExec([
+      { match: 'security ', result: new Error('permission denied') },
+    ])
+    restores.push(_testSetExecSync(fn))
+    const store = new _testStores.MacOSKeychainStore()
+    await assert.rejects(
+      () => store.put('svc', 'acct', 'x'),
+      /Keychain write failed for service="svc", account="acct".*permission denied/
+    )
+  })
+})
+
+describe('LinuxSecretServiceStore', () => {
+  const restores: Array<() => void> = []
+  afterEach(() => {
+    while (restores.length > 0) restores.pop()!()
+  })
+
+  it('put passes secret via stdin (input option) and uses store attributes', async () => {
+    const { fn, calls } = makeExec([{ match: 'secret-tool store', result: '' }])
+    restores.push(_testSetExecSync(fn))
+    const store = new _testStores.LinuxSecretServiceStore()
+    await store.put('elastic-cli', 'prod:es.api_key', 'hunter2')
+    const put = calls.find(c => c.cmd.includes('secret-tool store'))!
+    assert.ok(put)
+    assert.equal((put.options as { input?: string }).input, 'hunter2')
+    assert.match(put.cmd, /service 'elastic-cli'/)
+    assert.match(put.cmd, /account 'prod:es.api_key'/)
+  })
+
+  it('resolverExpr produces a secret_service: expression', () => {
+    const store = new _testStores.LinuxSecretServiceStore()
+    assert.equal(
+      store.resolverExpr('elastic-cli', 'prod:es.api_key'),
+      '$(secret_service:elastic-cli/prod:es.api_key)'
+    )
+  })
+})
+
+describe('PassStore', () => {
+  const restores: Array<() => void> = []
+  afterEach(() => {
+    while (restores.length > 0) restores.pop()!()
+  })
+
+  it('put uses `pass insert -m -f` with stdin', async () => {
+    const { fn, calls } = makeExec([{ match: 'pass insert', result: '' }])
+    restores.push(_testSetExecSync(fn))
+    const store = new _testStores.PassStore()
+    await store.put('elastic-cli', 'prod:k', 'secret-value')
+    const put = calls.find(c => c.cmd.includes('pass insert'))!
+    assert.ok(put)
+    assert.match(put.cmd, /pass insert -m -f 'elastic-cli\/prod:k'/)
+    assert.equal((put.options as { input?: string }).input, 'secret-value\n')
+  })
+
+  it('resolverExpr produces a pass: expression', () => {
+    const store = new _testStores.PassStore()
+    assert.equal(
+      store.resolverExpr('elastic-cli', 'prod:k'),
+      '$(pass:elastic-cli/prod:k)'
+    )
+  })
+})
+
+describe('WindowsCredentialManagerStore', () => {
+  const restores: Array<() => void> = []
+  afterEach(() => {
+    while (restores.length > 0) restores.pop()!()
+  })
+
+  it('put invokes powershell with an EncodedCommand', async () => {
+    const { fn, calls } = makeExec([{ match: 'powershell ', result: '' }])
+    restores.push(_testSetExecSync(fn))
+    const store = new _testStores.WindowsCredentialManagerStore()
+    await store.put('elastic-cli', 'prod:k', 'secret')
+    const put = calls.find(c => c.cmd.startsWith('powershell '))!
+    assert.ok(put)
+    assert.match(put.cmd, /EncodedCommand /)
+  })
+
+  it('resolverExpr produces a credential_manager: expression', () => {
+    const store = new _testStores.WindowsCredentialManagerStore()
+    assert.equal(
+      store.resolverExpr('elastic-cli', 'prod:k'),
+      '$(credential_manager:elastic-cli/prod:k)'
+    )
+  })
+})
+
+describe('NoopStore', () => {
+  it('put throws a clear error', async () => {
+    const store = new _testStores.NoopStore()
+    await assert.rejects(
+      () => store.put('svc', 'acct', 'x'),
+      /No OS secret store is available/
+    )
+  })
+
+  it('delete is a no-op', async () => {
+    const store = new _testStores.NoopStore()
+    await store.delete('svc', 'acct')
+  })
+
+  it('resolverExpr throws', () => {
+    const store = new _testStores.NoopStore()
+    assert.throws(() => store.resolverExpr('svc', 'acct'), /No OS secret store is available/)
+  })
+})

--- a/test/config/writer.test.ts
+++ b/test/config/writer.test.ts
@@ -1,0 +1,205 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { parse as parseYaml } from 'yaml'
+import {
+  writeConfig,
+  readRawConfig,
+  upsertContext,
+  removeContext,
+  setCurrentContext,
+  extractContext,
+  emptyConfig,
+  serializeConfig,
+  type RawConfig,
+} from '../../src/config/writer.ts'
+
+const SAMPLE: RawConfig = {
+  current_context: 'local',
+  contexts: {
+    local: {
+      elasticsearch: { url: 'http://localhost:9200', auth: { api_key: 'k1' } },
+    },
+    staging: {
+      elasticsearch: { url: 'https://staging.example.com:9200', auth: { api_key: 'k2' } },
+    },
+  },
+}
+
+describe('upsertContext', () => {
+  it('adds a new context without mutating the input', () => {
+    const next = upsertContext(SAMPLE, 'prod', {
+      elasticsearch: { url: 'https://prod.example.com:9200', auth: { api_key: 'k3' } },
+    })
+    assert.ok('prod' in next.contexts)
+    assert.ok(!('prod' in SAMPLE.contexts))
+    assert.notEqual(next, SAMPLE)
+    assert.notEqual(next.contexts, SAMPLE.contexts)
+  })
+
+  it('overwrites an existing context', () => {
+    const next = upsertContext(SAMPLE, 'local', {
+      kibana: { url: 'http://other:5601' },
+    })
+    assert.deepEqual(next.contexts.local, { kibana: { url: 'http://other:5601' } })
+    assert.deepEqual(SAMPLE.contexts.local, {
+      elasticsearch: { url: 'http://localhost:9200', auth: { api_key: 'k1' } },
+    })
+  })
+})
+
+describe('removeContext', () => {
+  it('removes a non-current context', () => {
+    const next = removeContext(SAMPLE, 'staging')
+    assert.ok(!('staging' in next.contexts))
+    assert.equal(next.current_context, 'local')
+  })
+
+  it('clears current_context when removing the active context', () => {
+    const next = removeContext(SAMPLE, 'local')
+    assert.ok(!('local' in next.contexts))
+    assert.equal(next.current_context, '')
+  })
+
+  it('returns the same config when removing a missing context', () => {
+    const next = removeContext(SAMPLE, 'nonexistent')
+    assert.equal(next, SAMPLE)
+  })
+})
+
+describe('setCurrentContext', () => {
+  it('updates current_context when the name exists', () => {
+    const next = setCurrentContext(SAMPLE, 'staging')
+    assert.equal(next.current_context, 'staging')
+    assert.equal(SAMPLE.current_context, 'local')
+  })
+
+  it('throws when the name does not exist', () => {
+    assert.throws(() => setCurrentContext(SAMPLE, 'prod'), /not found/)
+  })
+})
+
+describe('extractContext', () => {
+  it('returns the named context', () => {
+    assert.deepEqual(extractContext(SAMPLE, 'local'), SAMPLE.contexts.local)
+  })
+
+  it('throws when the name does not exist', () => {
+    assert.throws(() => extractContext(SAMPLE, 'prod'), /not found/)
+  })
+})
+
+describe('serializeConfig', () => {
+  it('emits current_context before contexts for stable diffs', () => {
+    const yaml = serializeConfig(SAMPLE)
+    assert.ok(yaml.indexOf('current_context') < yaml.indexOf('contexts'))
+  })
+
+  it('preserves $(...) resolver expressions as plain strings', () => {
+    const cfg: RawConfig = {
+      current_context: 'x',
+      contexts: {
+        x: { elasticsearch: { url: 'https://e:9200', auth: { api_key: '$(keychain:elastic-cli/x:es.api_key)' } } },
+      },
+    }
+    const yaml = serializeConfig(cfg)
+    assert.match(yaml, /\$\(keychain:elastic-cli\/x:es\.api_key\)/)
+    // round-trip
+    const parsed = parseYaml(yaml) as RawConfig
+    assert.equal(
+      (parsed.contexts.x as { elasticsearch: { auth: { api_key: string } } }).elasticsearch.auth.api_key,
+      '$(keychain:elastic-cli/x:es.api_key)'
+    )
+  })
+})
+
+describe('writeConfig', () => {
+  let dir: string
+  before(async () => { dir = await mkdtemp(join(tmpdir(), 'elastic-cli-writer-')) })
+  after(async () => rm(dir, { recursive: true, force: true }))
+
+  it('writes a YAML file at the given path', async () => {
+    const path = join(dir, 'basic.yml')
+    const result = await writeConfig(path, SAMPLE)
+    assert.equal(result.path, path)
+    const content = await readFile(path, 'utf-8')
+    const parsed = parseYaml(content) as RawConfig
+    assert.equal(parsed.current_context, 'local')
+    assert.ok('staging' in parsed.contexts)
+  })
+
+  it('enforces 0600 permissions on Unix', async () => {
+    if (process.platform === 'win32') return
+    const path = join(dir, 'perms.yml')
+    const result = await writeConfig(path, SAMPLE)
+    assert.equal(result.permsEnforced, true)
+    const st = await stat(path)
+    assert.equal(st.mode & 0o777, 0o600)
+    assert.deepEqual(result.warnings, [])
+  })
+
+  it('creates parent directories by default', async () => {
+    const path = join(dir, 'nested', 'deeper', 'cfg.yml')
+    await writeConfig(path, SAMPLE)
+    const st = await stat(path)
+    assert.ok(st.isFile())
+  })
+
+  it('round-trips via readRawConfig', async () => {
+    const path = join(dir, 'roundtrip.yml')
+    await writeConfig(path, SAMPLE)
+    const raw = await readRawConfig(path)
+    assert.equal(raw.current_context, SAMPLE.current_context)
+    assert.deepEqual(Object.keys(raw.contexts).sort(), ['local', 'staging'])
+  })
+
+  it('leaves no .tmp file on success', async () => {
+    const path = join(dir, 'tmp.yml')
+    await writeConfig(path, SAMPLE)
+    const { readdir } = await import('node:fs/promises')
+    const entries = await readdir(dir)
+    assert.ok(!entries.some(e => e.includes('.tmp')), `unexpected tmp files: ${entries.join(', ')}`)
+  })
+
+  it('can write a config with empty contexts (caller owns validity)', async () => {
+    const path = join(dir, 'empty.yml')
+    await writeConfig(path, emptyConfig())
+    const raw = await readRawConfig(path)
+    assert.deepEqual(raw.contexts, {})
+  })
+})
+
+describe('readRawConfig', () => {
+  let dir: string
+  before(async () => { dir = await mkdtemp(join(tmpdir(), 'elastic-cli-reader-')) })
+  after(async () => rm(dir, { recursive: true, force: true }))
+
+  it('returns emptyConfig when the file does not exist', async () => {
+    const raw = await readRawConfig(join(dir, 'missing.yml'))
+    assert.deepEqual(raw, emptyConfig())
+  })
+
+  it('returns emptyConfig on a file with null content', async () => {
+    const path = join(dir, 'null.yml')
+    await writeFile(path, '')
+    const raw = await readRawConfig(path)
+    assert.deepEqual(raw, emptyConfig())
+  })
+
+  it('preserves the commands section when present', async () => {
+    const path = join(dir, 'with-commands.yml')
+    await writeConfig(path, {
+      ...SAMPLE,
+      commands: { allowed: ['cloud.*'] },
+    })
+    const raw = await readRawConfig(path)
+    assert.deepEqual(raw.commands, { allowed: ['cloud.*'] })
+  })
+})


### PR DESCRIPTION
## Review guidance

**Please review each commit individually** — they address separate issues but share a small abstraction (`SecretStore`) introduced in the first:

1. [`ea6c85f`](https://github.com/elastic/cli/pull/216/commits/ea6c85f3dbd6b20d8b8e51f690fe9637f4bf50a3) — `elastic config` command group (#75)
2. [`246cf21`](https://github.com/elastic/cli/pull/216/commits/246cf21d16c71b2d02cea61b62e23ad81019608f) — `--save-as` / `--credentials-file` on serverless project create + reset-credentials (#154)

Each commit builds, lints, and tests green on its own.

## Summary

Closes #75 and #154 by sharing a single `SecretStore` abstraction between config authoring and serverless project creation.

### `elastic config …` (#75 — commit 1)

New flag-driven command group for authoring the config without hand-editing YAML:

```
elastic config context list
elastic config context add <name> [--es-url … --es-api-key …] [--force] [--inline-secrets]
elastic config context edit <name> [--es-url … | no flags → $EDITOR]
elastic config context remove <name> [--force]
elastic config current-context get
elastic config current-context set <name>
```

Secrets go to the OS keychain when available (macOS `security`, Linux `secret-tool` / `pass`, Windows Credential Manager). The YAML then contains `$(keychain:...)` resolver expressions, mirroring the existing read side in `src/config/resolvers.ts`. If no keychain is available (or `--inline-secrets` is passed), secrets are written inline and the file is `chmod 0600`.

A new stderr warning fires at load time when a config has inline (non-resolver) secrets at looser-than-0600 permissions.

### Credential-safe `serverless projects create` / `reset-credentials` (#154 — commit 2)

Scoped to those commands, three new flags:

- `--save-as <name>` — stores admin creds in the keychain, upserts a config context bound to the new project's endpoints, and redacts stdout. Next command runs as `elastic --use-context <name> ...` with zero manual wiring.
- `--credentials-file <path>` — alternative that writes a standalone 0600 YAML fragment instead of mutating the main config.
- `--force` — overwrite on name/file collision.

`reset-credentials --save-as <ctx>` updates the existing context's auth in-place (URLs preserved). Without either flag, behavior is unchanged.

## What a reviewer should know

- **No new dependencies.** `SecretStore` shells out to the same OS tools the existing read-side resolvers use, behind an interface so a native binding (keytar / `@napi-rs/keyring`) can be dropped in later without API churn.
- **Keychain entries use a predictable namespace.** `service="elastic-cli"`, `account="<context>:<dotted.field.path>"` (e.g. `prod:elasticsearch.auth.password`). Easy to audit (`security dump-keychain` / `secret-tool search service elastic-cli`) and to wipe.
- **`config` commands skip the `loadConfig` preAction hook** (see `src/cli.ts`) — they author the file and must tolerate it being absent.
- **Backwards compat:** `projects create` without `--save-as` / `--credentials-file` returns the full JSON response verbatim. A global `--redact` filter is deliberately deferred to a follow-up once usage patterns settle.
- **Follow-up PR** will wrap this in an interactive `elastic config init` TUI (`@inquirer/prompts`), reusing the same primitives.

## Test plan

- [x] `npm run build` — clean.
- [x] `npm run test:lint` — clean.
- [x] `npm run test:unit` — 940 tests pass (75 new). Coverage 98.59% lines / 91.29% branches / 96.57% functions (above 90% threshold).
- [x] Manual: `config context add/edit/remove/list` with keychain (macOS) + inline fallback, `current-context set/get`, name-collision guards, $EDITOR round-trip, `--inline-secrets` opt-out.
- [x] Manual: loose-perms warning fires for 0644 file with inline api_key, silent at 0600.
- [ ] Manual verification of `--save-as` against cloud functional harness (requires real cloud creds) — unit tests cover the keychain/config/redaction flow with canned responses.
