### PR TITLE
refactor: extract expression resolver into @elastic/config-resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 dist
 build
+*.tsbuildinfo
 *.log
 .env*
 .DS_Store

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,6 +7,9 @@ import eslint from '@eslint/js'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
+  {
+    ignores: ['**/dist/**', '**/build/**', '**/node_modules/**'],
+  },
   eslint.configs.recommended,
   tseslint.configs.recommended,
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
       "name": "@elastic/cli",
       "version": "0.1.0-alpha.1",
       "license": "Apache-2.0",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
+        "@elastic/config-resolver": "*",
         "@elastic/transport": "^9.3.5",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
@@ -66,6 +70,10 @@
       "engines": {
         "node": ">=0.1.90"
       }
+    },
+    "node_modules/@elastic/config-resolver": {
+      "resolved": "packages/config-resolver",
+      "link": true
     },
     "node_modules/@elastic/transport": {
       "version": "9.3.5",
@@ -8694,6 +8702,11 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "packages/config-resolver": {
+      "name": "@elastic/config-resolver",
+      "version": "0.1.0",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "elastic": "dist/cli.js"
   },
   "scripts": {
-    "build": "npm run build --workspaces --if-present && tsc",
+    "build": "tsc -b",
     "test": "npm run build && npm run test:unit && npm run test:license",
     "test:unit": "node --import tsx/esm --test --experimental-test-coverage --test-coverage-lines=90 --test-coverage-branches=90 --test-coverage-functions=90 --test-coverage-include='src/**/*.ts' --test-coverage-include='packages/*/src/**/*.ts' --test-coverage-exclude='src/es/apis/schemas/**' --test-coverage-exclude='src/cloud/apis/**' --test-coverage-exclude='src/es/apis.ts' --test-coverage-exclude='src/cloud/apis.ts' --test-coverage-exclude='src/cloud/serverless-apis.ts' --test-coverage-exclude='node_modules/**'",
     "test:lint": "eslint src packages",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "elastic": "dist/cli.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "npm run build --workspaces --if-present && tsc",
     "test": "npm run build && npm run test:unit && npm run test:license",
-    "test:unit": "node --import tsx/esm --test --experimental-test-coverage --test-coverage-lines=90 --test-coverage-branches=90 --test-coverage-functions=90 --test-coverage-include='src/**/*.ts' --test-coverage-exclude='src/es/apis/schemas/**' --test-coverage-exclude='src/cloud/apis/**' --test-coverage-exclude='src/es/apis.ts' --test-coverage-exclude='src/cloud/apis.ts' --test-coverage-exclude='src/cloud/serverless-apis.ts' --test-coverage-exclude='node_modules/**'",
-    "test:lint": "eslint src",
+    "test:unit": "node --import tsx/esm --test --experimental-test-coverage --test-coverage-lines=90 --test-coverage-branches=90 --test-coverage-functions=90 --test-coverage-include='src/**/*.ts' --test-coverage-include='packages/*/src/**/*.ts' --test-coverage-exclude='src/es/apis/schemas/**' --test-coverage-exclude='src/cloud/apis/**' --test-coverage-exclude='src/es/apis.ts' --test-coverage-exclude='src/cloud/apis.ts' --test-coverage-exclude='src/cloud/serverless-apis.ts' --test-coverage-exclude='node_modules/**'",
+    "test:lint": "eslint src packages",
     "codegen:functional": "npx tsx codegen/functional/index.ts --tests-dir ../elasticsearch-clients-tests/tests",
     "test:functional:es": "bash test/functional/es/run.sh",
     "test:functional:cloud": "bash test/functional/cloud/smoke.sh",
@@ -47,7 +47,11 @@
   "directories": {
     "test": "test"
   },
+  "workspaces": [
+    "packages/*"
+  ],
   "dependencies": {
+    "@elastic/config-resolver": "*",
     "@elastic/transport": "^9.3.5",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",

--- a/packages/config-resolver/README.md
+++ b/packages/config-resolver/README.md
@@ -1,0 +1,13 @@
+# @elastic/config-resolver
+
+Expression resolver used by the [Elastic CLI](https://github.com/elastic/cli)
+config pipeline. Walks arbitrary JSON-like values and replaces strings of the
+form `$(name:params)` with values fetched from a pluggable set of resolvers.
+
+Built-in resolvers: `file`, `env`, `cmd`, `keychain` (macOS), `secret_service`
+(Linux), `pass`, `credential_manager` (Windows).
+
+Additional resolvers can be registered at runtime via `registerResolver`.
+
+Published in-tree as a private workspace package. This is not currently
+released to the public npm registry; depend on it through the workspace.

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@elastic/config-resolver",
+  "version": "0.1.0",
+  "description": "Expression resolver for the Elastic CLI config pipeline. Resolves $(name:params) references from sources like env vars, files, and OS keychains.",
+  "license": "Apache-2.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -b"
+  }
+}

--- a/packages/config-resolver/src/index.ts
+++ b/packages/config-resolver/src/index.ts
@@ -6,6 +6,11 @@
 import { readFileSync, statSync } from 'node:fs'
 import { execSync, type ExecSyncOptionsWithStringEncoding } from 'node:child_process'
 
+/**
+ * Callback for a resolver registered under a given name. Receives the raw
+ * parameter string from inside `$(name:params)` and returns the resolved
+ * value (either synchronously or as a promise).
+ */
 export type ResolverFn = (params: string) => string | Promise<string>
 
 // ---------------------------------------------------------------------------
@@ -14,10 +19,19 @@ export type ResolverFn = (params: string) => string | Promise<string>
 
 const registry = new Map<string, ResolverFn>()
 
+/**
+ * Registers a resolver under {@link name} so that expressions of the form
+ * `$(name:params)` are routed to {@link fn}. Overwrites any previously
+ * registered resolver with the same name.
+ */
 export function registerResolver (name: string, fn: ResolverFn): void {
   registry.set(name, fn)
 }
 
+/**
+ * Looks up a resolver by name. Returns `undefined` if no resolver has been
+ * registered under that name.
+ */
 export function getResolver (name: string): ResolverFn | undefined {
   return registry.get(name)
 }
@@ -28,10 +42,22 @@ export function getResolver (name: string): ResolverFn | undefined {
 
 const EXPRESSION_RE = /\$\(([a-z_][a-z0-9_]*):([^)]+)\)/
 
+/**
+ * Cheap check for whether {@link value} might contain a resolver expression.
+ * Used as a fast path to skip regex matching on plain strings.
+ */
 export function containsExpression (value: string): boolean {
   return value.includes('$(')
 }
 
+/**
+ * Resolves every `$(name:params)` expression in {@link value} and returns the
+ * combined result. {@link fieldPath} is included in error messages to help
+ * locate the offending config key.
+ *
+ * @throws if any expression references an unknown resolver or if a resolver
+ *         callback itself throws.
+ */
 export async function resolveString (
   value: string,
   fieldPath: string
@@ -64,6 +90,14 @@ export async function resolveString (
 // Deep object walk
 // ---------------------------------------------------------------------------
 
+/**
+ * Recursively walks {@link obj} (objects, arrays, primitives) and replaces
+ * every string containing resolver expressions with its resolved value.
+ * Non-string values are returned unchanged. {@link path} is used internally
+ * to build dotted field paths for error messages; callers normally omit it.
+ *
+ * Prototype-polluting keys (`__proto__`, `constructor`) are skipped.
+ */
 export async function resolveExpressions (
   obj: unknown,
   path: string = ''

--- a/packages/config-resolver/test/index.test.ts
+++ b/packages/config-resolver/test/index.test.ts
@@ -8,7 +8,7 @@ import assert from 'node:assert/strict'
 import { mkdtemp, writeFile, rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { loadConfig } from '../../src/config/loader.ts'
+import { loadConfig } from '../../../src/config/loader.ts'
 import {
   containsExpression,
   resolveString,
@@ -17,7 +17,7 @@ import {
   _testResetResolvers,
   _testSetExecSync,
   _testSetPlatform,
-} from '../../src/config/resolvers.ts'
+} from '../src/index.ts'
 
 afterEach(() => {
   _testResetResolvers()

--- a/packages/config-resolver/tsconfig.json
+++ b/packages/config-resolver/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "composite": true
+  },
+  "include": ["src/**/*"]
+}

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -31,7 +31,7 @@ import { extname, join } from 'node:path'
 import { z } from 'zod'
 import { parse as parseYaml } from 'yaml'
 import { ContextSchema, CommandPolicySchema, StructuralConfigSchema } from './schema.ts'
-import { resolveExpressions } from './resolvers.ts'
+import { resolveExpressions } from '@elastic/config-resolver'
 import type { ConfigFile, ResolvedConfig, ResolvedContext } from './types.ts'
 
 /** Extensions that are rejected to prevent arbitrary code execution. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,8 @@
   },
   "include": [
     "src/**/*"
+  ],
+  "references": [
+    { "path": "./packages/config-resolver" }
   ]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,5 +4,5 @@
     "rootDir": ".",
     "noEmit": true
   },
-  "include": ["src/**/*", "test/**/*"]
+  "include": ["src/**/*", "test/**/*", "packages/*/src/**/*", "packages/*/test/**/*"]
 }


### PR DESCRIPTION
## Summary

- Extracts `src/config/resolvers.ts` into a new private in-repo npm workspace package `@elastic/config-resolver` (`packages/config-resolver/`), with its own `tsc -b` build and TypeScript project references; the root CLI consumes it via `import ... from '@elastic/config-resolver'`.
- `npm run build` now builds the workspace first and then the CLI, producing both `packages/config-resolver/dist/` and the root `dist/cli.js`. `test:lint` and `tsconfig.test.json` broadened to cover `packages/`; `eslint.config.js` ignores compiled `dist/`.
- Narrow scope per #145: in-repo workspace only. `private: true`, no npm publishing or release infra.

Refs: #145