### PR TITLE
ci: add weekly automated codegen workflow

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,8 +1,8 @@
 name: Weekly Codegen
 
-# Regenerates the auto-generated ES and Cloud API bindings against the latest
-# upstream `elastic/elastic-client-generator-js` output and, when the diff is
-# non-empty, opens a PR. See https://github.com/elastic/cli/issues/79.
+# Regenerates the auto-generated ES, Cloud and Kibana API bindings against the
+# latest upstream `elastic/elastic-client-generator-js` output and, when the
+# diff is non-empty, opens a PR. See https://github.com/elastic/cli/issues/79.
 on:
   schedule:
     # Monday 07:00 UTC — matches the cadence of the wider client-codegen suite
@@ -65,9 +65,10 @@ jobs:
         env:
           CODEGEN_GENERATOR_DIR: ${{ steps.generator.outputs.dir }}
         run: npm run codegen:cloud
-      # TODO(#79): add a `codegen:kibana` step here once the Kibana target
-      # lands in elastic/elastic-client-generator-js. The Kibana bindings
-      # tracking issue (elastic/cli#72) will gate this.
+      - name: Regenerate Kibana bindings
+        env:
+          CODEGEN_GENERATOR_DIR: ${{ steps.generator.outputs.dir }}
+        run: npm run codegen:kibana
 
       - name: Build
         run: npm run build
@@ -78,12 +79,12 @@ jobs:
         id: diff
         shell: bash
         run: |
-          if git diff --quiet -- src/es src/cloud; then
+          if git diff --quiet -- src/es src/cloud src/kb; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No generated changes — nothing to PR."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            git --no-pager diff --stat -- src/es src/cloud
+            git --no-pager diff --stat -- src/es src/cloud src/kb
           fi
 
       # Reuse the ephemeral token fetched at the start of the job — see the
@@ -102,14 +103,19 @@ jobs:
           commit-message: "chore(codegen): weekly update of generated API bindings"
           title: "chore(codegen): weekly update of generated API bindings"
           body: |
-            Automated weekly regeneration of the ES and Cloud API bindings
-            against the latest `elastic/elastic-client-generator-js` output.
+            Automated weekly regeneration of the ES, Cloud and Kibana API
+            bindings against the latest `elastic/elastic-client-generator-js`
+            output.
 
-            - `src/es/apis/**` and `src/es/apis.ts` — produced by `npm run cli-es`
+            - `src/es/apis/**` — produced by `npm run cli-es`
             - `src/es/apis/schemas/**` — produced by `npm run zod`
+            - `src/es/api-manifest.ts` — produced by `scripts/build-api-manifest.mjs`
             - `src/cloud/apis/**` and `src/cloud/apis.ts` — produced by `npm run cli-cloud`
+            - `src/kb/apis/**` — produced by `npx tsx cli/kibana/index.ts`
+            - `src/kb/api-manifest.ts` — produced by `scripts/build-kb-manifest.mts`
 
-            Run locally with `npm run codegen:es` / `npm run codegen:cloud`.
+            Run locally with `npm run codegen:es` / `npm run codegen:cloud` /
+            `npm run codegen:kibana`.
 
             Refs: #79
           committer: "elastic-machine <elasticmachine@users.noreply.github.com>"
@@ -117,6 +123,7 @@ jobs:
           add-paths: |
             src/es
             src/cloud
+            src/kb
 
       - name: PR summary
         if: steps.cpr.outputs.pull-request-url

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -1,0 +1,108 @@
+name: Weekly Codegen
+
+# Regenerates the auto-generated ES and Cloud API bindings against the latest
+# upstream `elastic/elastic-client-generator-js` output and, when the diff is
+# non-empty, opens a PR. See https://github.com/elastic/cli/issues/79.
+on:
+  schedule:
+    # Monday 07:00 UTC — matches the cadence of the wider client-codegen suite
+    # run by elastic/devtools-team (which fires one hour earlier).
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  codegen:
+    name: Regenerate API bindings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+      - name: Install repo dependencies
+        run: npm ci
+
+      - name: Prepare generator checkout (shared between codegen steps)
+        id: generator
+        shell: bash
+        run: |
+          dir="$RUNNER_TEMP/elastic-client-generator-js"
+          git clone --depth 1 --branch main https://github.com/elastic/elastic-client-generator-js.git "$dir"
+          (cd "$dir" && npm install --no-audit --no-fund)
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+
+      - name: Regenerate ES bindings
+        env:
+          CODEGEN_GENERATOR_DIR: ${{ steps.generator.outputs.dir }}
+        run: npm run codegen:es
+      - name: Regenerate Cloud bindings
+        env:
+          CODEGEN_GENERATOR_DIR: ${{ steps.generator.outputs.dir }}
+        run: npm run codegen:cloud
+      # TODO(#79): add a `codegen:kibana` step here once the Kibana target
+      # lands in elastic/elastic-client-generator-js. The Kibana bindings
+      # tracking issue (elastic/cli#72) will gate this.
+
+      - name: Build
+        run: npm run build
+      - name: Unit tests
+        run: npm run test:unit
+
+      - name: Detect generated diff
+        id: diff
+        shell: bash
+        run: |
+          if git diff --quiet -- src/es src/cloud; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No generated changes — nothing to PR."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            git --no-pager diff --stat -- src/es src/cloud
+          fi
+
+      # NOTE: Using GITHUB_TOKEN means the resulting PR will NOT trigger further
+      # workflow runs (including `ci.yml`). To get CI on weekly codegen PRs,
+      # replace `GITHUB_TOKEN` below with a fine-grained PAT stored as
+      # `CODEGEN_PR_TOKEN`. See:
+      # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+      - name: Create Pull Request
+        if: steps.diff.outputs.changed == 'true'
+        id: cpr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.CODEGEN_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          branch: chore/weekly-codegen
+          delete-branch: true
+          base: main
+          commit-message: "chore(codegen): weekly update of generated API bindings"
+          title: "chore(codegen): weekly update of generated API bindings"
+          body: |
+            Automated weekly regeneration of the ES and Cloud API bindings
+            against the latest `elastic/elastic-client-generator-js` output.
+
+            - `src/es/apis/**` and `src/es/apis.ts` — produced by `npm run cli-es`
+            - `src/es/apis/schemas/**` — produced by `npm run zod`
+            - `src/cloud/apis/**` and `src/cloud/apis.ts` — produced by `npm run cli-cloud`
+
+            Run locally with `npm run codegen:es` / `npm run codegen:cloud`.
+
+            Refs: #79
+          committer: "elastic-machine <elasticmachine@users.noreply.github.com>"
+          author: "elastic-machine <elasticmachine@users.noreply.github.com>"
+          add-paths: |
+            src/es
+            src/cloud
+
+      - name: PR summary
+        if: steps.cpr.outputs.pull-request-url
+        shell: bash
+        run: |
+          echo "Opened: ${{ steps.cpr.outputs.pull-request-url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -11,8 +11,8 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  id-token: write
 
 concurrency:
   group: ${{ github.workflow }}
@@ -30,12 +30,30 @@ jobs:
       - name: Install repo dependencies
         run: npm ci
 
+      # Issued via Vault OIDC. The backing token policy
+      # (resources/github-token-policies/token-policy-elastic-cli-codegen.yaml
+      # in elastic/catalog-info) scopes this token to elastic/cli and
+      # elastic/elastic-client-generator-js — the former so peter-evans can
+      # push the chore/weekly-codegen branch and open the PR, the latter so
+      # the generator repo (private) can be cloned.
+      - name: Fetch ephemeral Github token
+        id: fetch-token
+        uses: elastic/ci-gh-actions/fetch-github-token@622f9dc1eecdd4af2e81dfb38028aacb1dae03e8 # v1.5.0
+        with:
+          vault-instance: "ci-prod"
+
       - name: Prepare generator checkout (shared between codegen steps)
         id: generator
         shell: bash
+        env:
+          GH_TOKEN: ${{ steps.fetch-token.outputs.token }}
         run: |
           dir="$RUNNER_TEMP/elastic-client-generator-js"
-          git clone --depth 1 --branch main https://github.com/elastic/elastic-client-generator-js.git "$dir"
+          git -c "http.https://github.com/.extraheader=AUTHORIZATION: bearer $GH_TOKEN" \
+            clone --depth 1 --branch main https://github.com/elastic/elastic-client-generator-js.git "$dir"
+          # Drop the credential from the cloned repo's git config so it can't
+          # be reused by anything later in the job.
+          git -C "$dir" config --unset-all http.https://github.com/.extraheader || true
           (cd "$dir" && npm install --no-audit --no-fund)
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
 
@@ -68,17 +86,16 @@ jobs:
             git --no-pager diff --stat -- src/es src/cloud
           fi
 
-      # NOTE: Using GITHUB_TOKEN means the resulting PR will NOT trigger further
-      # workflow runs (including `ci.yml`). To get CI on weekly codegen PRs,
-      # replace `GITHUB_TOKEN` below with a fine-grained PAT stored as
-      # `CODEGEN_PR_TOKEN`. See:
-      # https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+      # Reuse the ephemeral token fetched at the start of the job — see the
+      # "Fetch ephemeral Github token" step above. Using it (vs. GITHUB_TOKEN)
+      # also means the resulting PR is authored by a non-Actions identity and
+      # therefore triggers downstream CI (e.g. `ci.yml`).
       - name: Create Pull Request
         if: steps.diff.outputs.changed == 'true'
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.CODEGEN_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          token: ${{ steps.fetch-token.outputs.token }}
           branch: chore/weekly-codegen
           delete-branch: true
           base: main

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,14 +56,15 @@ Thanks for your interest in contributing! We love receiving contributions from o
 
 ## Regenerating API bindings
 
-The files under `src/es/apis/`, `src/es/apis/schemas/` and `src/cloud/apis/` are auto-generated from [`elastic/elastic-client-generator-js`](https://github.com/elastic/elastic-client-generator-js) by CI (see `.github/workflows/codegen.yml`, which opens a PR every Monday). To reproduce locally:
+The files under `src/es/apis/`, `src/es/apis/schemas/`, `src/cloud/apis/` and `src/kb/apis/` are auto-generated from [`elastic/elastic-client-generator-js`](https://github.com/elastic/elastic-client-generator-js) by CI (see `.github/workflows/codegen.yml`, which opens a PR every Monday). The companion manifests at `src/es/api-manifest.ts` and `src/kb/api-manifest.ts` are derived from those generated files. To reproduce locally:
 
 ```bash
-npm run codegen:es      # regenerates ES namespaces + Zod schemas
+npm run codegen:es      # regenerates ES namespaces + Zod schemas + api-manifest
 npm run codegen:cloud   # regenerates Cloud namespaces
+npm run codegen:kibana  # regenerates Kibana namespaces + api-manifest
 ```
 
-Both scripts clone the generator into a temp directory and run its `npm run zod` / `npm run cli-es` / `npm run cli-cloud` targets. Set `CODEGEN_GENERATOR_DIR` to point at an existing checkout if you want to iterate on generator changes without cloning each time.
+The scripts clone the generator into a temp directory and run its `npm run zod` / `npm run cli-es` / `npm run cli-cloud` / `npx tsx cli/kibana/index.ts` targets, then invoke `scripts/build-api-manifest.mjs` (ES) and `scripts/build-kb-manifest.mts` (Kibana) to refresh the per-endpoint manifests consumed by the lazy loaders. Set `CODEGEN_GENERATOR_DIR` to point at an existing checkout if you want to iterate on generator changes without cloning each time.
 
 ## Linting
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,17 @@ Thanks for your interest in contributing! We love receiving contributions from o
 | `npm run test:lint -- --fix` | Fix linter errors automatically |
 | `npm run test:megalinter` | Run MegaLinter locally (requires Docker) |
 
+## Regenerating API bindings
+
+The files under `src/es/apis/`, `src/es/apis/schemas/` and `src/cloud/apis/` are auto-generated from [`elastic/elastic-client-generator-js`](https://github.com/elastic/elastic-client-generator-js) by CI (see `.github/workflows/codegen.yml`, which opens a PR every Monday). To reproduce locally:
+
+```bash
+npm run codegen:es      # regenerates ES namespaces + Zod schemas
+npm run codegen:cloud   # regenerates Cloud namespaces
+```
+
+Both scripts clone the generator into a temp directory and run its `npm run zod` / `npm run cli-es` / `npm run cli-cloud` targets. Set `CODEGEN_GENERATOR_DIR` to point at an existing checkout if you want to iterate on generator changes without cloning each time.
+
 ## Linting
 
 This project uses [MegaLinter](https://megalinter.io/) for comprehensive linting across TypeScript, YAML, GitHub Actions, Dockerfiles, and more. It also scans for secrets, copy-paste, and vulnerabilities.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
     "test:unit": "node --max-old-space-size=8192 --import tsx/esm --test --experimental-test-coverage --test-coverage-lines=90 --test-coverage-branches=90 --test-coverage-functions=90 --test-coverage-include='src/**/*.ts' --test-coverage-include='packages/*/src/**/*.ts' --test-coverage-exclude='src/cloud/apis/**' --test-coverage-exclude='src/es/apis.ts' --test-coverage-exclude='src/es/api-manifest.ts' --test-coverage-exclude='src/es/apis/**' --test-coverage-exclude='src/cloud/apis.ts' --test-coverage-exclude='src/cloud/serverless-apis.ts' --test-coverage-exclude='node_modules/**'",
     "test:lint": "eslint src packages",
     "codegen:functional": "npx tsx codegen/functional/index.ts --tests-dir ../elasticsearch-clients-tests/tests",
+    "codegen:es": "node scripts/codegen.mjs es",
+    "codegen:cloud": "node scripts/codegen.mjs cloud",
     "test:functional:es": "bash test/functional/es/run.sh",
     "test:functional:cloud": "bash test/functional/cloud/smoke.sh",
     "test:functional:kb": "bash test/functional/kb/run.sh",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "codegen:functional": "npx tsx codegen/functional/index.ts --tests-dir ../elasticsearch-clients-tests/tests",
     "codegen:es": "node scripts/codegen.mjs es",
     "codegen:cloud": "node scripts/codegen.mjs cloud",
+    "codegen:kibana": "node scripts/codegen.mjs kibana",
     "test:functional:es": "bash test/functional/es/run.sh",
     "test:functional:cloud": "bash test/functional/cloud/smoke.sh",
     "test:functional:kb": "bash test/functional/kb/run.sh",

--- a/scripts/build-kb-manifest.mts
+++ b/scripts/build-kb-manifest.mts
@@ -1,30 +1,41 @@
-import { allKbApis } from '../src/kb/apis.ts'
 import * as fs from 'fs'
 import * as path from 'path'
+import { pathToFileURL } from 'url'
+import type { KbApiDefinition } from '../src/kb/types.ts'
 
-const apisDir = './src/kb/apis'
-const files = fs.readdirSync(apisDir).filter(f => f.endsWith('.ts'))
+const apisDir = path.resolve('./src/kb/apis')
+const files = fs.readdirSync(apisDir).filter(f => f.endsWith('.ts')).sort()
 
-const nsToFile = new Map<string, string>()
-for (const def of allKbApis) {
-  if (!nsToFile.has(def.namespace)) {
-    for (const file of files) {
-      const content = fs.readFileSync(path.join(apisDir, file), 'utf8')
-      if (content.includes(`namespace: "${def.namespace}"`)) {
-        nsToFile.set(def.namespace, file.replace('.ts', ''))
-        break
-      }
-    }
+function toCamelCase (stem: string): string {
+  return stem.replace(/-([a-z0-9])/g, (_, c: string) => c.toUpperCase())
+}
+
+interface Entry {
+  def: KbApiDefinition
+  file: string
+}
+
+const entries: Entry[] = []
+for (const file of files) {
+  const stem = file.replace(/\.ts$/, '')
+  const exportName = `${toCamelCase(stem)}Apis`
+  const mod = await import(pathToFileURL(path.join(apisDir, file)).href) as Record<string, KbApiDefinition[]>
+  const defs = mod[exportName]
+  if (!Array.isArray(defs)) {
+    throw new Error(`src/kb/apis/${file} did not export ${exportName}`)
+  }
+  for (const def of defs) {
+    entries.push({ def, file: stem })
   }
 }
 
-const manifest = allKbApis.map(d => ({
-  name: d.name,
-  namespace: d.namespace,
-  description: d.description,
-  method: d.method,
-  path: d.path,
-  namespaceFile: nsToFile.get(d.namespace) ?? 'unknown',
+const manifest = entries.map(({ def, file }) => ({
+  name: def.name,
+  namespace: def.namespace,
+  description: def.description,
+  method: def.method,
+  path: def.path,
+  namespaceFile: file,
 }))
 
 const lines = [
@@ -34,7 +45,7 @@ const lines = [
   ' */',
   '',
   '/*',
-  ' * AUTO-GENERATED from src/kb/apis/*.ts.',
+  ' * AUTO-GENERATED from src/kb/apis/*.ts via scripts/build-kb-manifest.mts.',
   ' * DO NOT EDIT BY HAND. Regenerate after running the code generator.',
   ' */',
   '',

--- a/scripts/codegen.mjs
+++ b/scripts/codegen.mjs
@@ -5,12 +5,13 @@
  */
 
 /**
- * Orchestrates regeneration of the ES and Cloud API bindings against the
- * upstream elastic/elastic-client-generator-js repo.
+ * Orchestrates regeneration of the ES, Cloud and Kibana API bindings against
+ * the upstream elastic/elastic-client-generator-js repo.
  *
  * Usage (from package.json scripts):
  *   node scripts/codegen.mjs es
  *   node scripts/codegen.mjs cloud
+ *   node scripts/codegen.mjs kibana
  *
  * Environment:
  *   CODEGEN_GENERATOR_DIR    Reuse an existing generator checkout (absolute
@@ -21,12 +22,20 @@
  *   CODEGEN_ES_VERSION       Elasticsearch schema version (default: main).
  *
  * Design rationale:
- *   The upstream generator's npm scripts (`npm run zod`, `npm run cli-es`,
- *   `npm run cli-cloud`) share a single `output/` directory that each run
- *   wipes via `npm run clean`. This script runs them sequentially and copies
- *   the relevant files out of `output/` between runs, mapping them onto the
- *   repo layout at `src/es/apis/`, `src/es/apis/schemas/` and
- *   `src/cloud/apis/`.
+ *   The upstream generator's targets (`npm run zod`, `npm run cli-es`,
+ *   `npm run cli-cloud`, `npx tsx cli/kibana/index.ts`) share a single
+ *   `output/` directory. `npm run zod` / `npm run cli-es` wipe it via
+ *   `npm run clean`; the kibana entrypoint self-wipes `output/kibana/`;
+ *   `npm run cli-cloud` does not clean at all (we wipe before running it).
+ *   This script runs them sequentially and copies the relevant files into
+ *   `src/es/apis/`, `src/es/apis/schemas/`, `src/cloud/apis/`, and
+ *   `src/kb/apis/`.
+ *
+ *   `src/es/apis.ts` and `src/kb/apis.ts` are hand-written lazy loaders on
+ *   `main` (see #266 and the ES equivalent) — they are NOT overwritten by
+ *   the generator output. Instead, after each codegen run for those targets
+ *   we invoke `scripts/build-api-manifest.mjs` / `scripts/build-kb-manifest.mts`
+ *   to refresh the per-endpoint manifest the lazy loader consumes.
  */
 
 import { spawnSync } from 'node:child_process'
@@ -100,26 +109,27 @@ function generateEs (generatorDir) {
   const version = process.env.CODEGEN_ES_VERSION ?? 'main'
   const output = join(generatorDir, 'output')
 
-  console.log(`[codegen] Step 1/2: Zod schemas (version: ${version})`)
+  console.log(`[codegen] Step 1/3: Zod schemas (version: ${version})`)
   run('npm', ['run', 'zod', '--', '--version', version], { cwd: generatorDir, shell: process.platform === 'win32' })
   const schemasDest = join(REPO_ROOT, 'src', 'es', 'apis', 'schemas')
   clearDir(schemasDest, (entry) => entry.endsWith('.ts'))
   copyTsFiles(output, schemasDest)
   console.log(`[codegen]   wrote schemas -> ${schemasDest}`)
 
-  console.log(`[codegen] Step 2/2: ES API namespace files (version: ${version})`)
+  console.log(`[codegen] Step 2/3: ES API namespace files (version: ${version})`)
   run('npm', ['run', 'cli-es', '--', '--version', version], { cwd: generatorDir, shell: process.platform === 'win32' })
   const apisDest = join(REPO_ROOT, 'src', 'es', 'apis')
   clearDir(apisDest, (entry) => entry.endsWith('.ts'))
   copyTsFiles(join(output, 'es', 'apis'), apisDest)
-  // Generator emits the barrel as `output/es/index.ts`; the repo expects it
-  // as `src/es/apis.ts` next to the `apis/` directory.
-  const barrelSrc = join(output, 'es', 'index.ts')
-  const barrelDest = join(REPO_ROOT, 'src', 'es', 'apis.ts')
-  if (!existsSync(barrelSrc)) throw new Error(`Missing barrel: ${barrelSrc}`)
-  cpSync(barrelSrc, barrelDest)
   console.log(`[codegen]   wrote APIs -> ${apisDest}`)
-  console.log(`[codegen]   wrote barrel -> ${barrelDest}`)
+  // The generator also emits `output/es/index.ts` as a flat barrel re-exporting
+  // every namespace, but `src/es/apis.ts` is a hand-written lazy loader on
+  // `main` (see #218). We deliberately skip copying the barrel; the manifest
+  // step below produces the metadata the lazy loader consumes.
+
+  console.log('[codegen] Step 3/3: Rebuild src/es/api-manifest.ts')
+  run('node', ['scripts/build-api-manifest.mjs'], { cwd: REPO_ROOT, shell: process.platform === 'win32' })
+  console.log(`[codegen]   wrote manifest -> ${join(REPO_ROOT, 'src', 'es', 'api-manifest.ts')}`)
 }
 
 function generateCloud (generatorDir) {
@@ -141,16 +151,39 @@ function generateCloud (generatorDir) {
   console.log(`[codegen]   wrote barrel -> ${barrelDest}`)
 }
 
+function generateKibana (generatorDir) {
+  const output = join(generatorDir, 'output')
+
+  console.log('[codegen] Step 1/2: Kibana API namespace files')
+  // The kibana entrypoint self-wipes `output/kibana/` before writing, so we
+  // don't need to clean anything ourselves. There is no `cli-kibana` npm
+  // script in the generator yet — invoke the ts source directly via tsx,
+  // matching the pattern the generator uses for `cli-cloud`.
+  run('npx', ['tsx', 'cli/kibana/index.ts'], { cwd: generatorDir, shell: process.platform === 'win32' })
+  const apisDest = join(REPO_ROOT, 'src', 'kb', 'apis')
+  clearDir(apisDest, (entry) => entry.endsWith('.ts'))
+  copyTsFiles(join(output, 'kibana', 'apis'), apisDest)
+  console.log(`[codegen]   wrote APIs -> ${apisDest}`)
+  // `output/kibana/apis.ts` (a flat barrel) is intentionally NOT copied —
+  // `src/kb/apis.ts` is the hand-written lazy loader added by #266. The
+  // manifest step below produces the metadata the loader consumes.
+
+  console.log('[codegen] Step 2/2: Rebuild src/kb/api-manifest.ts')
+  run('npx', ['tsx', 'scripts/build-kb-manifest.mts'], { cwd: REPO_ROOT, shell: process.platform === 'win32' })
+  console.log(`[codegen]   wrote manifest -> ${join(REPO_ROOT, 'src', 'kb', 'api-manifest.ts')}`)
+}
+
 const target = process.argv[2]
-if (target !== 'es' && target !== 'cloud') {
-  console.error('Usage: node scripts/codegen.mjs <es|cloud>')
+if (target !== 'es' && target !== 'cloud' && target !== 'kibana') {
+  console.error('Usage: node scripts/codegen.mjs <es|cloud|kibana>')
   process.exit(1)
 }
 
 try {
   const generatorDir = ensureGenerator()
   if (target === 'es') generateEs(generatorDir)
-  else generateCloud(generatorDir)
+  else if (target === 'cloud') generateCloud(generatorDir)
+  else generateKibana(generatorDir)
   console.log(`[codegen] Done (${target}).`)
 } catch (err) {
   console.error(`[codegen] Failed: ${err instanceof Error ? err.message : String(err)}`)

--- a/scripts/codegen.mjs
+++ b/scripts/codegen.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Orchestrates regeneration of the ES and Cloud API bindings against the
+ * upstream elastic/elastic-client-generator-js repo.
+ *
+ * Usage (from package.json scripts):
+ *   node scripts/codegen.mjs es
+ *   node scripts/codegen.mjs cloud
+ *
+ * Environment:
+ *   CODEGEN_GENERATOR_DIR    Reuse an existing generator checkout (absolute
+ *                            path). When unset, the script clones the repo
+ *                            into a fresh temporary directory and installs
+ *                            its dependencies.
+ *   CODEGEN_GENERATOR_REF    Ref/branch/tag to clone (default: main).
+ *   CODEGEN_ES_VERSION       Elasticsearch schema version (default: main).
+ *
+ * Design rationale:
+ *   The upstream generator's npm scripts (`npm run zod`, `npm run cli-es`,
+ *   `npm run cli-cloud`) share a single `output/` directory that each run
+ *   wipes via `npm run clean`. This script runs them sequentially and copies
+ *   the relevant files out of `output/` between runs, mapping them onto the
+ *   repo layout at `src/es/apis/`, `src/es/apis/schemas/` and
+ *   `src/cloud/apis/`.
+ */
+
+import { spawnSync } from 'node:child_process'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const GENERATOR_REPO = 'https://github.com/elastic/elastic-client-generator-js.git'
+
+function run (command, args, opts = {}) {
+  const result = spawnSync(command, args, { stdio: 'inherit', shell: false, ...opts })
+  if (result.status !== 0) {
+    const cwd = opts.cwd ?? process.cwd()
+    throw new Error(`Command failed (${command} ${args.join(' ')}) in ${cwd}: exit ${result.status ?? 'signal'}`)
+  }
+}
+
+/**
+ * Ensure a checkout of the generator exists and has its dependencies installed.
+ * Returns an absolute path to it. When CODEGEN_GENERATOR_DIR is set the caller
+ * is responsible for the checkout; this function only verifies it exists and
+ * skips install (the caller should have installed). Otherwise a fresh temp
+ * clone is produced and its dependencies installed via npm.
+ */
+function ensureGenerator () {
+  const existing = process.env.CODEGEN_GENERATOR_DIR
+  if (existing != null && existing.length > 0) {
+    if (!existsSync(existing)) {
+      throw new Error(`CODEGEN_GENERATOR_DIR="${existing}" does not exist`)
+    }
+    console.log(`[codegen] Using existing generator checkout: ${existing}`)
+    return existing
+  }
+
+  const ref = process.env.CODEGEN_GENERATOR_REF ?? 'main'
+  const dir = mkdtempSync(join(tmpdir(), 'elastic-client-generator-'))
+  console.log(`[codegen] Cloning ${GENERATOR_REPO} @ ${ref} -> ${dir}`)
+  run('git', ['clone', '--depth', '1', '--branch', ref, GENERATOR_REPO, dir])
+  console.log('[codegen] Installing generator dependencies (npm install)')
+  run('npm', ['install', '--no-audit', '--no-fund'], { cwd: dir, shell: process.platform === 'win32' })
+  return dir
+}
+
+/** Remove every file in `dir` matching `predicate`. Non-recursive. */
+function clearDir (dir, predicate = () => true) {
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+    return
+  }
+  for (const entry of readdirSync(dir)) {
+    if (!predicate(entry)) continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) continue // leave sub-directories alone
+    rmSync(full, { force: true })
+  }
+}
+
+/** Copy every *.ts file from `src` (non-recursive) into `dest`. */
+function copyTsFiles (src, dest) {
+  if (!existsSync(src)) throw new Error(`Expected generator output at ${src}`)
+  mkdirSync(dest, { recursive: true })
+  for (const entry of readdirSync(src)) {
+    if (!entry.endsWith('.ts')) continue
+    cpSync(join(src, entry), join(dest, entry))
+  }
+}
+
+function generateEs (generatorDir) {
+  const version = process.env.CODEGEN_ES_VERSION ?? 'main'
+  const output = join(generatorDir, 'output')
+
+  console.log(`[codegen] Step 1/2: Zod schemas (version: ${version})`)
+  run('npm', ['run', 'zod', '--', '--version', version], { cwd: generatorDir, shell: process.platform === 'win32' })
+  const schemasDest = join(REPO_ROOT, 'src', 'es', 'apis', 'schemas')
+  clearDir(schemasDest, (entry) => entry.endsWith('.ts'))
+  copyTsFiles(output, schemasDest)
+  console.log(`[codegen]   wrote schemas -> ${schemasDest}`)
+
+  console.log(`[codegen] Step 2/2: ES API namespace files (version: ${version})`)
+  run('npm', ['run', 'cli-es', '--', '--version', version], { cwd: generatorDir, shell: process.platform === 'win32' })
+  const apisDest = join(REPO_ROOT, 'src', 'es', 'apis')
+  clearDir(apisDest, (entry) => entry.endsWith('.ts'))
+  copyTsFiles(join(output, 'es', 'apis'), apisDest)
+  // Generator emits the barrel as `output/es/index.ts`; the repo expects it
+  // as `src/es/apis.ts` next to the `apis/` directory.
+  const barrelSrc = join(output, 'es', 'index.ts')
+  const barrelDest = join(REPO_ROOT, 'src', 'es', 'apis.ts')
+  if (!existsSync(barrelSrc)) throw new Error(`Missing barrel: ${barrelSrc}`)
+  cpSync(barrelSrc, barrelDest)
+  console.log(`[codegen]   wrote APIs -> ${apisDest}`)
+  console.log(`[codegen]   wrote barrel -> ${barrelDest}`)
+}
+
+function generateCloud (generatorDir) {
+  const output = join(generatorDir, 'output')
+
+  console.log('[codegen] Cloud API namespace files')
+  // `npm run cli-cloud` does not call clean itself, so wipe any leftover
+  // output from a previous step before running the generator.
+  rmSync(output, { recursive: true, force: true })
+  run('npm', ['run', 'cli-cloud'], { cwd: generatorDir, shell: process.platform === 'win32' })
+  const apisDest = join(REPO_ROOT, 'src', 'cloud', 'apis')
+  clearDir(apisDest, (entry) => entry.endsWith('.ts'))
+  copyTsFiles(join(output, 'cloud', 'apis'), apisDest)
+  const barrelSrc = join(output, 'cloud', 'apis.ts')
+  const barrelDest = join(REPO_ROOT, 'src', 'cloud', 'apis.ts')
+  if (!existsSync(barrelSrc)) throw new Error(`Missing barrel: ${barrelSrc}`)
+  cpSync(barrelSrc, barrelDest)
+  console.log(`[codegen]   wrote APIs -> ${apisDest}`)
+  console.log(`[codegen]   wrote barrel -> ${barrelDest}`)
+}
+
+const target = process.argv[2]
+if (target !== 'es' && target !== 'cloud') {
+  console.error('Usage: node scripts/codegen.mjs <es|cloud>')
+  process.exit(1)
+}
+
+try {
+  const generatorDir = ensureGenerator()
+  if (target === 'es') generateEs(generatorDir)
+  else generateCloud(generatorDir)
+  console.log(`[codegen] Done (${target}).`)
+} catch (err) {
+  console.error(`[codegen] Failed: ${err instanceof Error ? err.message : String(err)}`)
+  process.exit(1)
+}

--- a/src/kb/api-manifest.ts
+++ b/src/kb/api-manifest.ts
@@ -4,7 +4,7 @@
  */
 
 /*
- * AUTO-GENERATED from src/kb/apis/*.ts.
+ * AUTO-GENERATED from src/kb/apis/*.ts via scripts/build-kb-manifest.mts.
  * DO NOT EDIT BY HAND. Regenerate after running the code generator.
  */
 
@@ -1996,6 +1996,14 @@ export const kbApiManifest: readonly KbApiMeta[] = [
     "description": "Import saved objects",
     "method": "POST",
     "path": "/api/saved_objects/_import",
+    "namespaceFile": "saved-objects"
+  },
+  {
+    "name": "post-saved-objects-resolve-import-errors",
+    "namespace": "saved-objects",
+    "description": "Resolve import errors",
+    "method": "POST",
+    "path": "/api/saved_objects/_resolve_import_errors",
     "namespaceFile": "saved-objects"
   },
   {


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/codegen.yml`, a weekly (`cron: 0 7 * * 1`) + `workflow_dispatch` workflow that regenerates the auto-generated ES, Cloud and Kibana API bindings from `elastic/elastic-client-generator-js` and opens a PR via `peter-evans/create-pull-request` when the diff is non-empty. Node 24, Actions pinned by SHA + version comment to match the repo's existing style.
- The generator repo is private, so the workflow fetches an ephemeral GitHub token via Vault OIDC (`elastic/ci-gh-actions/fetch-github-token`) and reuses it for both the clone and the PR creation — using a non-Actions identity for the PR also means downstream CI (e.g. `ci.yml`) fires on the weekly PR.
- Adds three npm scripts (`codegen:es`, `codegen:cloud`, `codegen:kibana`) that wrap a small orchestrator at `scripts/codegen.mjs`. The script clones the generator, installs its deps, runs `npm run zod` / `npm run cli-es` / `npm run cli-cloud` / `npx tsx cli/kibana/index.ts`, and copies outputs into `src/es/apis/`, `src/es/apis/schemas/`, `src/cloud/apis/` and `src/kb/apis/`. After ES and Kibana it also rebuilds the lazy-loader manifests via `scripts/build-api-manifest.mjs` and `scripts/build-kb-manifest.mts`. The hand-written `src/es/apis.ts` and `src/kb/apis.ts` lazy loaders are intentionally not overwritten. No new runtime or dev dependencies — only Node, git and npm from the environment.
- Fixes `scripts/build-kb-manifest.mts`: it imported the dead `allKbApis` symbol (removed by the lazy-load refactor in #266) and now loads each `src/kb/apis/*.ts` directly. As a side-effect this picks up one endpoint (`post-saved-objects-resolve-import-errors`) that was missing from `src/kb/api-manifest.ts`.
- Documents the local flow in CONTRIBUTING.md under a "Regenerating API bindings" subsection (mentions `CODEGEN_GENERATOR_DIR` for reusing a checkout).

Refs: #79