### PR TITLE
refactor(kb): stack kb aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,12 +171,13 @@ elastic --json version
 
 ### `stack` - Elastic Stack
 
-Interact with Elastic Stack components. Today only `stack es` (Elasticsearch) is
-wired up; `stack kibana` and `stack fleet` are reserved for future work.
+Interact with Elastic Stack components. Both `stack es` (Elasticsearch) and
+`stack kb` (Kibana) are available. Full-name aliases also work:
 
 ```bash
 elastic stack --help
-elastic stack es --help
+elastic stack es --help          # or: elastic stack elasticsearch --help
+elastic stack kb --help          # or: elastic stack kibana --help
 ```
 
 #### `stack es` - Elasticsearch API
@@ -229,6 +230,18 @@ elastic stack es update --index my-index --id abc123
 ```
 
 Run `elastic stack es <command> --help` for all available options on any command.
+
+#### `stack kb` - Kibana API
+
+Run Kibana API calls. Commands are organised by namespace (e.g. `data-views`,
+`cases`, `alerting`). Requires a `kibana` service block in the active context.
+
+```bash
+elastic stack kb data-views list
+elastic stack kb cases list
+```
+
+Run `elastic stack kb --help` to see all available namespaces.
 
 ### `cloud` - Elastic Cloud
 

--- a/README.md
+++ b/README.md
@@ -236,12 +236,21 @@ Run `elastic stack es <command> --help` for all available options on any command
 Run Kibana API calls. Commands are organised by namespace (e.g. `data-views`,
 `cases`, `alerting`). Requires a `kibana` service block in the active context.
 
+All `stack kb` subcommands support:
+
+| Option | Description |
+|---|---|
+| `--dry-run` | Validate inputs and exit without making any API call |
+| `--input-file <path>` | Load command input from a JSON file instead of CLI flags |
+
 ```bash
 elastic stack kb data-views list
+elastic stack kb data-views get --data-view-id <id>
 elastic stack kb cases list
+elastic stack kb alerting list-rule-types
 ```
 
-Run `elastic stack kb --help` to see all available namespaces.
+Run `elastic stack kb <namespace> --help` for all available commands in a namespace.
 
 ### `cloud` - Elastic Cloud
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@
 
 import { Command } from 'commander'
 import { defineCommand, defineGroup, hideBlockedCommands } from './factory.js'
+import type { OpaqueCommandHandle } from './factory.js'
 import { loadConfig, type LoadConfigResult } from './config/loader.ts'
 import { setResolvedConfig } from './config/store.ts'
 
@@ -72,10 +73,37 @@ const { operands } = program.parseOptions(process.argv.slice(2))
 const firstArg = operands[0]
 
 if (firstArg === 'stack') {
-  const { registerEsCommands } = await import('./es/register.ts')
+  const stackChildren: OpaqueCommandHandle[] = []
+
+  const secondArg = operands[1]
+  const esArgs = new Set(['es', 'elasticsearch'])
+  const kbArgs = new Set(['kb', 'kibana'])
+
+  if (secondArg == null || esArgs.has(secondArg)) {
+    const { registerEsCommands } = await import('./es/register.ts')
+    const esGroup = registerEsCommands()
+    esGroup.alias('elasticsearch')
+    stackChildren.push(esGroup)
+  } else {
+    const esStub = defineGroup({ name: 'es', description: 'Interact with the Elasticsearch API' })
+    esStub.alias('elasticsearch')
+    stackChildren.push(esStub)
+  }
+
+  if (secondArg == null || kbArgs.has(secondArg)) {
+    const { registerKbCommands } = await import('./kb/register.ts')
+    const kbGroup = registerKbCommands()
+    kbGroup.alias('kibana')
+    stackChildren.push(kbGroup)
+  } else {
+    const kbStub = defineGroup({ name: 'kb', description: 'Interact with the Kibana API' })
+    kbStub.alias('kibana')
+    stackChildren.push(kbStub)
+  }
+
   program.addCommand(defineGroup(
     { name: 'stack', description: 'Interact with Elastic Stack components (Elasticsearch, Kibana, Fleet)' },
-    registerEsCommands()
+    ...stackChildren
   ))
 } else {
   program.addCommand(defineGroup({ name: 'stack', description: 'Interact with Elastic Stack components (Elasticsearch, Kibana, Fleet)' }))
@@ -93,13 +121,6 @@ if (firstArg === 'docs') {
   program.addCommand(registerDocsCommands())
 } else {
   program.addCommand(defineGroup({ name: 'docs', description: 'Search, read, and ask questions about Elastic documentation' }))
-}
-
-if (firstArg === 'kb') {
-  const { registerKbCommands } = await import('./kb/register.ts')
-  program.addCommand(registerKbCommands())
-} else {
-  program.addCommand(defineGroup({ name: 'kb', description: 'Interact with the Kibana API' }))
 }
 
 // Load config early so --help can hide blocked commands. Skip for commands

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -72,7 +72,16 @@ program.addCommand(versionCmd)
 // is registered so the group appears in help text without paying the cost of loading
 // and compiling all API schemas.
 const { operands } = program.parseOptions(process.argv.slice(2))
-const firstArg = operands[0]
+let firstArg = operands[0]
+
+// Deprecation redirect: `elastic kb ...` → `elastic stack kb ...`
+if (firstArg === 'kb') {
+  process.stderr.write('Warning: "elastic kb" is deprecated. Use "elastic stack kb" instead.\n')
+  const kbIdx = process.argv.indexOf('kb', 2)
+  if (kbIdx !== -1) process.argv.splice(kbIdx, 0, 'stack')
+  operands.splice(0, 0, 'stack')
+  firstArg = 'stack'
+}
 
 if (firstArg === 'stack') {
   const stackChildren: OpaqueCommandHandle[] = []

--- a/src/kb/register.ts
+++ b/src/kb/register.ts
@@ -73,12 +73,13 @@ function buildLeafHandle (def: KbApiDefinition): OpaqueCommandHandle {
 }
 
 /**
- * Registers all Kibana API commands under a top-level `kb` group.
+ * Registers all Kibana API commands under a `kb` group, intended to be
+ * nested under the top-level `stack` group by the CLI entrypoint.
  *
- * Definitions with a `namespace` are grouped into a sub-group (`elastic kb <namespace> <name>`).
+ * Definitions with a `namespace` are grouped into a sub-group (`elastic stack kb <namespace> <name>`).
  *
  * @param definitions - flat array of API definitions; defaults to the full built-in registry
- * @returns an `OpaqueCommandHandle` for the top-level `kb` group
+ * @returns an `OpaqueCommandHandle` for the `kb` group, ready for `program.addCommand()`
  */
 export function registerKbCommands (
   definitions: KbApiDefinition[] = allKbApis

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -266,4 +266,16 @@ describe('elastic CLI -- stack command tree', () => {
       await rm(dir, { recursive: true })
     }
   })
+
+  it('`elastic kb --help` redirects to stack kb with deprecation warning', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-kb-deprecation-'))
+    try {
+      const { code, stdout, stderr } = await runCli(['kb', '--help'], { cwd: dir, env: { HOME: dir } })
+      assert.equal(code, 0, `expected exit code 0, got ${code}`)
+      assert.match(stderr, /deprecated.*elastic stack kb/i, 'expected deprecation warning on stderr')
+      assert.match(stdout, /kb\|kibana/m, 'expected kb commands in output')
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
 })

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -207,24 +207,26 @@ describe('elastic CLI -- config-free commands', () => {
 })
 
 describe('elastic CLI -- stack command tree', () => {
-  it('top-level help lists `stack` and not `es`', async () => {
+  it('top-level help lists `stack` and not `es` or `kb`', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-help-'))
     try {
       const { code, stdout } = await runCli(['--help'], { cwd: dir, env: { HOME: dir } })
       assert.equal(code, 0, `expected exit code 0, got ${code}`)
       assert.match(stdout, /^\s*stack\s/m, 'expected `stack` in top-level help')
       assert.doesNotMatch(stdout, /^\s*es\s/m, '`es` must not appear as a top-level command')
+      assert.doesNotMatch(stdout, /^\s*kb\s/m, '`kb` must not appear as a top-level command')
     } finally {
       await rm(dir, { recursive: true })
     }
   })
 
-  it('`elastic stack --help` lists the `es` sub-group', async () => {
+  it('`elastic stack --help` lists `es` and `kb` sub-groups with aliases', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-stack-help-'))
     try {
       const { code, stdout } = await runCli(['stack', '--help'], { cwd: dir, env: { HOME: dir } })
       assert.equal(code, 0, `expected exit code 0, got ${code}`)
-      assert.match(stdout, /^\s*es\s/m, 'expected `es` under stack')
+      assert.match(stdout, /es\|elasticsearch/m, 'expected `es|elasticsearch` under stack')
+      assert.match(stdout, /kb\|kibana/m, 'expected `kb|kibana` under stack')
     } finally {
       await rm(dir, { recursive: true })
     }
@@ -238,6 +240,28 @@ describe('elastic CLI -- stack command tree', () => {
       assert.match(stdout, /^\s*indices\s/m, 'expected `indices` group')
       assert.match(stdout, /^\s*cluster\s/m, 'expected `cluster` group')
       assert.match(stdout, /^\s*ml\s/m, 'expected `ml` group')
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
+  it('`elastic stack elasticsearch --help` works as alias for `elastic stack es`', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-es-alias-'))
+    try {
+      const { code, stdout } = await runCli(['stack', 'elasticsearch', '--help'], { cwd: dir, env: { HOME: dir } })
+      assert.equal(code, 0, `expected exit code 0, got ${code}`)
+      assert.match(stdout, /^\s*indices\s/m, 'expected `indices` group via elasticsearch alias')
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
+  it('`elastic stack kibana --help` works as alias for `elastic stack kb`', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-kb-alias-'))
+    try {
+      const { code, stdout } = await runCli(['stack', 'kibana', '--help'], { cwd: dir, env: { HOME: dir } })
+      assert.equal(code, 0, `expected exit code 0, got ${code}`)
+      assert.match(stdout, /kb\b/m, 'expected kb-related content via kibana alias')
     } finally {
       await rm(dir, { recursive: true })
     }


### PR DESCRIPTION
## Summary

- Move `elastic kb` to `elastic stack kb` for consistency with `elastic stack es` (#193)
- Add `elasticsearch` and `kibana` as full-name aliases so both `elastic stack es` and `elastic stack elasticsearch` work (same for `kb`/`kibana`)
- Lazy-load KB schemas only when `stack kb` or `stack kibana` is invoked (same pattern as ES)
- `elastic stack --help` now shows `es|elasticsearch` and `kb|kibana`

## Test plan

- [x] `elastic stack kb --help` shows Kibana namespaces
- [x] `elastic stack kibana --help` works as alias
- [x] `elastic stack elasticsearch --help` works as alias
- [x] `elastic --help` does not list `kb` or `es` at top level
- [x] `elastic stack --help` lists both `es|elasticsearch` and `kb|kibana`

closes https://github.com/elastic/cli/issues/226