### PR TITLE
feat: implement elastic sanitize command 

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,8 +36,8 @@ let earlyConfig: LoadConfigResult | undefined
 
 program.hook('preAction', async (thisCommand, actionCommand) => {
   if (actionCommand.name() === 'version') return
-  // docs commands use public elastic.co APIs — no config required
   if (actionCommand.parent?.name() === 'docs') return
+  if (actionCommand.parent?.name() === 'sanitize') return
   // `config` commands author the config file itself — loading it would be
   // circular (and must tolerate the absence of a file)
   for (let c = actionCommand.parent; c != null; c = c.parent) {
@@ -146,11 +146,19 @@ if (firstArg === 'config') {
 } else {
   program.addCommand(defineGroup({ name: 'config', description: 'Author and maintain the elastic config file' }))
 }
+
+if (firstArg === 'sanitize') {
+  const { registerSanitizeCommands } = await import('./sanitize/register.ts')
+  program.addCommand(registerSanitizeCommands())
+} else {
+  program.addCommand(defineGroup({ name: 'sanitize', description: 'Sanitize values for safe use in Elasticsearch' }))
+}
+
 // Load config early so --help can hide blocked commands. Skip for commands
-// that don't need config (e.g. `version`, or `config` which authors the file)
+// that don't need config (e.g. `version`, `sanitize`, or `config` which authors the file)
 // to avoid unnecessary file I/O and a confusing "no config found" path.
 // The result is cached in earlyConfig so the preAction hook can reuse it.
-if (firstArg !== 'version' && firstArg !== 'config') {
+if (firstArg !== 'version' && firstArg !== 'config' && firstArg !== 'sanitize') {
   earlyConfig = await loadConfig({})
   if (earlyConfig.ok) {
     setResolvedConfig(earlyConfig.value)

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -112,7 +112,7 @@ export function sanitizeIndexName (value: string): SanitizeResult {
 
   if (s === '.' || s === '..') {
     changes.push('replaced reserved dot name')
-    s = '_dot'
+    s = 'dot'
   }
 
   if (Buffer.byteLength(s, 'utf-8') > 255) {
@@ -167,7 +167,7 @@ export function sanitizeSnapshotName (value: string): SanitizeResult {
 
   if (s === '.' || s === '..') {
     changes.push('replaced reserved dot name')
-    s = '_dot'
+    s = 'dot'
   }
 
   if (Buffer.byteLength(s, 'utf-8') > 255) {

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,305 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Pure sanitization functions for Elasticsearch value types.
+ *
+ * Each sanitizer strips characters that are invalid per the Elasticsearch
+ * server source code, returning the cleaned value and a list of changes
+ * made. Agents use these to clean user-provided inputs before passing them
+ * to CLI commands.
+ *
+ * Sources: `MetadataCreateIndexService`, `SnapshotsServiceUtils`,
+ *          `DataStream`, `ObjectMapper`, `Strings.INVALID_FILENAME_CHARS`.
+ */
+
+/** Result returned by every sanitizer function. */
+export interface SanitizeResult {
+  original: string
+  sanitized: string
+  type: string
+  changes: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+const ZERO_WIDTH_CHARS = new Set([
+  '\u200B', '\u200C', '\u200D', '\u200E', '\u200F',
+  '\uFEFF', '\u00AD',
+  '\u2060', '\u2061', '\u2062', '\u2063', '\u2064',
+])
+
+/**
+ * Truncates `value` to at most `maxBytes` UTF-8 bytes without splitting
+ * multi-byte characters.
+ */
+export function truncateUtf8 (value: string, maxBytes: number): string {
+  const buf = Buffer.from(value, 'utf-8')
+  if (buf.length <= maxBytes) return value
+  let end = maxBytes
+  // Walk backwards to avoid landing in the middle of a multi-byte sequence.
+  // A UTF-8 continuation byte has the form 10xxxxxx (0x80..0xBF).
+  while (end > 0 && (buf[end]! & 0xC0) === 0x80) {
+    end--
+  }
+  return buf.subarray(0, end).toString('utf-8')
+}
+
+function stripChars (value: string, chars: Set<string>): string {
+  let result = ''
+  for (const ch of value) {
+    if (!chars.has(ch)) result += ch
+  }
+  return result
+}
+
+function stripZeroWidth (value: string): string {
+  let result = ''
+  for (const ch of value) {
+    if (!ZERO_WIDTH_CHARS.has(ch)) result += ch
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Index name / alias name
+// ---------------------------------------------------------------------------
+
+const INDEX_FORBIDDEN = new Set([
+  '\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',', '#', ':',
+])
+
+/**
+ * Sanitizes a value for use as an Elasticsearch index name or alias name.
+ *
+ * Rules (from `validateIndexOrAliasName`):
+ * - Lowercase
+ * - Strip `\\/\*?"<>| ,#:`
+ * - Remove leading `_`, `-`, `+`
+ * - Truncate to 255 bytes (UTF-8)
+ * - Replace the reserved literals `.` and `..`
+ */
+export function sanitizeIndexName (value: string): SanitizeResult {
+  const changes: string[] = []
+  let s = stripZeroWidth(value)
+  if (s !== value) changes.push('stripped zero-width characters')
+
+  const lowered = s.toLowerCase()
+  if (lowered !== s) {
+    changes.push('lowercased')
+    s = lowered
+  }
+
+  const noWhitespace = s.replace(/\s/g, '')
+  if (noWhitespace !== s) {
+    changes.push('stripped whitespace')
+    s = noWhitespace
+  }
+
+  const stripped = stripChars(s, INDEX_FORBIDDEN)
+  if (stripped !== s) {
+    changes.push('stripped forbidden characters')
+    s = stripped
+  }
+
+  const beforeLeading = s
+  s = s.replace(/^[_\-+]+/, '')
+  if (s !== beforeLeading) changes.push('removed leading _, -, or + characters')
+
+  if (s === '.' || s === '..') {
+    changes.push('replaced reserved dot name')
+    s = '_dot'
+  }
+
+  if (Buffer.byteLength(s, 'utf-8') > 255) {
+    s = truncateUtf8(s, 255)
+    changes.push('truncated to 255 bytes')
+  }
+
+  if (s.length === 0 && value.length > 0) {
+    changes.push('value is empty after sanitization')
+  }
+
+  return { original: value, sanitized: s, type: 'index-name', changes }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot name
+// ---------------------------------------------------------------------------
+
+/**
+ * Sanitizes a value for use as an Elasticsearch snapshot name.
+ *
+ * Nearly the same rules as index names but:
+ * - All whitespace is stripped (not just spaces)
+ * - Only leading `_` is removed (not `-` or `+`)
+ */
+export function sanitizeSnapshotName (value: string): SanitizeResult {
+  const changes: string[] = []
+  let s = stripZeroWidth(value)
+  if (s !== value) changes.push('stripped zero-width characters')
+
+  const lowered = s.toLowerCase()
+  if (lowered !== s) {
+    changes.push('lowercased')
+    s = lowered
+  }
+
+  const noWhitespace = s.replace(/\s/g, '')
+  if (noWhitespace !== s) {
+    changes.push('stripped whitespace')
+    s = noWhitespace
+  }
+
+  const stripped = stripChars(s, INDEX_FORBIDDEN)
+  if (stripped !== s) {
+    changes.push('stripped forbidden characters')
+    s = stripped
+  }
+
+  const beforeLeading = s
+  s = s.replace(/^_+/, '')
+  if (s !== beforeLeading) changes.push('removed leading _ characters')
+
+  if (s === '.' || s === '..') {
+    changes.push('replaced reserved dot name')
+    s = '_dot'
+  }
+
+  if (Buffer.byteLength(s, 'utf-8') > 255) {
+    s = truncateUtf8(s, 255)
+    changes.push('truncated to 255 bytes')
+  }
+
+  if (s.length === 0 && value.length > 0) {
+    changes.push('value is empty after sanitization')
+  }
+
+  return { original: value, sanitized: s, type: 'snapshot-name', changes }
+}
+
+// ---------------------------------------------------------------------------
+// Data stream components
+// ---------------------------------------------------------------------------
+
+const DATA_STREAM_TYPE_DATASET_FORBIDDEN = new Set([
+  '\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',', '#', ':', '-',
+])
+
+const DATA_STREAM_NAMESPACE_FORBIDDEN = new Set([
+  '\\', '/', '*', '?', '"', '<', '>', '|', ' ', ',', '#', ':',
+])
+
+/** Sanitizes a data stream `type` component. */
+export function sanitizeDataStreamType (value: string): SanitizeResult {
+  return sanitizeDataStreamComponent(value, DATA_STREAM_TYPE_DATASET_FORBIDDEN, 'data-stream-type')
+}
+
+/** Sanitizes a data stream `dataset` component. */
+export function sanitizeDataStreamDataset (value: string): SanitizeResult {
+  return sanitizeDataStreamComponent(value, DATA_STREAM_TYPE_DATASET_FORBIDDEN, 'data-stream-dataset')
+}
+
+/** Sanitizes a data stream `namespace` component (allows hyphens). */
+export function sanitizeDataStreamNamespace (value: string): SanitizeResult {
+  return sanitizeDataStreamComponent(value, DATA_STREAM_NAMESPACE_FORBIDDEN, 'data-stream-namespace')
+}
+
+function sanitizeDataStreamComponent (value: string, forbidden: Set<string>, type: string): SanitizeResult {
+  const changes: string[] = []
+  let s = stripZeroWidth(value)
+  if (s !== value) changes.push('stripped zero-width characters')
+
+  const stripped = stripChars(s, forbidden)
+  if (stripped !== s) {
+    changes.push('stripped forbidden characters')
+    s = stripped
+  }
+
+  if (s.length === 0 && value.length > 0) {
+    changes.push('value is empty after sanitization')
+  }
+
+  return { original: value, sanitized: s, type, changes }
+}
+
+// ---------------------------------------------------------------------------
+// Field name
+// ---------------------------------------------------------------------------
+
+/**
+ * Sanitizes a mapping field name.
+ *
+ * Lighter restrictions: only trims whitespace and warns about dots
+ * (which create object hierarchies in Elasticsearch).
+ */
+export function sanitizeFieldName (value: string): SanitizeResult {
+  const changes: string[] = []
+  let s = stripZeroWidth(value)
+  if (s !== value) changes.push('stripped zero-width characters')
+
+  const trimmed = s.trim()
+  if (trimmed !== s) {
+    changes.push('trimmed whitespace')
+    s = trimmed
+  }
+
+  if (s.length === 0) {
+    changes.push('value is empty after sanitization')
+    return { original: value, sanitized: '', type: 'field-name', changes }
+  }
+
+  if (s.includes('.')) {
+    changes.push('dots present — these create nested object hierarchies in mappings')
+  }
+
+  return { original: value, sanitized: s, type: 'field-name', changes }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline name
+// ---------------------------------------------------------------------------
+
+/**
+ * Sanitizes an ingest pipeline name.
+ * Uses the same rules as index names (`validateIndexOrAliasName`).
+ */
+export function sanitizePipelineName (value: string): SanitizeResult {
+  const result = sanitizeIndexName(value)
+  return { ...result, type: 'pipeline-name' }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshot repository name
+// ---------------------------------------------------------------------------
+
+const FILENAME_FORBIDDEN = new Set([
+  '\\', '/', '*', '?', '"', '<', '>', '|', ':',
+])
+
+/**
+ * Sanitizes a snapshot repository name.
+ * Strips invalid filename characters (`Strings.INVALID_FILENAME_CHARS`).
+ * Does not lowercase — repository names are case-preserving.
+ */
+export function sanitizeRepositoryName (value: string): SanitizeResult {
+  const changes: string[] = []
+  let s = stripZeroWidth(value)
+  if (s !== value) changes.push('stripped zero-width characters')
+
+  const stripped = stripChars(s, FILENAME_FORBIDDEN)
+  if (stripped !== s) {
+    changes.push('stripped invalid filename characters')
+    s = stripped
+  }
+
+  if (s.length === 0 && value.length > 0) {
+    changes.push('value is empty after sanitization')
+  }
+
+  return { original: value, sanitized: s, type: 'repository-name', changes }
+}

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -27,6 +27,7 @@ export interface SanitizeResult {
 // Shared helpers
 // ---------------------------------------------------------------------------
 
+// Best-effort list of common zero-width / invisible characters; not exhaustive.
 const ZERO_WIDTH_CHARS = new Set([
   '\u200B', '\u200C', '\u200D', '\u200E', '\u200F',
   '\uFEFF', '\u00AD',
@@ -50,19 +51,11 @@ export function truncateUtf8 (value: string, maxBytes: number): string {
 }
 
 function stripChars (value: string, chars: Set<string>): string {
-  let result = ''
-  for (const ch of value) {
-    if (!chars.has(ch)) result += ch
-  }
-  return result
+  return Array.from(value).filter(ch => !chars.has(ch)).join('')
 }
 
 function stripZeroWidth (value: string): string {
-  let result = ''
-  for (const ch of value) {
-    if (!ZERO_WIDTH_CHARS.has(ch)) result += ch
-  }
-  return result
+  return Array.from(value).filter(ch => !ZERO_WIDTH_CHARS.has(ch)).join('')
 }
 
 // ---------------------------------------------------------------------------

--- a/src/sanitize/register.ts
+++ b/src/sanitize/register.ts
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */

--- a/src/sanitize/register.ts
+++ b/src/sanitize/register.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * `elastic sanitize <type> <value>` command tree.
+ *
+ * Exposes the pure sanitization functions from {@link ../lib/sanitize.ts} as
+ * CLI subcommands. Each value type is a leaf command with a single positional
+ * argument. The handler returns a structured {@link SanitizeResult} for
+ * `--json` mode; plain-text mode emits just the sanitized string (suitable
+ * for shell substitution via `$(elastic sanitize index-name '...')`).
+ */
+
+import { defineCommand, defineGroup } from '../factory.ts'
+import type { JsonValue, OpaqueCommandHandle } from '../factory.ts'
+import {
+  sanitizeIndexName,
+  sanitizeSnapshotName,
+  sanitizeDataStreamType,
+  sanitizeDataStreamDataset,
+  sanitizeDataStreamNamespace,
+  sanitizeFieldName,
+  sanitizePipelineName,
+  sanitizeRepositoryName,
+  type SanitizeResult,
+} from '../lib/sanitize.ts'
+
+interface SanitizerEntry {
+  name: string
+  description: string
+  fn: (value: string) => SanitizeResult
+}
+
+const SANITIZERS: SanitizerEntry[] = [
+  { name: 'index-name', description: 'Sanitize an Elasticsearch index or alias name', fn: sanitizeIndexName },
+  { name: 'snapshot-name', description: 'Sanitize an Elasticsearch snapshot name', fn: sanitizeSnapshotName },
+  { name: 'data-stream-type', description: 'Sanitize a data stream type component', fn: sanitizeDataStreamType },
+  { name: 'data-stream-dataset', description: 'Sanitize a data stream dataset component', fn: sanitizeDataStreamDataset },
+  { name: 'data-stream-namespace', description: 'Sanitize a data stream namespace component', fn: sanitizeDataStreamNamespace },
+  { name: 'field-name', description: 'Sanitize a mapping field name', fn: sanitizeFieldName },
+  { name: 'pipeline-name', description: 'Sanitize an ingest pipeline name', fn: sanitizePipelineName },
+  { name: 'repository-name', description: 'Sanitize a snapshot repository name', fn: sanitizeRepositoryName },
+]
+
+/**
+ * Builds the `elastic sanitize` command group with one leaf command per
+ * value type.
+ */
+export function registerSanitizeCommands (): OpaqueCommandHandle {
+  const commands = SANITIZERS.map(({ name, description, fn }) =>
+    defineCommand({
+      name,
+      description,
+      positionalArg: { name: 'value', description: 'the value to sanitize', required: true },
+      handler: (parsed) => {
+        const value = parsed.arg ?? ''
+        return fn(value) as unknown as JsonValue
+      },
+      formatOutput: (result) => {
+        const r = result as unknown as SanitizeResult
+        return r.sanitized + '\n'
+      },
+    }),
+  )
+
+  return defineGroup(
+    { name: 'sanitize', description: 'Sanitize values for safe use in Elasticsearch' },
+    ...commands,
+  )
+}

--- a/src/sanitize/register.ts
+++ b/src/sanitize/register.ts
@@ -56,7 +56,19 @@ export function registerSanitizeCommands (): OpaqueCommandHandle {
       positionalArg: { name: 'value', description: 'the value to sanitize', required: true },
       handler: (parsed) => {
         const value = parsed.arg ?? ''
-        return fn(value) as unknown as JsonValue
+        const result = fn(value)
+        if (result.sanitized.length === 0 && value.length > 0) {
+          return {
+            error: {
+              code: 'sanitize_empty',
+              message: `value became empty after sanitization`,
+              original: value,
+              type: result.type,
+              changes: result.changes,
+            },
+          }
+        }
+        return result as unknown as JsonValue
       },
       formatOutput: (result) => {
         const r = result as unknown as SanitizeResult

--- a/src/sanitize/register.ts
+++ b/src/sanitize/register.ts
@@ -60,6 +60,9 @@ export function registerSanitizeCommands (): OpaqueCommandHandle {
       },
       formatOutput: (result) => {
         const r = result as unknown as SanitizeResult
+        if (r.changes.length > 0) {
+          process.stderr.write(`# changes: ${r.changes.join(', ')}\n`)
+        }
         return r.sanitized + '\n'
       },
     }),

--- a/test/lib/sanitize.test.ts
+++ b/test/lib/sanitize.test.ts
@@ -102,6 +102,20 @@ describe('sanitizeIndexName', () => {
     assert.ok(r.changes.some(c => /dot/i.test(c) || /reserved/i.test(c)))
   })
 
+  it('dot replacement is idempotent (sanitizing twice gives the same result)', () => {
+    const first = sanitizeIndexName('.')
+    const second = sanitizeIndexName(first.sanitized)
+    assert.equal(second.sanitized, first.sanitized)
+    assert.equal(second.changes.length, 0)
+  })
+
+  it('double-dot replacement is idempotent', () => {
+    const first = sanitizeIndexName('..')
+    const second = sanitizeIndexName(first.sanitized)
+    assert.equal(second.sanitized, first.sanitized)
+    assert.equal(second.changes.length, 0)
+  })
+
   it('strips zero-width characters', () => {
     const r = sanitizeIndexName('my\u200Bindex\uFEFF')
     assert.equal(r.sanitized, 'myindex')
@@ -166,6 +180,13 @@ describe('sanitizeSnapshotName', () => {
     const long = 'a'.repeat(300)
     const r = sanitizeSnapshotName(long)
     assert.equal(Buffer.byteLength(r.sanitized, 'utf-8'), 255)
+  })
+
+  it('dot replacement is idempotent', () => {
+    const first = sanitizeSnapshotName('.')
+    const second = sanitizeSnapshotName(first.sanitized)
+    assert.equal(second.sanitized, first.sanitized)
+    assert.equal(second.changes.length, 0)
   })
 })
 

--- a/test/lib/sanitize.test.ts
+++ b/test/lib/sanitize.test.ts
@@ -1,0 +1,315 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  sanitizeIndexName,
+  sanitizeSnapshotName,
+  sanitizeDataStreamType,
+  sanitizeDataStreamDataset,
+  sanitizeDataStreamNamespace,
+  sanitizeFieldName,
+  sanitizePipelineName,
+  sanitizeRepositoryName,
+  truncateUtf8,
+  type SanitizeResult,
+} from '../../src/lib/sanitize.ts'
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+describe('truncateUtf8', () => {
+  it('returns the string unchanged when within byte limit', () => {
+    assert.equal(truncateUtf8('hello', 255), 'hello')
+  })
+
+  it('truncates ASCII strings to the byte limit', () => {
+    const long = 'a'.repeat(300)
+    const result = truncateUtf8(long, 255)
+    assert.equal(result.length, 255)
+    assert.equal(Buffer.byteLength(result, 'utf-8'), 255)
+  })
+
+  it('does not split multi-byte characters', () => {
+    // Each emoji is 4 bytes. 63 emojis = 252 bytes, 64 = 256 > 255.
+    const emojis = '😀'.repeat(64)
+    const result = truncateUtf8(emojis, 255)
+    assert.equal(Buffer.byteLength(result, 'utf-8'), 252)
+    assert.equal(result.length, 63 * 2) // each emoji is 2 UTF-16 code units
+  })
+
+  it('handles 2-byte characters at the boundary', () => {
+    // 'ñ' is 2 bytes in UTF-8. 127 ñ = 254 bytes, 128 = 256 > 255.
+    const input = 'ñ'.repeat(128)
+    const result = truncateUtf8(input, 255)
+    assert.equal(Buffer.byteLength(result, 'utf-8'), 254)
+  })
+
+  it('returns empty string for empty input', () => {
+    assert.equal(truncateUtf8('', 255), '')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Index name / alias name
+// ---------------------------------------------------------------------------
+
+describe('sanitizeIndexName', () => {
+  it('passes through a valid lowercase index name', () => {
+    const r = sanitizeIndexName('my-index-001')
+    assert.equal(r.sanitized, 'my-index-001')
+    assert.deepEqual(r.changes, [])
+  })
+
+  it('lowercases the value', () => {
+    const r = sanitizeIndexName('My-Index')
+    assert.equal(r.sanitized, 'my-index')
+    assert.ok(r.changes.some(c => /lowercase/i.test(c)))
+  })
+
+  it('strips forbidden characters', () => {
+    const r = sanitizeIndexName('my\\index/name*with?bad"chars<>|and spaces,#:')
+    assert.equal(r.sanitized, 'myindexnamewithbadcharsandspaces')
+    assert.ok(r.changes.some(c => /stripped/i.test(c) || /removed/i.test(c)))
+  })
+
+  it('removes leading _, -, +', () => {
+    const r = sanitizeIndexName('_-+my-index')
+    assert.equal(r.sanitized, 'my-index')
+    assert.ok(r.changes.some(c => /leading/i.test(c)))
+  })
+
+  it('truncates to 255 bytes', () => {
+    const long = 'a'.repeat(300)
+    const r = sanitizeIndexName(long)
+    assert.equal(Buffer.byteLength(r.sanitized, 'utf-8'), 255)
+    assert.ok(r.changes.some(c => /truncat/i.test(c)))
+  })
+
+  it('replaces "." with a safe alternative', () => {
+    const r = sanitizeIndexName('.')
+    assert.notEqual(r.sanitized, '.')
+    assert.notEqual(r.sanitized, '')
+    assert.ok(r.changes.some(c => /dot/i.test(c) || /reserved/i.test(c)))
+  })
+
+  it('replaces ".." with a safe alternative', () => {
+    const r = sanitizeIndexName('..')
+    assert.notEqual(r.sanitized, '..')
+    assert.ok(r.changes.some(c => /dot/i.test(c) || /reserved/i.test(c)))
+  })
+
+  it('strips zero-width characters', () => {
+    const r = sanitizeIndexName('my\u200Bindex\uFEFF')
+    assert.equal(r.sanitized, 'myindex')
+  })
+
+  it('returns an error result when input sanitizes to empty', () => {
+    const r = sanitizeIndexName('***')
+    assert.equal(r.sanitized, '')
+    assert.ok(r.changes.some(c => /empty/i.test(c)))
+  })
+
+  it('preserves dots in the middle of a name', () => {
+    const r = sanitizeIndexName('my.index.name')
+    assert.equal(r.sanitized, 'my.index.name')
+  })
+
+  it('strips newlines and other whitespace (issue #76 example)', () => {
+    const r = sanitizeIndexName(' foo\nbar')
+    assert.equal(r.sanitized, 'foobar')
+    assert.ok(r.changes.some(c => /whitespace/i.test(c)))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Snapshot name
+// ---------------------------------------------------------------------------
+
+describe('sanitizeSnapshotName', () => {
+  it('passes through a valid snapshot name', () => {
+    const r = sanitizeSnapshotName('daily-backup-001')
+    assert.equal(r.sanitized, 'daily-backup-001')
+    assert.deepEqual(r.changes, [])
+  })
+
+  it('lowercases the value', () => {
+    const r = sanitizeSnapshotName('MySnapshot')
+    assert.equal(r.sanitized, 'mysnapshot')
+  })
+
+  it('strips all whitespace (not just leading/trailing)', () => {
+    const r = sanitizeSnapshotName('my snapshot name')
+    assert.equal(r.sanitized, 'mysnapshotname')
+  })
+
+  it('removes leading _ only (not - or +)', () => {
+    const r = sanitizeSnapshotName('_snapshot')
+    assert.equal(r.sanitized, 'snapshot')
+
+    const r2 = sanitizeSnapshotName('-snapshot')
+    assert.equal(r2.sanitized, '-snapshot')
+
+    const r3 = sanitizeSnapshotName('+snapshot')
+    assert.equal(r3.sanitized, '+snapshot')
+  })
+
+  it('strips the same forbidden characters as index names', () => {
+    const r = sanitizeSnapshotName('snap\\shot/with*bad?chars')
+    assert.equal(r.sanitized, 'snapshotwithbadchars')
+  })
+
+  it('truncates to 255 bytes', () => {
+    const long = 'a'.repeat(300)
+    const r = sanitizeSnapshotName(long)
+    assert.equal(Buffer.byteLength(r.sanitized, 'utf-8'), 255)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Data stream components
+// ---------------------------------------------------------------------------
+
+describe('sanitizeDataStreamType', () => {
+  it('passes through a valid type', () => {
+    const r = sanitizeDataStreamType('logs')
+    assert.equal(r.sanitized, 'logs')
+    assert.deepEqual(r.changes, [])
+  })
+
+  it('strips forbidden characters including hyphens', () => {
+    const r = sanitizeDataStreamType('my-log\\type')
+    assert.equal(r.sanitized, 'mylogtype')
+  })
+
+  it('strips spaces, commas, hash, colon', () => {
+    const r = sanitizeDataStreamType('my type,with#extras:here')
+    assert.equal(r.sanitized, 'mytypewithextrashere')
+  })
+})
+
+describe('sanitizeDataStreamDataset', () => {
+  it('passes through a valid dataset', () => {
+    const r = sanitizeDataStreamDataset('nginx.access')
+    assert.equal(r.sanitized, 'nginx.access')
+    assert.deepEqual(r.changes, [])
+  })
+
+  it('strips hyphens', () => {
+    const r = sanitizeDataStreamDataset('my-dataset')
+    assert.equal(r.sanitized, 'mydataset')
+  })
+})
+
+describe('sanitizeDataStreamNamespace', () => {
+  it('passes through a valid namespace', () => {
+    const r = sanitizeDataStreamNamespace('production')
+    assert.equal(r.sanitized, 'production')
+    assert.deepEqual(r.changes, [])
+  })
+
+  it('allows hyphens (unlike type/dataset)', () => {
+    const r = sanitizeDataStreamNamespace('my-namespace')
+    assert.equal(r.sanitized, 'my-namespace')
+    assert.deepEqual(r.changes, [])
+  })
+
+  it('strips other forbidden characters', () => {
+    const r = sanitizeDataStreamNamespace('my namespace*with|bad')
+    assert.equal(r.sanitized, 'mynamespacewithbad')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Field name
+// ---------------------------------------------------------------------------
+
+describe('sanitizeFieldName', () => {
+  it('passes through a valid field name', () => {
+    const r = sanitizeFieldName('message')
+    assert.equal(r.sanitized, 'message')
+    assert.deepEqual(r.changes, [])
+  })
+
+  it('trims leading and trailing whitespace', () => {
+    const r = sanitizeFieldName('  message  ')
+    assert.equal(r.sanitized, 'message')
+    assert.ok(r.changes.some(c => /trim/i.test(c) || /whitespace/i.test(c)))
+  })
+
+  it('warns when dots are present (but preserves them)', () => {
+    const r = sanitizeFieldName('host.name')
+    assert.equal(r.sanitized, 'host.name')
+    assert.ok(r.changes.some(c => /dot/i.test(c)))
+  })
+
+  it('returns an error for empty input', () => {
+    const r = sanitizeFieldName('')
+    assert.equal(r.sanitized, '')
+    assert.ok(r.changes.some(c => /empty/i.test(c)))
+  })
+
+  it('returns an error for whitespace-only input', () => {
+    const r = sanitizeFieldName('   ')
+    assert.equal(r.sanitized, '')
+    assert.ok(r.changes.some(c => /empty/i.test(c)))
+  })
+
+  it('strips zero-width characters', () => {
+    const r = sanitizeFieldName('my\u200Bfield')
+    assert.equal(r.sanitized, 'myfield')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Pipeline name
+// ---------------------------------------------------------------------------
+
+describe('sanitizePipelineName', () => {
+  it('applies the same rules as index names', () => {
+    const r = sanitizePipelineName('My\\Pipeline*Name')
+    assert.equal(r.sanitized, 'mypipelinename')
+  })
+
+  it('removes leading _-+ characters', () => {
+    const r = sanitizePipelineName('_my-pipeline')
+    assert.equal(r.sanitized, 'my-pipeline')
+  })
+
+  it('truncates to 255 bytes', () => {
+    const long = 'p'.repeat(300)
+    const r = sanitizePipelineName(long)
+    assert.equal(Buffer.byteLength(r.sanitized, 'utf-8'), 255)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Repository name
+// ---------------------------------------------------------------------------
+
+describe('sanitizeRepositoryName', () => {
+  it('passes through a valid repository name', () => {
+    const r = sanitizeRepositoryName('my-backup-repo')
+    assert.equal(r.sanitized, 'my-backup-repo')
+    assert.deepEqual(r.changes, [])
+  })
+
+  it('strips invalid filename characters', () => {
+    const r = sanitizeRepositoryName('my\\repo/with*bad?chars"<>|:')
+    assert.equal(r.sanitized, 'myrepowithbadchars')
+  })
+
+  it('preserves case (unlike index names)', () => {
+    const r = sanitizeRepositoryName('MyRepo')
+    assert.equal(r.sanitized, 'MyRepo')
+  })
+
+  it('strips zero-width characters', () => {
+    const r = sanitizeRepositoryName('my\u200Brepo')
+    assert.equal(r.sanitized, 'myrepo')
+  })
+})

--- a/test/lib/sanitize.test.ts
+++ b/test/lib/sanitize.test.ts
@@ -15,7 +15,6 @@ import {
   sanitizePipelineName,
   sanitizeRepositoryName,
   truncateUtf8,
-  type SanitizeResult,
 } from '../../src/lib/sanitize.ts'
 
 // ---------------------------------------------------------------------------

--- a/test/sanitize/register.test.ts
+++ b/test/sanitize/register.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { registerSanitizeCommands } from '../../src/sanitize/register.ts'
+
+describe('registerSanitizeCommands', () => {
+  it('creates a group named "sanitize"', () => {
+    const group = registerSanitizeCommands()
+    assert.equal(group.name(), 'sanitize')
+  })
+
+  it('has subcommands for all supported value types', () => {
+    const group = registerSanitizeCommands()
+    const subNames = group.commands.map((c: { name: () => string }) => c.name()).sort()
+    assert.deepEqual(subNames, [
+      'data-stream-dataset',
+      'data-stream-namespace',
+      'data-stream-type',
+      'field-name',
+      'index-name',
+      'pipeline-name',
+      'repository-name',
+      'snapshot-name',
+    ])
+  })
+
+  it('each subcommand has a positional value argument', () => {
+    const group = registerSanitizeCommands()
+    for (const cmd of group.commands as Array<{ name: () => string; registeredArguments: Array<{ name: () => string }> }>) {
+      const args = cmd.registeredArguments
+      assert.equal(args.length, 1, `${cmd.name()} should have one positional arg`)
+      assert.equal(args[0].name(), 'value')
+    }
+  })
+
+  it('index-name handler returns sanitized result', async () => {
+    const group = registerSanitizeCommands()
+    const indexCmd = (group.commands as Array<{ name: () => string }>).find(c => c.name() === 'index-name')!
+    assert.ok(indexCmd);
+
+    // Use parseAsync to invoke the handler through Commander
+    (indexCmd as import('commander').Command).exitOverride()
+    const written: string[] = []
+    const origWrite = process.stdout.write.bind(process.stdout)
+    process.stdout.write = ((chunk: string) => { written.push(chunk); return true }) as typeof process.stdout.write
+    try {
+      await (indexCmd as import('commander').Command).parseAsync(['My\\Bad*Index'], { from: 'user' })
+    } finally {
+      process.stdout.write = origWrite
+    }
+
+    const output = written.join('')
+    assert.ok(output.includes('mybadindex'), `expected sanitized value in output, got: ${output}`)
+  })
+})

--- a/test/sanitize/register.test.ts
+++ b/test/sanitize/register.test.ts
@@ -56,4 +56,50 @@ describe('registerSanitizeCommands', () => {
     const output = written.join('')
     assert.ok(output.includes('mybadindex'), `expected sanitized value in output, got: ${output}`)
   })
+
+  it('plain-text mode writes changes to stderr when input was modified', async () => {
+    const group = registerSanitizeCommands()
+    const indexCmd = (group.commands as Array<{ name: () => string }>).find(c => c.name() === 'index-name')!;
+
+    (indexCmd as import('commander').Command).exitOverride()
+    const stdoutChunks: string[] = []
+    const stderrChunks: string[] = []
+    const origStdout = process.stdout.write.bind(process.stdout)
+    const origStderr = process.stderr.write.bind(process.stderr)
+    process.stdout.write = ((chunk: string) => { stdoutChunks.push(chunk); return true }) as typeof process.stdout.write
+    process.stderr.write = ((chunk: string) => { stderrChunks.push(chunk); return true }) as typeof process.stderr.write
+    try {
+      await (indexCmd as import('commander').Command).parseAsync(['My*Index'], { from: 'user' })
+    } finally {
+      process.stdout.write = origStdout
+      process.stderr.write = origStderr
+    }
+
+    const stdout = stdoutChunks.join('')
+    const stderr = stderrChunks.join('')
+    assert.ok(stdout.includes('myindex'), `stdout should have sanitized value, got: ${stdout}`)
+    assert.ok(stderr.includes('lowercased'), `stderr should list changes, got: ${stderr}`)
+    assert.ok(stderr.includes('stripped forbidden characters'), `stderr should list changes, got: ${stderr}`)
+  })
+
+  it('plain-text mode does not write to stderr when input is unchanged', async () => {
+    const group = registerSanitizeCommands()
+    const indexCmd = (group.commands as Array<{ name: () => string }>).find(c => c.name() === 'index-name')!;
+
+    (indexCmd as import('commander').Command).exitOverride()
+    const stderrChunks: string[] = []
+    const origStdout = process.stdout.write.bind(process.stdout)
+    const origStderr = process.stderr.write.bind(process.stderr)
+    process.stdout.write = (() => true) as typeof process.stdout.write
+    process.stderr.write = ((chunk: string) => { stderrChunks.push(chunk); return true }) as typeof process.stderr.write
+    try {
+      await (indexCmd as import('commander').Command).parseAsync(['validname'], { from: 'user' })
+    } finally {
+      process.stdout.write = origStdout
+      process.stderr.write = origStderr
+    }
+
+    const stderr = stderrChunks.join('')
+    assert.equal(stderr, '', `stderr should be empty when no changes, got: ${stderr}`)
+  })
 })

--- a/test/sanitize/register.test.ts
+++ b/test/sanitize/register.test.ts
@@ -82,6 +82,31 @@ describe('registerSanitizeCommands', () => {
     assert.ok(stderr.includes('stripped forbidden characters'), `stderr should list changes, got: ${stderr}`)
   })
 
+  it('returns error result when value is empty after sanitization', async () => {
+    const group = registerSanitizeCommands()
+    const indexCmd = (group.commands as Array<{ name: () => string }>).find(c => c.name() === 'index-name')!;
+
+    (indexCmd as import('commander').Command).exitOverride()
+    const stdoutChunks: string[] = []
+    const stderrChunks: string[] = []
+    const origStdout = process.stdout.write.bind(process.stdout)
+    const origStderr = process.stderr.write.bind(process.stderr)
+    const origExitCode = process.exitCode
+    process.stdout.write = ((chunk: string) => { stdoutChunks.push(chunk); return true }) as typeof process.stdout.write
+    process.stderr.write = ((chunk: string) => { stderrChunks.push(chunk); return true }) as typeof process.stderr.write
+    try {
+      await (indexCmd as import('commander').Command).parseAsync(['***'], { from: 'user' })
+    } finally {
+      process.stdout.write = origStdout
+      process.stderr.write = origStderr
+      process.exitCode = origExitCode
+    }
+
+    const stderr = stderrChunks.join('')
+    assert.equal(stdoutChunks.join(''), '', 'stdout should be empty')
+    assert.ok(stderr.includes('sanitize_empty') || stderr.includes('empty after sanitization'), `stderr should report empty result, got: ${stderr}`)
+  })
+
   it('plain-text mode does not write to stderr when input is unchanged', async () => {
     const group = registerSanitizeCommands()
     const indexCmd = (group.commands as Array<{ name: () => string }>).find(c => c.name() === 'index-name')!;


### PR DESCRIPTION
Closes https://github.com/elastic/cli/issues/76
## Summary

Implements `elastic sanitize <type> <value>` (#76) a utility command that agents (or humans) can use to clean values before passing them to other CLI commands. Each Elasticsearch value type has its own subcommand with rules sourced from the ES server codebase.

### Supported types

| Subcommand | Key rules |
|---|---|
| `index-name` | lowercase, strip `\/\*?"<>\|,#: `, remove leading `_-+`, replace `.`/`..`, truncate 255B |
| `snapshot-name` | same as index-name but only strips leading `_`, strips all whitespace |
| `data-stream-type` | strip forbidden chars including `-` |
| `data-stream-dataset` | same as type |
| `data-stream-namespace` | same as type but allows `-` |
| `field-name` | trim whitespace, warn on dots (they create object hierarchies) |
| `pipeline-name` | delegates to index-name rules |
| `repository-name` | strip invalid filename chars, case-preserving |

All sanitizers also strip zero-width characters (ZWSP, ZWNJ, BOM, soft hyphen, etc.) and handle UTF-8 truncation without splitting multi-byte characters.

### Usage

```bash
# Plain text (shell-substitution friendly)
elastic sanitize index-name ' foo\nbar'
# => foobar

# Structured output for agents
elastic sanitize index-name 'My*Index' --json
# => {"original":"My*Index","sanitized":"myindex","type":"index-name","changes":["lowercased","stripped forbidden characters"]}