### PR TITLE
feat: add elastic esql command group

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -145,6 +145,13 @@ if (firstArg === 'config') {
 } else {
   program.addCommand(defineGroup({ name: 'config', description: 'Author and maintain the elastic config file' }))
 }
+
+if (firstArg === 'esql') {
+  const { registerEsqlCommands } = await import('./esql/register.ts')
+  program.addCommand(registerEsqlCommands())
+} else {
+  program.addCommand(defineGroup({ name: 'esql', description: 'Query Elasticsearch using ES|QL from the command line' }))
+}
 // Load config early so --help can hide blocked commands. Skip for commands
 // that don't need config (e.g. `version`, or `config` which authors the file)
 // to avoid unnecessary file I/O and a confusing "no config found" path.

--- a/src/esql/commands/check.ts
+++ b/src/esql/commands/check.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Command } from 'commander'
+import { runQuery } from '../esql-client.ts'
+import { applyParams } from '../saved-queries.ts'
+import { handleError } from './query.ts'
+
+const OPERATORS = ['<=', '>=', '!=', '==', '<', '>'] as const
+type Operator = typeof OPERATORS[number]
+
+export interface Assertion {
+  column: string
+  operator: Operator
+  value: string
+}
+
+export function parseAssertion (expr: string): Assertion {
+  for (const op of OPERATORS) {
+    const idx = expr.indexOf(op)
+    if (idx < 0) continue
+    const column = expr.slice(0, idx).trim()
+    const value = expr.slice(idx + op.length).trim()
+    if (!column) throw new Error(`Missing column name in assertion: "${expr}"`)
+    if (!value) throw new Error(`Missing value in assertion: "${expr}"`)
+    return { column, operator: op, value }
+  }
+  throw new Error(`No valid operator in assertion: "${expr}" (supported: ${OPERATORS.join(', ')})`)
+}
+
+function toNumber (v: unknown): number | null {
+  if (typeof v === 'number') return v
+  if (typeof v === 'string') { const n = parseFloat(v); return isNaN(n) ? null : n }
+  return null
+}
+
+export function evalAssertion (a: Assertion, actual: unknown): boolean {
+  const actualNum = toNumber(actual)
+  const expectedNum = toNumber(a.value)
+
+  if (actualNum !== null && expectedNum !== null) {
+    switch (a.operator) {
+      case '<':  return actualNum < expectedNum
+      case '<=': return actualNum <= expectedNum
+      case '>':  return actualNum > expectedNum
+      case '>=': return actualNum >= expectedNum
+      case '==': return actualNum === expectedNum
+      case '!=': return actualNum !== expectedNum
+    }
+  }
+
+  const actualStr = String(actual ?? '')
+  switch (a.operator) {
+    case '<':  return actualStr < a.value
+    case '<=': return actualStr <= a.value
+    case '>':  return actualStr > a.value
+    case '>=': return actualStr >= a.value
+    case '==': return actualStr === a.value
+    case '!=': return actualStr !== a.value
+  }
+}
+
+export function createCheckCommand (): Command {
+  const cmd = new Command('check')
+  cmd.description('Run a query and assert conditions on the result')
+  cmd.argument('<query>', 'ES|QL query to execute')
+  cmd.option('--assert <expr>', 'assertion in "column op value" format (repeatable)', (v, a: string[]) => [...a, v], [] as string[])
+  cmd.option('--quiet', 'suppress output; only set exit code')
+  cmd.option('--timeout <duration>', 'per-query timeout (e.g. 60s, 5m)')
+  cmd.option('--param <kv>', 'key=value for {{placeholder}} substitution (repeatable)', (v, a: string[]) => [...a, v], [] as string[])
+  cmd.allowExcessArguments(false)
+
+  cmd.action(async (queryArg: string, options: Record<string, unknown>) => {
+    const assertExprs = options.assert as string[]
+    if (!assertExprs || assertExprs.length === 0) {
+      process.stderr.write('Error: at least one --assert expression is required\n')
+      process.exitCode = 1
+      return
+    }
+
+    let assertions: Assertion[]
+    try {
+      assertions = assertExprs.map(parseAssertion)
+    } catch (err) {
+      process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`)
+      process.exitCode = 1
+      return
+    }
+
+    const params = options.param as string[]
+    let query = queryArg
+    if (params.length > 0) { query = applyParams(query, params) }
+
+    const quiet = !!(options.quiet)
+
+    try {
+      const resp = await runQuery(query)
+
+      if (resp.values.length === 0) {
+        process.stderr.write('Error: query returned no rows — cannot evaluate assertions\n')
+        process.exitCode = 1
+        return
+      }
+
+      const colIndex = new Map(resp.columns.map((c, i) => [c.name, i]))
+      const row = resp.values[0]!
+      let allPassed = true
+
+      for (const a of assertions) {
+        const idx = colIndex.get(a.column)
+        if (idx === undefined) {
+          const available = resp.columns.map(c => c.name).join(', ')
+          process.stderr.write(`Error: column "${a.column}" not found (available: ${available})\n`)
+          process.exitCode = 1
+          return
+        }
+
+        const actual = row[idx]
+        const passed = evalAssertion(a, actual)
+        if (!quiet) {
+          const status = passed ? 'PASS' : 'FAIL'
+          process.stderr.write(`${status}: ${a.column} ${a.operator} ${a.value} (actual: ${actual})\n`)
+        }
+        if (!passed) allPassed = false
+      }
+
+      if (!allPassed) {
+        process.exitCode = 1
+      }
+    } catch (err) {
+      handleError(err)
+    }
+  })
+
+  return cmd
+}

--- a/src/esql/commands/queries.ts
+++ b/src/esql/commands/queries.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Command } from 'commander'
+import Table from 'cli-table3'
+import { loadSavedQueries, saveSavedQueries, applyParams } from '../saved-queries.ts'
+import { runQuery } from '../esql-client.ts'
+import { formatOutput, defaultFormat } from '../formatter.ts'
+import { handleError } from './query.ts'
+
+function createQueriesListCommand (): Command {
+  const cmd = new Command('list')
+  cmd.description('List all saved queries')
+  cmd.action(() => {
+    const file = loadSavedQueries()
+    const names = Object.keys(file.queries).sort()
+
+    if (names.length === 0) {
+      process.stderr.write("No saved queries. Use 'elastic esql save <name> <query>' to save one.\n")
+      return
+    }
+
+    const table = new Table({ head: ['name', 'query'], style: { head: [] } })
+    for (const name of names) {
+      const sq = file.queries[name]!
+      const preview = sq.query.length > 80 ? sq.query.slice(0, 77) + '...' : sq.query
+      table.push([name, preview])
+    }
+    process.stdout.write(table.toString() + '\n')
+  })
+  return cmd
+}
+
+function createQueriesRunCommand (): Command {
+  const cmd = new Command('run')
+  cmd.description('Run a saved query')
+  cmd.argument('<name>', 'name of the saved query to run')
+  cmd.option('-f, --format <fmt>', 'output format: table, json, ndjson, csv, tsv')
+  cmd.option('--no-header', 'suppress column headers')
+  cmd.option('--delimiter <char>', 'custom field delimiter')
+  cmd.option('--columns <list>', 'comma-separated list of columns to include')
+  cmd.option('-o, --output <file>', 'write results to file instead of stdout')
+  cmd.option('--quiet', 'suppress incidental stderr')
+  cmd.option('--param <kv>', 'key=value for {{placeholder}} substitution (repeatable)', (v, a: string[]) => [...a, v], [] as string[])
+  cmd.allowExcessArguments(false)
+
+  cmd.action(async (name: string, options: Record<string, unknown>) => {
+    const file = loadSavedQueries()
+    const sq = file.queries[name]
+    if (!sq) {
+      process.stderr.write(`Error: unknown query "${name}" — run: elastic esql queries list\n`)
+      process.exitCode = 1; return
+    }
+
+    const params = options.param as string[]
+    let query = sq.query
+    if (params.length > 0) query = applyParams(query, params)
+
+    const quiet = !!(options.quiet)
+    if (sq.cluster && !quiet) {
+      process.stderr.write(`Using cluster: ${sq.cluster}\n`)
+    }
+
+    const format = (options.format as string | undefined) ?? defaultFormat()
+    const delimiter = options.delimiter as string | undefined
+    const noHeader = !(options.header as boolean ?? true)
+    const columnsRaw = options.columns as string | undefined
+    const columns = columnsRaw ? columnsRaw.split(',').map(c => c.trim()).filter(Boolean) : undefined
+
+    try {
+      const resp = await runQuery(query)
+      formatOutput(resp, { format, noHeader, delimiter, columns }, process.stdout)
+      if (!quiet && process.stdout.isTTY) {
+        process.stderr.write(`\n${resp.values.length} rows in set (${resp.took}ms)\n`)
+      }
+    } catch (err) {
+      handleError(err)
+    }
+  })
+
+  return cmd
+}
+
+function createQueriesRemoveCommand (): Command {
+  const cmd = new Command('remove')
+  cmd.description('Remove a saved query')
+  cmd.argument('<name>', 'name of the query to remove')
+  cmd.allowExcessArguments(false)
+
+  cmd.action((name: string) => {
+    const file = loadSavedQueries()
+    if (!(name in file.queries)) {
+      process.stderr.write(`Error: unknown query "${name}" — run: elastic esql queries list\n`)
+      process.exitCode = 1; return
+    }
+    delete file.queries[name]
+    saveSavedQueries(file)
+    process.stderr.write(`Query '${name}' removed.\n`)
+  })
+
+  return cmd
+}
+
+export function createQueriesCommand (): Command {
+  const cmd = new Command('queries')
+  cmd.description('Manage saved ES|QL queries')
+  cmd.addCommand(createQueriesListCommand())
+  cmd.addCommand(createQueriesRunCommand())
+  cmd.addCommand(createQueriesRemoveCommand())
+  cmd.action(function (this: Command) {
+    if (this.args.length > 0) {
+      this.error(`unknown command: ${this.args[0]}`)
+    } else {
+      this.help()
+    }
+  })
+  return cmd
+}

--- a/src/esql/commands/query.ts
+++ b/src/esql/commands/query.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Command } from 'commander'
+import { readFileSync, createWriteStream } from 'node:fs'
+import { runQuery, EsqlError } from '../esql-client.ts'
+import { formatOutput, printStats, defaultFormat, warnIfPartial } from '../formatter.ts'
+import { applyParams } from '../saved-queries.ts'
+import { injectWhere } from '../inject.ts'
+
+export function splitQueries (input: string): string[] {
+  return input.split(';').map(q => q.trim()).filter(q => q !== '')
+}
+
+function parseDuration (s: string): number | null {
+  const m = /^(\d+(?:\.\d+)?)(ms|s|m|h|d|w)$/.exec(s)
+  if (!m) return null
+  const n = parseFloat(m[1]!)
+  switch (m[2]) {
+    case 'ms': return n
+    case 's':  return n * 1_000
+    case 'm':  return n * 60_000
+    case 'h':  return n * 3_600_000
+    case 'd':  return n * 86_400_000
+    case 'w':  return n * 7 * 86_400_000
+    default:   return null
+  }
+}
+
+export function parseRelativeTime (s: string, now: Date): Date {
+  const ms = parseDuration(s)
+  if (ms !== null) return new Date(now.getTime() - ms)
+  const d = new Date(s)
+  if (!isNaN(d.getTime())) return d
+  throw new Error(`Invalid time value: "${s}" — use a duration (e.g. 1h, 30m, 2d, 1w) or ISO date`)
+}
+
+export function applyTimeFlagsToQuery (
+  query: string,
+  since: string | undefined,
+  until: string | undefined,
+  now: Date,
+  tsField = '@timestamp',
+): string {
+  const sinceDate = since != null ? parseRelativeTime(since, now) : undefined
+  const untilDate = until != null ? parseRelativeTime(until, now) : undefined
+  if (sinceDate != null && untilDate != null && sinceDate >= untilDate) {
+    throw new Error('--since must be earlier than --until (time range is empty or reversed)')
+  }
+  const parts: string[] = []
+  if (sinceDate != null) parts.push(`${tsField} >= "${sinceDate.toISOString()}"`)
+  if (untilDate != null) parts.push(`${tsField} <= "${untilDate.toISOString()}"`)
+  if (parts.length === 0) return query
+  return injectWhere(query, parts.join(' AND '))
+}
+
+export function createQueryCommand (): Command {
+  const cmd = new Command('query')
+  cmd.description('Execute an ES|QL query')
+  cmd.argument('[query]', 'ES|QL query string, or "-" to read from stdin')
+  cmd.option('-f, --format <fmt>', 'output format: table, json, ndjson, csv, tsv (default: table for TTY, tsv for pipes)')
+  cmd.option('--no-header', 'suppress column headers')
+  cmd.option('--delimiter <char>', 'custom field delimiter (implies tsv)')
+  cmd.option('--columns <list>', 'comma-separated list of columns to include')
+  cmd.option('-o, --output <file>', 'write results to file instead of stdout')
+  cmd.option('--stats', 'print query performance stats to stderr')
+  cmd.option('--stats-only', 'print stats only, suppress row output (implies --stats)')
+  cmd.option('--profile', 'include per-driver profile breakdown (implies --stats)')
+  cmd.option('-x, --expanded', 'force vertical record-per-line layout')
+  cmd.option('--show-null-cols', 'keep columns that are null in every row in table mode')
+  cmd.option('--timeout <duration>', 'per-query timeout (e.g. 60s, 5m)')
+  cmd.option('--file <path>', 'read query from file (queries separated by ;)')
+  cmd.option('--param <kv>', 'key=value for {{placeholder}} substitution (repeatable)', (v, a: string[]) => [...a, v], [] as string[])
+  cmd.option('--since <time>', 'inject WHERE @timestamp >= <time> (e.g. 1h, 30m, 2025-01-01)')
+  cmd.option('--until <time>', 'inject WHERE @timestamp <= <time>')
+  cmd.option('--quiet', 'suppress incidental stderr (row counts, timing)')
+  cmd.allowExcessArguments(false)
+
+  cmd.action(async (queryArg: string | undefined, options: Record<string, unknown>) => {
+    const fileOpt = options.file as string | undefined
+    let queries: string[]
+
+    if (fileOpt) {
+      try {
+        queries = splitQueries(readFileSync(fileOpt, 'utf-8'))
+      } catch (err) {
+        process.stderr.write(`Error reading file: ${err instanceof Error ? err.message : String(err)}\n`)
+        process.exitCode = 1
+        return
+      }
+    } else if (!queryArg) {
+      if (process.stdin.isTTY) {
+        cmd.help()
+        return
+      }
+      const chunks: Buffer[] = []
+      for await (const chunk of process.stdin) { chunks.push(chunk as Buffer) }
+      queries = splitQueries(Buffer.concat(chunks).toString('utf-8'))
+    } else if (queryArg === '-') {
+      const chunks: Buffer[] = []
+      for await (const chunk of process.stdin) { chunks.push(chunk as Buffer) }
+      queries = splitQueries(Buffer.concat(chunks).toString('utf-8'))
+    } else {
+      queries = [queryArg]
+    }
+
+    const params = options.param as string[]
+    const since = options.since as string | undefined
+    const until = options.until as string | undefined
+    const format = options.format as string | undefined
+    const delimiter = options.delimiter as string | undefined
+    const columnsRaw = options.columns as string | undefined
+    const columns = columnsRaw ? columnsRaw.split(',').map(c => c.trim()).filter(Boolean) : undefined
+    const noHeader = !(options.header as boolean ?? true)
+    const outputFile = options.output as string | undefined
+    const doStats = !!(options.stats || options.statsOnly || options.profile)
+    const statsOnly = !!(options.statsOnly)
+    const profile = !!(options.profile)
+    const expanded = !!(options.expanded)
+    const showNullCols = !!(options.showNullCols)
+    const quiet = !!(options.quiet)
+
+    const resolvedFormat = format ?? (delimiter ? 'tsv' : defaultFormat())
+
+    const writer = outputFile ? createWriteStream(outputFile) : process.stdout
+
+    const now = new Date()
+    for (let i = 0; i < queries.length; i++) {
+      let q = queries[i]!
+      if (params.length > 0) { q = applyParams(q, params) }
+      if (since || until) {
+        try { q = applyTimeFlagsToQuery(q, since, until, now) }
+        catch (err) { process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`); process.exitCode = 1; return }
+      }
+
+      try {
+        const resp = await runQuery(q, { profile })
+        warnIfPartial(resp)
+        if (doStats) { printStats(resp, resp.values.length) }
+        if (!statsOnly) {
+          formatOutput(resp, {
+            format: resolvedFormat, noHeader, delimiter, columns, expanded, showNullCols
+          }, writer)
+          if (!quiet && process.stdout.isTTY && !outputFile) {
+            process.stderr.write(`\n${resp.values.length} rows in set (${resp.took}ms)\n`)
+          }
+        }
+      } catch (err) {
+        if (queries.length > 1) {
+          process.stderr.write(`Error in query ${i + 1}: ${err instanceof Error ? err.message : String(err)}\n`)
+          continue
+        }
+        handleError(err)
+        return
+      }
+
+      if (queries.length > 1 && i < queries.length - 1 && !quiet && process.stdout.isTTY) {
+        process.stderr.write('\n')
+      }
+    }
+
+    if (outputFile) {
+      if (!quiet) process.stderr.write(`Results written to ${outputFile}\n`)
+      if (writer !== process.stdout) (writer as ReturnType<typeof createWriteStream>).end()
+    }
+  })
+
+  return cmd
+}
+
+export function handleError (err: unknown): void {
+  if (err instanceof EsqlError) {
+    process.stderr.write(`Error: ${err.message}\n`)
+    if (err.isConnection) {
+      process.stderr.write('Hint: check your Elasticsearch connection in the active config context.\n')
+    }
+  } else if (err instanceof Error && err.message.startsWith('missing_config:')) {
+    process.stderr.write(`Error: ${err.message.slice('missing_config: '.length)}\n`)
+    process.stderr.write('Run: elastic config context show\n')
+  } else {
+    process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`)
+  }
+  process.exitCode = 1
+}

--- a/src/esql/commands/save.ts
+++ b/src/esql/commands/save.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Command } from 'commander'
+import { loadSavedQueries, saveSavedQueries, looksLikeEsqlQuery } from '../saved-queries.ts'
+
+export function createSaveCommand (): Command {
+  const cmd = new Command('save')
+  cmd.description('Save a named ES|QL query for later use')
+  cmd.argument('<name>', 'name for the saved query')
+  cmd.argument('<query>', 'ES|QL query string')
+  cmd.allowExcessArguments(false)
+
+  cmd.action((name: string, query: string) => {
+    if (/[ |,()]/.test(name)) {
+      if (!looksLikeEsqlQuery(name) && looksLikeEsqlQuery(query)) {
+        process.stderr.write(`Error: arguments look swapped — try: elastic esql save ${query} '${name}'\n`)
+      } else {
+        process.stderr.write(`Error: query name "${name}" contains spaces or special characters — use a simple name like 'my-query'\n`)
+      }
+      process.exitCode = 1
+      return
+    }
+
+    if (!looksLikeEsqlQuery(query)) {
+      process.stderr.write(`Error: "${query}" doesn't look like an ES|QL query — should start with FROM, ROW, or SHOW\n`)
+      process.exitCode = 1
+      return
+    }
+
+    const file = loadSavedQueries()
+    const existed = name in file.queries
+    file.queries[name] = { query }
+    saveSavedQueries(file)
+
+    process.stderr.write(existed ? `Query '${name}' updated.\n` : `Query '${name}' saved.\n`)
+  })
+
+  return cmd
+}

--- a/src/esql/commands/tail.ts
+++ b/src/esql/commands/tail.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Command } from 'commander'
+import { runQuery } from '../esql-client.ts'
+import { formatOutput, warnIfPartial, printStats } from '../formatter.ts'
+import { applyParams, loadSavedQueries } from '../saved-queries.ts'
+import { isFromQuery, injectWhere, injectSort } from '../inject.ts'
+import type { EsqlResponse } from '../esql-client.ts'
+
+function parseDuration (s: string): number {
+  const m = /^(\d+(?:\.\d+)?)(ms|s|m|h|d)$/.exec(s)
+  if (!m) throw new Error(`Invalid duration "${s}" — use e.g. 5m, 1h`)
+  const n = parseFloat(m[1]!)
+  switch (m[2]) {
+    case 'ms': return n
+    case 's': return n * 1000
+    case 'm': return n * 60_000
+    case 'h': return n * 3_600_000
+    case 'd': return n * 86_400_000
+    default: return n * 1000
+  }
+}
+
+export function buildTailQuery (baseQuery: string, tsField: string, lastSeen: string): string {
+  const whereExpr = `${tsField} > "${lastSeen}"`
+  const q = injectWhere(baseQuery, whereExpr)
+  return injectSort(q, `${tsField} ASC`)
+}
+
+export function tsColumnIndex (resp: EsqlResponse, tsField: string): number {
+  return resp.columns.findIndex(c => c.name === tsField)
+}
+
+export function extractMaxTimestamp (resp: EsqlResponse, tsIdx: number): string | null {
+  for (let i = resp.values.length - 1; i >= 0; i--) {
+    const row = resp.values[i]
+    if (!row) continue
+    const v = row[tsIdx]
+    if (typeof v === 'string' && v !== '') return v
+  }
+  return null
+}
+
+export function createTailCommand (): Command {
+  const cmd = new Command('tail')
+  cmd.description('Follow a query, printing only new rows on each poll')
+  cmd.argument('[query]', 'ES|QL query (must use FROM; or use --saved)')
+  cmd.option('--every <duration>', 'poll interval', '2s')
+  cmd.option('--since <time>', 'initial lookback window (e.g. 5m, 1h)', '5m')
+  cmd.option('--ts-field <field>', 'timestamp field for delta tracking', '@timestamp')
+  cmd.option('-f, --format <fmt>', 'output format: table, json, ndjson, csv, tsv', 'tsv')
+  cmd.option('--no-header', 'suppress column headers on first poll')
+  cmd.option('--delimiter <char>', 'custom field delimiter')
+  cmd.option('--columns <list>', 'comma-separated list of columns to include')
+  cmd.option('--timeout <duration>', 'per-query timeout')
+  cmd.option('--param <kv>', 'key=value for {{placeholder}} substitution (repeatable)', (v, a: string[]) => [...a, v], [] as string[])
+  cmd.option('--saved <name>', 'run a saved query by name')
+  cmd.option('--stats', 'print query performance stats each poll')
+  cmd.allowExcessArguments(false)
+
+  cmd.action(async (queryArg: string | undefined, options: Record<string, unknown>) => {
+    const savedName = options.saved as string | undefined
+    let baseQuery: string
+
+    if (savedName) {
+      const file = loadSavedQueries()
+      const sq = file.queries[savedName]
+      if (!sq) {
+        process.stderr.write(`Error: unknown query "${savedName}" — run: elastic esql queries list\n`)
+        process.exitCode = 1; return
+      }
+      baseQuery = sq.query
+    } else if (queryArg) {
+      baseQuery = queryArg
+    } else {
+      process.stderr.write('Error: provide a query argument or use --saved <name>\n')
+      process.exitCode = 1; return
+    }
+
+    const params = options.param as string[]
+    if (params.length > 0) baseQuery = applyParams(baseQuery, params)
+
+    if (!isFromQuery(baseQuery)) {
+      process.stderr.write('Error: tail only supports FROM-based queries\n')
+      process.exitCode = 1; return
+    }
+
+    const everyMs = (() => { try { return parseDuration(options.every as string) } catch (e) { process.stderr.write(`Error: ${(e as Error).message}\n`); process.exitCode = 1; return null } })()
+    if (everyMs === null) return
+
+    const sinceRaw = options.since as string
+    let lastSeen: string
+    try {
+      lastSeen = new Date(Date.now() - parseDuration(sinceRaw)).toISOString()
+    } catch {
+      lastSeen = new Date(Date.now() - 5 * 60_000).toISOString()
+    }
+
+    const tsField = options.tsField as string ?? '@timestamp'
+    const format = options.format as string
+    const delimiter = options.delimiter as string | undefined
+    const noHeader = !(options.header as boolean ?? true)
+    const columnsRaw = options.columns as string | undefined
+    const columns = columnsRaw ? columnsRaw.split(',').map(c => c.trim()).filter(Boolean) : undefined
+    const showStats = !!(options.stats)
+
+    let firstPoll = true
+    let stopped = false
+
+    const doPoll = async (): Promise<boolean> => {
+      const q = buildTailQuery(baseQuery, tsField, lastSeen)
+      try {
+        const resp = await runQuery(q)
+        warnIfPartial(resp)
+
+        const tsIdx = tsColumnIndex(resp, tsField)
+        if (tsIdx < 0) {
+          process.stderr.write(`Error: tail requires "${tsField}" in the output — add it to your KEEP clause or pass --ts-field\n`)
+          return true // fatal
+        }
+
+        if (resp.values.length > 0) {
+          formatOutput(resp, {
+            format, noHeader: noHeader || !firstPoll, delimiter, columns
+          }, process.stdout)
+          const maxTs = extractMaxTimestamp(resp, tsIdx)
+          if (maxTs) lastSeen = maxTs
+        } else if (firstPoll) {
+          if (!noHeader) {
+            formatOutput({ ...resp, values: [] }, { format, noHeader: false, delimiter, columns }, process.stdout)
+          }
+          process.stderr.write(`(no rows in the last ${sinceRaw}; polling every ${options.every as string} for new data)\n`)
+        }
+
+        if (showStats) printStats(resp, resp.values.length)
+        firstPoll = false
+      } catch (err) {
+        process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`)
+      }
+      return false
+    }
+
+    const fatal = await doPoll()
+    if (fatal) return
+
+    const stop = (): void => {
+      stopped = true
+      clearInterval(intervalId)
+      process.stderr.write('\nStopped.\n')
+    }
+    process.on('SIGINT', stop)
+    process.on('SIGTERM', stop)
+
+    const intervalId = setInterval(async () => {
+      if (stopped) return
+      await doPoll()
+    }, everyMs)
+
+    await new Promise<void>(resolve => {
+      process.once('SIGINT', resolve)
+      process.once('SIGTERM', resolve)
+    })
+    clearInterval(intervalId)
+  })
+
+  return cmd
+}

--- a/src/esql/commands/watch.ts
+++ b/src/esql/commands/watch.ts
@@ -8,7 +8,6 @@ import { runQuery } from '../esql-client.ts'
 import { formatOutput, printStats, warnIfPartial } from '../formatter.ts'
 import { applyParams, loadSavedQueries } from '../saved-queries.ts'
 import { injectWhere } from '../inject.ts'
-import { handleError } from './query.ts'
 
 function parseDuration (s: string): number {
   const m = /^(\d+(?:\.\d+)?)(ms|s|m|h)$/.exec(s)
@@ -144,7 +143,6 @@ export function createWatchCommand (): Command {
       process.once('SIGTERM', resolve)
     })
     clearInterval(intervalId)
-    handleError // reference to suppress unused import warning
   })
 
   return cmd

--- a/src/esql/commands/watch.ts
+++ b/src/esql/commands/watch.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Command } from 'commander'
+import { runQuery } from '../esql-client.ts'
+import { formatOutput, printStats, warnIfPartial } from '../formatter.ts'
+import { applyParams, loadSavedQueries } from '../saved-queries.ts'
+import { injectWhere } from '../inject.ts'
+import { handleError } from './query.ts'
+
+function parseDuration (s: string): number {
+  const m = /^(\d+(?:\.\d+)?)(ms|s|m|h)$/.exec(s)
+  if (!m) throw new Error(`Invalid duration "${s}" — use e.g. 2s, 30s, 1m`)
+  const n = parseFloat(m[1]!)
+  switch (m[2]) {
+    case 'ms': return n
+    case 's': return n * 1000
+    case 'm': return n * 60_000
+    case 'h': return n * 3_600_000
+    default: return n * 1000
+  }
+}
+
+function parseRelativeTime (s: string, now: Date): Date {
+  const ms = (() => {
+    const m = /^(\d+(?:\.\d+)?)(ms|s|m|h|d)$/.exec(s)
+    if (!m) return null
+    const n = parseFloat(m[1]!)
+    switch (m[2]) {
+      case 'ms': return n
+      case 's': return n * 1000
+      case 'm': return n * 60_000
+      case 'h': return n * 3_600_000
+      case 'd': return n * 86_400_000
+      default: return null
+    }
+  })()
+  if (ms !== null) return new Date(now.getTime() - ms)
+  const d = new Date(s)
+  if (!isNaN(d.getTime())) return d
+  throw new Error(`Invalid time value: "${s}"`)
+}
+
+function buildTimedQuery (query: string, since: string | undefined, until: string | undefined, now: Date): string {
+  const parts: string[] = []
+  if (since) parts.push(`@timestamp >= "${parseRelativeTime(since, now).toISOString()}"`)
+  if (until) parts.push(`@timestamp <= "${parseRelativeTime(until, now).toISOString()}"`)
+  if (parts.length === 0) return query
+  try { return injectWhere(query, parts.join(' AND ')) }
+  catch { return query }
+}
+
+export function createWatchCommand (): Command {
+  const cmd = new Command('watch')
+  cmd.description('Re-run a query on an interval, refreshing the terminal each time')
+  cmd.argument('[query]', 'ES|QL query to run (or use --saved)')
+  cmd.option('--every <duration>', 'refresh interval (e.g. 2s, 1m)', '5s')
+  cmd.option('-f, --format <fmt>', 'output format: table, json, csv, tsv', 'table')
+  cmd.option('--no-header', 'suppress column headers')
+  cmd.option('--delimiter <char>', 'custom field delimiter (implies tsv)')
+  cmd.option('--columns <list>', 'comma-separated list of columns to include')
+  cmd.option('--timeout <duration>', 'per-query timeout')
+  cmd.option('--param <kv>', 'key=value for {{placeholder}} substitution (repeatable)', (v, a: string[]) => [...a, v], [] as string[])
+  cmd.option('--saved <name>', 'run a saved query by name')
+  cmd.option('--stats', 'print query performance stats each refresh')
+  cmd.option('--stats-only', 'stats only; skip row output (implies --stats)')
+  cmd.option('--profile', 'include per-driver profile breakdown (implies --stats)')
+  cmd.option('--show-null-cols', 'keep all-null columns in table mode')
+  cmd.option('-x, --expanded', 'force vertical record-per-line layout')
+  cmd.option('--since <time>', 'inject WHERE @timestamp >= <time> — re-evaluated each tick')
+  cmd.option('--until <time>', 'inject WHERE @timestamp <= <time>')
+  cmd.allowExcessArguments(false)
+
+  cmd.action(async (queryArg: string | undefined, options: Record<string, unknown>) => {
+    const savedName = options.saved as string | undefined
+    let baseQuery: string
+
+    if (savedName) {
+      const file = loadSavedQueries()
+      const sq = file.queries[savedName]
+      if (!sq) {
+        process.stderr.write(`Error: unknown query "${savedName}" — run: elastic esql queries list\n`)
+        process.exitCode = 1; return
+      }
+      baseQuery = sq.query
+    } else if (queryArg) {
+      baseQuery = queryArg
+    } else {
+      process.stderr.write('Error: provide a query argument or use --saved <name>\n')
+      process.exitCode = 1; return
+    }
+
+    const params = options.param as string[]
+    if (params.length > 0) baseQuery = applyParams(baseQuery, params)
+
+    const everyMs = (() => { try { return parseDuration(options.every as string) } catch (e) { process.stderr.write(`Error: ${(e as Error).message}\n`); process.exitCode = 1; return null } })()
+    if (everyMs === null) return
+
+    const format = options.format as string
+    const delimiter = options.delimiter as string | undefined
+    const resolvedFormat = delimiter ? 'tsv' : format
+    const noHeader = !(options.header as boolean ?? true)
+    const columnsRaw = options.columns as string | undefined
+    const columns = columnsRaw ? columnsRaw.split(',').map(c => c.trim()).filter(Boolean) : undefined
+    const doStats = !!(options.stats || options.statsOnly || options.profile)
+    const statsOnly = !!(options.statsOnly)
+    const profile = !!(options.profile)
+    const showNullCols = !!(options.showNullCols)
+    const expanded = !!(options.expanded)
+    const since = options.since as string | undefined
+    const until = options.until as string | undefined
+
+    const runOnce = async (): Promise<void> => {
+      process.stdout.write('\x1b[2J\x1b[H')
+      const now = new Date()
+      process.stderr.write(`Every ${options.every as string} — ${now.toLocaleTimeString()}\n\n`)
+      const q = buildTimedQuery(baseQuery, since, until, now)
+      try {
+        const resp = await runQuery(q, { profile })
+        warnIfPartial(resp)
+        if (doStats) printStats(resp, resp.values.length)
+        if (!statsOnly) {
+          formatOutput(resp, { format: resolvedFormat, noHeader, delimiter, columns, showNullCols, expanded }, process.stdout)
+          process.stderr.write(`\n${resp.values.length} rows (${resp.took}ms)\n`)
+        }
+      } catch (err) {
+        process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`)
+      }
+    }
+
+    await runOnce()
+
+    const stop = (): void => { clearInterval(intervalId); process.stderr.write('\nStopped.\n') }
+    process.on('SIGINT', stop)
+    process.on('SIGTERM', stop)
+
+    const intervalId = setInterval(runOnce, everyMs)
+    // Keep the process alive until explicitly stopped
+    intervalId.unref?.()
+    await new Promise<void>(resolve => {
+      process.once('SIGINT', resolve)
+      process.once('SIGTERM', resolve)
+    })
+    clearInterval(intervalId)
+    handleError // reference to suppress unused import warning
+  })
+
+  return cmd
+}

--- a/src/esql/esql-client.ts
+++ b/src/esql/esql-client.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { errors } from '@elastic/transport'
+import { getTransport } from '../lib/transport.ts'
+
+export interface EsqlColumn {
+  name: string
+  type: string
+}
+
+export interface EsqlResponse {
+  columns: EsqlColumn[]
+  values: unknown[][]
+  took: number
+  is_partial?: boolean
+  profile?: {
+    drivers: Array<{ description: string; took_nanos: number; cpu_nanos: number }>
+  }
+}
+
+export interface QueryOptions {
+  profile?: boolean
+}
+
+export class EsqlError extends Error {
+  constructor (
+    message: string,
+    public readonly status?: number,
+    public readonly isConnection = false
+  ) {
+    super(message)
+    this.name = 'EsqlError'
+  }
+}
+
+const TLS_HINTS = [/SSL routines/i, /wrong version number/i, /EPROTO/i, /ERR_SSL/i]
+
+function appendTlsHint (msg: string): string {
+  if (TLS_HINTS.some(re => re.test(msg))) {
+    return msg + '\n\nHint: looks like a TLS error. If Elasticsearch is on plain HTTP, use http:// instead of https://.'
+  }
+  return msg
+}
+
+export async function runQuery (query: string, opts: QueryOptions = {}): Promise<EsqlResponse> {
+  const transport = getTransport()
+  try {
+    const body = await transport.request<EsqlResponse>({
+      method: 'POST',
+      path: '/_query',
+      body: {
+        query,
+        ...(opts.profile === true && { profile: true }),
+      },
+    })
+    return body
+  } catch (err) {
+    if (err instanceof errors.ResponseError) {
+      const esBody = err.body as Record<string, unknown> | null
+      const esError = esBody?.error as Record<string, unknown> | null
+      const type = typeof esError?.type === 'string' ? esError.type : null
+      const reason = typeof esError?.reason === 'string' ? esError.reason : null
+      const msg = type && reason ? `${type}: ${reason}` : (err.message || `HTTP ${err.statusCode}`)
+      throw new EsqlError(msg, err.statusCode ?? undefined)
+    }
+    if (err instanceof errors.ConnectionError) {
+      const msg = appendTlsHint(err.message || 'connection failed')
+      const url = (err.meta as Record<string, unknown> | undefined)?.meta as Record<string, unknown> | undefined
+      const urlStr = (url?.connection as Record<string, unknown> | undefined)?.url?.toString()
+      throw new EsqlError(urlStr ? `${msg} (${urlStr})` : msg, undefined, true)
+    }
+    if (err instanceof errors.TimeoutError) {
+      throw new EsqlError(err.message || 'request timed out')
+    }
+    throw err
+  }
+}

--- a/src/esql/formatter.ts
+++ b/src/esql/formatter.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import Table from 'cli-table3'
+import type { EsqlColumn, EsqlResponse } from './esql-client.ts'
+
+export interface FormatOptions {
+  format?: string | undefined
+  noHeader?: boolean | undefined
+  delimiter?: string | undefined
+  columns?: string[] | undefined
+  expanded?: boolean | undefined
+  showNullCols?: boolean | undefined
+}
+
+export function defaultFormat (): string {
+  return process.stdout.isTTY ? 'table' : 'tsv'
+}
+
+function resolveActive (resp: EsqlResponse, filterCols?: string[]): { cols: EsqlColumn[]; indices: number[] } {
+  if (!filterCols || filterCols.length === 0) {
+    return { cols: resp.columns, indices: resp.columns.map((_, i) => i) }
+  }
+  const colMap = new Map(resp.columns.map((c, i) => [c.name, i]))
+  const matched: Array<{ col: EsqlColumn; origIdx: number }> = []
+  for (const name of filterCols) {
+    const idx = colMap.get(name)
+    if (idx !== undefined) matched.push({ col: resp.columns[idx]!, origIdx: idx })
+  }
+  // If none matched, return all columns (same as no filter)
+  if (matched.length === 0) {
+    return { cols: resp.columns, indices: resp.columns.map((_, i) => i) }
+  }
+  // Preserve response column order, not filter order
+  matched.sort((a, b) => a.origIdx - b.origIdx)
+  return { cols: matched.map(m => m.col), indices: matched.map(m => m.origIdx) }
+}
+
+export function formatOutput (resp: EsqlResponse, opts: FormatOptions, writer: NodeJS.WritableStream): void {
+  const fmt = opts.format ?? defaultFormat()
+  let { cols, indices } = resolveActive(resp, opts.columns)
+
+  // In table mode, hide columns that are null in every row unless --show-null-cols
+  if ((fmt === 'table' || opts.expanded) && opts.showNullCols !== true) {
+    const keep = cols.map((_, ci) => resp.values.some(row => row[indices[ci]!] != null))
+    cols = cols.filter((_, i) => keep[i])
+    indices = indices.filter((_, i) => keep[i])
+  }
+
+  const colNames = cols.map(c => c.name)
+
+  if (fmt === 'json') {
+    const objs = resp.values.map(row => {
+      const obj: Record<string, unknown> = {}
+      for (let i = 0; i < colNames.length; i++) { obj[colNames[i]!] = row[indices[i]!] }
+      return obj
+    })
+    writer.write(JSON.stringify(objs, null, 2) + '\n')
+    return
+  }
+
+  if (fmt === 'ndjson') {
+    for (const row of resp.values) {
+      const obj: Record<string, unknown> = {}
+      for (let i = 0; i < colNames.length; i++) { obj[colNames[i]!] = row[indices[i]!] }
+      writer.write(JSON.stringify(obj) + '\n')
+    }
+    return
+  }
+
+  const isDelimited = fmt === 'csv' || fmt === 'tsv' || (opts.delimiter != null && opts.delimiter !== '')
+  if (isDelimited) {
+    const delim = fmt === 'csv' ? ',' : (opts.delimiter ?? '\t')
+    if (!opts.noHeader) { writer.write(colNames.join(delim) + '\n') }
+    for (const row of resp.values) {
+      const cells = indices.map(idx => {
+        const v = row[idx]
+        const s = v == null ? '' : String(v)
+        if (fmt === 'csv' && (s.includes(',') || s.includes('"') || s.includes('\n'))) {
+          return `"${s.replace(/"/g, '""')}"`
+        }
+        return s
+      })
+      writer.write(cells.join(delim) + '\n')
+    }
+    return
+  }
+
+  if (opts.expanded === true) {
+    for (const row of resp.values) {
+      const tbl = new Table({ style: { head: [] } })
+      for (let i = 0; i < colNames.length; i++) {
+        tbl.push({ [colNames[i]!]: String(row[indices[i]!] ?? '') })
+      }
+      writer.write(tbl.toString() + '\n')
+    }
+    return
+  }
+
+  if (fmt !== 'table') {
+    throw new Error(`unknown format: ${fmt}`)
+  }
+
+  // default: table
+  const table = new Table({
+    head: opts.noHeader ? [] : colNames,
+    style: { head: [] },
+  })
+  for (const row of resp.values) {
+    table.push(indices.map(idx => String(row[idx] ?? '')))
+  }
+  writer.write(table.toString() + '\n')
+}
+
+/** Convert nanoseconds to a human-readable string (ns / µs / ms / s). */
+export function formatNanos (nanos: number): string {
+  if (nanos < 1_000) return `${nanos}ns`
+  if (nanos < 1_000_000) return `${(nanos / 1_000).toFixed(1)}µs`
+  if (nanos < 1_000_000_000) return `${(nanos / 1_000_000).toFixed(1)}ms`
+  return `${(nanos / 1_000_000_000).toFixed(2)}s`
+}
+
+interface DriverGroup {
+  description: string
+  count: number
+  totalNanos: number
+}
+
+function groupDrivers (
+  drivers: NonNullable<EsqlResponse['profile']>['drivers'],
+): DriverGroup[] {
+  const map = new Map<string, DriverGroup>()
+  for (const d of drivers) {
+    const g = map.get(d.description)
+    if (g) { g.count++; g.totalNanos += d.took_nanos }
+    else map.set(d.description, { description: d.description, count: 1, totalNanos: d.took_nanos })
+  }
+  return [...map.values()].sort((a, b) => b.totalNanos - a.totalNanos)
+}
+
+export function printStats (
+  resp: EsqlResponse,
+  rowCount: number,
+  writer: NodeJS.WritableStream = process.stderr,
+): void {
+  if (resp.is_partial === true) {
+    writer.write('Warning: results are partial — some shards may have failed\n')
+  }
+  writer.write(`${rowCount} rows in set (${resp.took}ms)\n`)
+  if (resp.profile?.drivers && resp.profile.drivers.length > 0) {
+    writer.write('Profile (aggregated by task):\n')
+    for (const g of groupDrivers(resp.profile.drivers)) {
+      const label = g.count > 1 ? `${g.description} x${g.count}` : g.description
+      writer.write(`  ${label}: ${formatNanos(g.totalNanos)}\n`)
+    }
+  }
+}
+
+export function warnIfPartial (
+  resp: EsqlResponse,
+  writer: NodeJS.WritableStream = process.stderr,
+): void {
+  if (resp.is_partial === true) {
+    writer.write('Warning: results are partial — some shards may have failed\n')
+  }
+}

--- a/src/esql/hints.ts
+++ b/src/esql/hints.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { EsqlError } from './esql-client.ts'
+
+/**
+ * Given a parsed query-error reason string, return a short suggestion string
+ * (e.g. "Did you mean WHERE?" or "Unknown function: AVGG") or empty string
+ * when no pattern matches.
+ */
+export function parsingSuggestion (reason: string): string {
+  // "mismatched input 'FOO' expecting {'BAR', 'BAZ', ...}" — suggest first expected token
+  const expectMatch = /expecting \{[^']*'([A-Z_]+)'/.exec(reason)
+  if (expectMatch) return `Did you mean ${expectMatch[1]!}?`
+
+  // "Unknown function [NAME]" or "Unknown column [NAME]"
+  const unknownMatch = /Unknown (?:function|column) \[([^\]]+)\]/i.exec(reason)
+  if (unknownMatch) return `Unknown identifier: ${unknownMatch[1]!}`
+
+  return ''
+}
+
+/**
+ * Return a human-readable hint for an EsqlError, or empty string when no
+ * specific hint applies (e.g. for unexpected error types).
+ */
+export function errorHint (err: EsqlError | null | undefined): string {
+  if (err == null) return ''
+
+  if (err.isConnection) {
+    const msg = err.message
+    if (/connection refused/i.test(msg)) {
+      return 'Connection refused — is Elasticsearch running and reachable?'
+    }
+    if (/tls|certificate|ssl/i.test(msg)) {
+      return 'TLS/certificate error — if Elasticsearch is on plain HTTP, use http:// in your config'
+    }
+    if (/timed out|deadline exceeded/i.test(msg)) {
+      return 'Request timed out — check that Elasticsearch is responding'
+    }
+    return ''
+  }
+
+  switch (err.status) {
+    case 401:
+      return '401 Authentication failed — check your credentials (elastic config context show)'
+    case 403:
+      return '403 Forbidden — your API key or user may be missing required index or cluster privileges'
+    case 404: {
+      if (/index_not_found/i.test(err.message)) {
+        return 'Index not found — check your index pattern or alias'
+      }
+      return '404 Not found — check your index pattern or resource name'
+    }
+    case 400: {
+      const suggestion = parsingSuggestion(err.message)
+      return suggestion !== ''
+        ? suggestion
+        : 'ES|QL query syntax error — check your query and refer to the ES|QL documentation'
+    }
+    case 503:
+      return '503 Elasticsearch unavailable — check cluster health and node availability'
+    case 429:
+      return '429 Too many requests — reduce query frequency or increase cluster resources'
+    default:
+      return ''
+  }
+}

--- a/src/esql/inject.ts
+++ b/src/esql/inject.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function isFromQuery (query: string): boolean {
+  return /^\s*FROM\s/i.test(query)
+}
+
+/**
+ * Walk `query` skipping ES|QL string literals (triple-quoted, double-quoted)
+ * and comments (`//`, `/* * /`). Calls `test` on each top-level character.
+ * Returns the index where `test` first returns true, or -1.
+ */
+function scanTopLevel (query: string, test: (ch: string, i: number) => boolean): number {
+  let i = 0
+  while (i < query.length) {
+    // Triple-quoted string """...""" — must be checked before double-quoted
+    if (query.startsWith('"""', i)) {
+      i += 3
+      while (i < query.length && !query.startsWith('"""', i)) i++
+      i += 3
+      continue
+    }
+    // Double-quoted string "..."
+    if (query[i] === '"') {
+      i++
+      while (i < query.length && query[i] !== '"') {
+        if (query[i] === '\\') i++
+        i++
+      }
+      i++ // skip closing "
+      continue
+    }
+    // Line comment //...
+    if (query.startsWith('//', i)) {
+      while (i < query.length && query[i] !== '\n') i++
+      continue
+    }
+    // Block comment /*...*/
+    if (query.startsWith('/*', i)) {
+      i += 2
+      while (i < query.length && !query.startsWith('*/', i)) i++
+      i += 2
+      continue
+    }
+    if (test(query[i]!, i)) return i
+    i++
+  }
+  return -1
+}
+
+/**
+ * Find the index of the first top-level `|`. If `commandRe` is given, only
+ * matches a `|` whose next non-whitespace word matches the regex.
+ */
+function findTopLevelPipe (query: string, commandRe?: RegExp): number {
+  return scanTopLevel(query, (ch, i) => {
+    if (ch !== '|') return false
+    if (!commandRe) return true
+    const rest = query.slice(i + 1).trimStart()
+    const m = /^([A-Za-z_]+)/.exec(rest)
+    return !!(m && commandRe.test(m[1]!))
+  })
+}
+
+/**
+ * Inject `| WHERE <expr>` immediately before the first top-level pipe in a
+ * FROM query (i.e. before any existing processing steps). Empty `expr` is
+ * a no-op. Throws for non-FROM queries.
+ */
+export function injectWhere (query: string, expr: string): string {
+  if (!expr) return query
+  if (!isFromQuery(query)) throw new Error('injectWhere: only FROM-based queries are supported')
+  const pipeIdx = findTopLevelPipe(query)
+  if (pipeIdx === -1) {
+    return `${query.trimEnd()} | WHERE ${expr}`
+  }
+  const before = query.slice(0, pipeIdx).trimEnd()
+  const after = query.slice(pipeIdx) // includes the leading |
+  return `${before} | WHERE ${expr} ${after}`
+}
+
+/**
+ * Inject `| SORT <orderExpr>` before `| LIMIT` (or at end if no LIMIT).
+ * Idempotent: if a top-level SORT already exists, returns the query unchanged.
+ * Empty `orderExpr` is a no-op.
+ */
+export function injectSort (query: string, orderExpr: string): string {
+  if (!orderExpr) return query
+  if (findTopLevelPipe(query, /^SORT$/i) !== -1) return query // already has SORT
+  const limitIdx = findTopLevelPipe(query, /^LIMIT$/i)
+  if (limitIdx === -1) {
+    return `${query.trimEnd()} | SORT ${orderExpr}`
+  }
+  const before = query.slice(0, limitIdx).trimEnd()
+  const after = query.slice(limitIdx) // includes the leading |
+  return `${before} | SORT ${orderExpr} ${after}`
+}
+
+/** Returns true if the query contains a top-level STATS command. */
+export function hasAggregation (query: string): boolean {
+  return findTopLevelPipe(query, /^STATS$/i) !== -1
+}

--- a/src/esql/register.ts
+++ b/src/esql/register.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Command } from 'commander'
+import type { OpaqueCommandHandle } from '../factory.ts'
+import { createQueryCommand } from './commands/query.ts'
+import { createCheckCommand } from './commands/check.ts'
+import { createWatchCommand } from './commands/watch.ts'
+import { createTailCommand } from './commands/tail.ts'
+import { createSaveCommand } from './commands/save.ts'
+import { createQueriesCommand } from './commands/queries.ts'
+import { runRepl } from './repl.ts'
+
+export function registerEsqlCommands (): OpaqueCommandHandle {
+  const group = new Command('esql')
+  group.description('Query Elasticsearch using ES|QL from the command line')
+  group.allowExcessArguments(true)
+
+  group.addCommand(createQueryCommand())
+  group.addCommand(createWatchCommand())
+  group.addCommand(createTailCommand())
+  group.addCommand(createCheckCommand())
+  group.addCommand(createSaveCommand())
+  group.addCommand(createQueriesCommand())
+
+  // When invoked with no sub-command and connected to a TTY: launch REPL
+  group.action(async function (this: Command) {
+    const args = this.args
+    if (args.length > 0) {
+      this.error(`unknown command: ${args[0]}`)
+      return
+    }
+    if (process.stdin.isTTY && process.stdout.isTTY) {
+      await runRepl()
+    } else {
+      this.help()
+    }
+  })
+
+  return group as OpaqueCommandHandle
+}

--- a/src/esql/repl.ts
+++ b/src/esql/repl.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import readline from 'node:readline'
+import { existsSync, readFileSync, appendFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { runQuery, EsqlError } from './esql-client.ts'
+import { formatOutput, defaultFormat } from './formatter.ts'
+
+const HISTORY_FILE = join(homedir(), '.elastic-esql-history')
+const MAX_HISTORY = 200
+
+/** Source commands valid at the start of a query. */
+const SOURCE_COMMANDS = ['FROM', 'ROW', 'SHOW', 'TS']
+
+/** Processing commands valid after a pipe. */
+const PROCESSING_COMMANDS = [
+  'WHERE', 'STATS', 'BY', 'SORT', 'LIMIT', 'KEEP', 'DROP',
+  'EVAL', 'RENAME', 'AS', 'ENRICH', 'ON', 'WITH', 'DISSECT', 'GROK', 'MV_EXPAND',
+]
+
+/** All recognized keywords for completion (no duplicates). */
+const KEYWORDS: string[] = [...new Set([
+  ...SOURCE_COMMANDS,
+  ...PROCESSING_COMMANDS,
+  'COUNT', 'COUNT_DISTINCT', 'AVG', 'SUM', 'MIN', 'MAX', 'MEDIAN', 'PERCENTILE',
+  'ASC', 'DESC', 'NULLS', 'FIRST', 'LAST', 'LIKE', 'RLIKE', 'IN', 'NOT', 'AND', 'OR',
+  'IS NULL', 'IS NOT NULL',
+])]
+
+/** Returns true if the user's current line is incomplete and expects more input. */
+export function needsContinuation (line: string): boolean {
+  const t = line.trimEnd()
+  return t.endsWith('|') || t.endsWith('\\')
+}
+
+/** Extracts the index name / pattern from a FROM or TS source command. */
+export function extractIndexName (query: string): string {
+  const m = /^\s*(?:FROM|TS)\s+([^\s|,]+)/i.exec(query)
+  return m ? m[1]! : ''
+}
+
+/** Returns keyword completion candidates for the given line prefix. */
+export function getCandidates (line: string): string[] {
+  const upper = line.trimStart().toUpperCase()
+  // After a pipe: offer processing commands
+  const lastPipe = line.lastIndexOf('|')
+  const prefix = lastPipe >= 0 ? line.slice(lastPipe + 1).trimStart().toUpperCase() : upper
+  const pool = lastPipe >= 0 ? PROCESSING_COMMANDS : (upper === '' ? SOURCE_COMMANDS : KEYWORDS)
+  const hits = pool.filter(kw => kw.startsWith(prefix))
+  return hits.length > 0 ? hits : pool
+}
+
+function completer (line: string): [string[], string] {
+  const candidates = getCandidates(line)
+  return [candidates.map(kw => kw + ' '), line]
+}
+
+function loadHistory (): string[] {
+  if (!existsSync(HISTORY_FILE)) return []
+  try {
+    return readFileSync(HISTORY_FILE, 'utf-8')
+      .split('\n')
+      .filter(l => l.trim() !== '')
+      .slice(-MAX_HISTORY)
+  } catch {
+    return []
+  }
+}
+
+function saveHistory (line: string): void {
+  try { appendFileSync(HISTORY_FILE, line + '\n', 'utf-8') } catch { /* ignore */ }
+}
+
+export async function runRepl (): Promise<void> {
+  process.stderr.write('ES|QL interactive shell. Type a query and press Enter. Ctrl-C or Ctrl-D to exit.\n\n')
+
+  const history = loadHistory()
+
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stderr,
+    completer,
+    terminal: true,
+    history,
+    historySize: MAX_HISTORY,
+  })
+
+  let buffer = ''
+
+  const prompt = (): void => {
+    rl.setPrompt(buffer === '' ? 'esql> ' : '   -> ')
+    rl.prompt()
+  }
+
+  prompt()
+
+  for await (const line of rl) {
+    const trimmed = line.trim()
+
+    if (trimmed === '' && buffer === '') {
+      prompt()
+      continue
+    }
+
+    if (trimmed === '\\q' || trimmed === 'quit' || trimmed === 'exit') {
+      process.stderr.write('Bye.\n')
+      rl.close()
+      return
+    }
+
+    // Accumulate multi-line queries: if line ends with `|` or `\` it's incomplete
+    if (needsContinuation(trimmed)) {
+      buffer += (buffer === '' ? '' : ' ') + trimmed
+      prompt()
+      continue
+    }
+
+    const query = buffer === '' ? trimmed : `${buffer} ${trimmed}`
+    buffer = ''
+
+    if (query === '') { prompt(); continue }
+
+    saveHistory(query)
+
+    try {
+      const resp = await runQuery(query)
+      formatOutput(resp, { format: defaultFormat() }, process.stdout)
+      process.stderr.write(`${resp.values.length} rows in set (${resp.took}ms)\n`)
+    } catch (err) {
+      if (err instanceof EsqlError) {
+        process.stderr.write(`Error: ${err.message}\n`)
+        if (err.isConnection) {
+          process.stderr.write('Check your connection config: elastic config context show\n')
+        }
+      } else {
+        process.stderr.write(`Error: ${err instanceof Error ? err.message : String(err)}\n`)
+      }
+    }
+
+    prompt()
+  }
+}

--- a/src/esql/saved-queries.ts
+++ b/src/esql/saved-queries.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { homedir } from 'node:os'
+import { parse, stringify } from 'yaml'
+
+export interface SavedQuery {
+  query: string
+  cluster?: string
+}
+
+export interface SavedQueriesFile {
+  queries: Record<string, SavedQuery>
+}
+
+function configPath (): string {
+  return join(homedir(), '.elasticrc-esql.yml')
+}
+
+export function loadSavedQueries (): SavedQueriesFile {
+  try {
+    const raw = readFileSync(configPath(), 'utf-8')
+    const parsed = parse(raw) as Record<string, unknown>
+    if (parsed && typeof parsed.queries === 'object' && parsed.queries !== null) {
+      return { queries: parsed.queries as Record<string, SavedQuery> }
+    }
+  } catch {
+    // file doesn't exist yet
+  }
+  return { queries: {} }
+}
+
+export function saveSavedQueries (file: SavedQueriesFile): void {
+  writeFileSync(configPath(), stringify(file), 'utf-8')
+}
+
+export function listQueryNames (): string[] {
+  const file = loadSavedQueries()
+  return Object.keys(file.queries).sort()
+}
+
+export function looksLikeEsqlQuery (q: string): boolean {
+  const upper = q.trimStart().toUpperCase()
+  return upper.startsWith('FROM ') || upper.startsWith('ROW ') || upper.startsWith('SHOW ') ||
+    upper.startsWith('FROM\t') || upper.startsWith('ROW\t') || upper.startsWith('SHOW\t')
+}
+
+export function applyParams (query: string, params: string[]): string {
+  if (params.length === 0) return query
+
+  const parsed: Array<{ key: string; value: string }> = []
+  for (const param of params) {
+    const eq = param.indexOf('=')
+    if (eq === -1) throw new Error(`param "${param}" has no "="`)
+    const key = param.slice(0, eq).trim()
+    if (!key) throw new Error(`param "${param}" has empty key`)
+    parsed.push({ key, value: param.slice(eq + 1) })
+  }
+
+  for (const { key } of parsed) {
+    if (!query.includes(`{{${key}}}`)) throw new Error(`param ${key} has no placeholder in query`)
+  }
+
+  let result = query
+  for (const { key, value } of parsed) {
+    result = result.replaceAll(`{{${key}}}`, value)
+  }
+
+  const unresolved = /\{\{([^}]+)\}\}/.exec(result)
+  if (unresolved) throw new Error(`query has unresolved placeholder {{${unresolved[1]}}}`)
+
+  return result
+}

--- a/src/lib/transport.ts
+++ b/src/lib/transport.ts
@@ -75,3 +75,12 @@ export function getTransport (): Transport {
 export function _testResetTransport (): void {
   _transport = undefined
 }
+
+/**
+ * Directly sets the cached Transport instance.
+ *
+ * @internal test seam -- use when you need a custom transport (e.g. maxRetries: 0)
+ */
+export function _testSetTransport (t: Transport): void {
+  _transport = t
+}

--- a/test/esql/check.test.ts
+++ b/test/esql/check.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { parseAssertion, evalAssertion } from '../../src/esql/commands/check.ts'
+
+describe('parseAssertion', () => {
+  it('parses simple integer comparison', () => {
+    const a = parseAssertion('x < 80')
+    assert.deepEqual(a, { column: 'x', operator: '<', value: '80' })
+  })
+
+  it('parses >= operator', () => {
+    const a = parseAssertion('count >= 3')
+    assert.deepEqual(a, { column: 'count', operator: '>=', value: '3' })
+  })
+
+  it('parses == with decimal value', () => {
+    const a = parseAssertion('ratio == 1.5')
+    assert.deepEqual(a, { column: 'ratio', operator: '==', value: '1.5' })
+  })
+
+  it('parses != operator', () => {
+    const a = parseAssertion('status != 0')
+    assert.deepEqual(a, { column: 'status', operator: '!=', value: '0' })
+  })
+
+  it('parses <= operator', () => {
+    const a = parseAssertion('latency <= 200')
+    assert.deepEqual(a, { column: 'latency', operator: '<=', value: '200' })
+  })
+
+  it('parses string value', () => {
+    const a = parseAssertion('env == production')
+    assert.deepEqual(a, { column: 'env', operator: '==', value: 'production' })
+  })
+
+  it('trims whitespace around column and value', () => {
+    const a = parseAssertion('  x  >=  10  ')
+    assert.deepEqual(a, { column: 'x', operator: '>=', value: '10' })
+  })
+
+  it('throws when no operator found', () => {
+    assert.throws(() => parseAssertion('x 80'), /No valid operator/)
+  })
+
+  it('throws when column name is missing', () => {
+    assert.throws(() => parseAssertion('< 80'), /Missing column name/)
+  })
+
+  it('throws when value is missing', () => {
+    assert.throws(() => parseAssertion('x <'), /Missing value/)
+  })
+})
+
+describe('evalAssertion', () => {
+  it('evaluates numeric < (pass)', () => {
+    assert.equal(evalAssertion({ column: 'x', operator: '<', value: '80' }, 60), true)
+  })
+
+  it('evaluates numeric < (fail)', () => {
+    assert.equal(evalAssertion({ column: 'x', operator: '<', value: '80' }, 90), false)
+  })
+
+  it('evaluates >= with integer actual', () => {
+    assert.equal(evalAssertion({ column: 'x', operator: '>=', value: '3' }, 3), true)
+    assert.equal(evalAssertion({ column: 'x', operator: '>=', value: '3' }, 2), false)
+  })
+
+  it('evaluates == with integer', () => {
+    assert.equal(evalAssertion({ column: 'x', operator: '==', value: '1' }, 1), true)
+  })
+
+  it('evaluates != with zero', () => {
+    assert.equal(evalAssertion({ column: 'x', operator: '!=', value: '0' }, 0), false)
+  })
+
+  it('evaluates <= boundary', () => {
+    assert.equal(evalAssertion({ column: 'x', operator: '<=', value: '5' }, 5), true)
+  })
+
+  it('evaluates > boundary (fail)', () => {
+    assert.equal(evalAssertion({ column: 'x', operator: '>', value: '5' }, 5), false)
+  })
+
+  it('evaluates float64 actual', () => {
+    assert.equal(evalAssertion({ column: 'x', operator: '>', value: '1.5' }, 2.0), true)
+    assert.equal(evalAssertion({ column: 'x', operator: '>', value: '1.5' }, 1.0), false)
+  })
+
+  it('evaluates string-parsed actual (numeric string)', () => {
+    // actual is a string "42", value is "50"
+    assert.equal(evalAssertion({ column: 'x', operator: '<', value: '50' }, '42'), true)
+  })
+
+  it('falls back to string comparison when neither side is numeric', () => {
+    assert.equal(evalAssertion({ column: 'env', operator: '==', value: 'production' }, 'production'), true)
+    assert.equal(evalAssertion({ column: 'env', operator: '==', value: 'production' }, 'staging'), false)
+    assert.equal(evalAssertion({ column: 'env', operator: '!=', value: 'production' }, 'staging'), true)
+  })
+})

--- a/test/esql/client.test.ts
+++ b/test/esql/client.test.ts
@@ -5,78 +5,21 @@
 
 import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import * as http from 'node:http'
-import * as net from 'node:net'
-import { Transport, WeightedConnectionPool, UndiciConnection } from '@elastic/transport'
+import { Transport, errors } from '@elastic/transport'
 import { runQuery, EsqlError } from '../../src/esql/esql-client.ts'
-import { setResolvedConfig } from '../../src/config/store.ts'
-import { _testResetTransport, _testSetTransport } from '../../src/lib/transport.ts'
+import { setResolvedConfig, _testResetConfig } from '../../src/config/store.ts'
+import { getTransport, _testResetTransport, _testSetTransport } from '../../src/lib/transport.ts'
 import type { ResolvedConfig } from '../../src/config/types.ts'
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-interface MockServerHandle {
-  url: string
-  lastRequest: () => { method: string; path: string; headers: http.IncomingHttpHeaders; body: unknown }
-  close: () => Promise<void>
-}
+type RequestParams = { method: string; path: string; body?: unknown }
 
-/** HTTP server that calls `handler` for every request and records the last request. */
-function startMockServer (
-  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
-): Promise<MockServerHandle> {
-  return new Promise((resolve, reject) => {
-    let lastReq: { method: string; path: string; headers: http.IncomingHttpHeaders; body: unknown } = {
-      method: '', path: '', headers: {}, body: undefined,
-    }
-    const server = http.createServer((req, res) => {
-      const chunks: Buffer[] = []
-      req.on('data', (c: Buffer) => chunks.push(c))
-      req.on('end', () => {
-        const raw = Buffer.concat(chunks).toString('utf-8')
-        let body: unknown
-        try { body = JSON.parse(raw) } catch { body = raw }
-        lastReq = { method: req.method ?? '', path: req.url ?? '', headers: req.headers, body }
-        handler(req, res)
-      })
-    })
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server.address() as { port: number }
-      resolve({
-        url: `http://127.0.0.1:${addr.port}`,
-        lastRequest: () => lastReq,
-        close: () => new Promise<void>(r => server.close(() => r())),
-      })
-    })
-    server.on('error', reject)
-  })
-}
-
-/**
- * TCP server that accepts connections and immediately destroys them.
- * Produces a near-instant ECONNRESET on each attempt — avoids long timeout
- * waits even when the transport retries.
- */
-function startRejectingServer (): Promise<{ url: string; close: () => Promise<void> }> {
-  return new Promise((resolve, reject) => {
-    const server = net.createServer(socket => { socket.destroy() })
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server.address() as { port: number }
-      resolve({
-        url: `http://127.0.0.1:${addr.port}`,
-        close: () => new Promise<void>(r => server.close(() => r())),
-      })
-    })
-    server.on('error', reject)
-  })
-}
-
-function jsonResponse (res: http.ServerResponse, status: number, body: unknown): void {
-  const payload = JSON.stringify(body)
-  res.writeHead(status, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) })
-  res.end(payload)
+/** Mock transport that calls `handler` for every request. */
+function makeMockTransport (handler: (params: RequestParams) => Promise<unknown>): Transport {
+  return { request: handler } as unknown as Transport
 }
 
 const GOOD_RESPONSE = {
@@ -89,114 +32,109 @@ function makeConfig (url: string, auth?: ResolvedConfig['context']['elasticsearc
   return { context: { elasticsearch: { url, auth } } } as ResolvedConfig
 }
 
+function makeResponseError (status: number, body: unknown): errors.ResponseError {
+  return new errors.ResponseError({
+    body,
+    statusCode: status,
+    headers: {},
+    meta: { request: { params: {}, options: {}, id: 1 }, connection: null, attempts: 0, aborted: false },
+    warnings: null,
+  } as Parameters<typeof errors.ResponseError>[0])
+}
+
+function makeConnectionError (message: string, url: string): errors.ConnectionError {
+  return new errors.ConnectionError(message, {
+    body: null,
+    statusCode: null,
+    headers: {},
+    meta: { connection: { url: new URL(url) }, request: { params: {}, options: {}, id: 1 }, attempts: 1, aborted: false },
+    warnings: null,
+  } as Parameters<typeof errors.ConnectionError>[1])
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
 describe('runQuery — happy path', () => {
-  let server: MockServerHandle
+  let lastParams: RequestParams
 
-  beforeEach(async () => {
-    server = await startMockServer((_req, res) => jsonResponse(res, 200, GOOD_RESPONSE))
-    setResolvedConfig(makeConfig(server.url))
+  beforeEach(() => {
+    _testSetTransport(makeMockTransport(async (params) => {
+      lastParams = params as RequestParams
+      return { ...GOOD_RESPONSE }
+    }))
   })
 
-  afterEach(async () => {
-    _testResetTransport()
-    await server.close()
-  })
+  afterEach(() => _testResetTransport())
 
   it('POSTs to /_query and parses the response', async () => {
     const resp = await runQuery('ROW x = 1')
     assert.deepEqual(resp.columns, [{ name: 'x', type: 'integer' }])
     assert.deepEqual(resp.values, [[1]])
     assert.equal(resp.took, 3)
-    const req = server.lastRequest()
-    assert.equal(req.method, 'POST')
-    assert.equal(req.path, '/_query')
+    assert.equal(lastParams.method, 'POST')
+    assert.equal(lastParams.path, '/_query')
   })
 
   it('sends the query in the request body', async () => {
     await runQuery('ROW x = 1')
-    const body = server.lastRequest().body as Record<string, unknown>
+    const body = lastParams.body as Record<string, unknown>
     assert.equal(body.query, 'ROW x = 1')
   })
 
   it('omits the profile key from the request body by default', async () => {
     await runQuery('ROW x = 1')
-    const body = server.lastRequest().body as Record<string, unknown>
+    const body = lastParams.body as Record<string, unknown>
     assert.equal('profile' in body, false)
   })
 
   it('sends profile: true in the request body when requested', async () => {
     await runQuery('ROW x = 1', { profile: true })
-    const body = server.lastRequest().body as Record<string, unknown>
+    const body = lastParams.body as Record<string, unknown>
     assert.equal(body.profile, true)
   })
 
   it('preserves is_partial flag in the response', async () => {
-    _testResetTransport()
-    const partial = await startMockServer((_req, res) =>
-      jsonResponse(res, 200, { ...GOOD_RESPONSE, is_partial: true }),
-    )
-    setResolvedConfig(makeConfig(partial.url))
-    try {
-      const resp = await runQuery('ROW x = 1')
-      assert.equal(resp.is_partial, true)
-    } finally {
-      _testResetTransport()
-      await partial.close()
-    }
+    _testSetTransport(makeMockTransport(async () => ({ ...GOOD_RESPONSE, is_partial: true })))
+    const resp = await runQuery('ROW x = 1')
+    assert.equal(resp.is_partial, true)
   })
 
   it('returns profile.drivers when profile: true is requested', async () => {
-    _testResetTransport()
     const profileResp = {
       ...GOOD_RESPONSE,
       profile: {
         drivers: [{ description: 'driver-1', took_nanos: 1_000_000, cpu_nanos: 500_000 }],
       },
     }
-    const profSrv = await startMockServer((_req, res) => jsonResponse(res, 200, profileResp))
-    setResolvedConfig(makeConfig(profSrv.url))
-    try {
-      const resp = await runQuery('ROW x = 1', { profile: true })
-      assert.ok(Array.isArray(resp.profile?.drivers))
-      assert.equal(resp.profile?.drivers[0]?.description, 'driver-1')
-    } finally {
-      _testResetTransport()
-      await profSrv.close()
-    }
+    _testSetTransport(makeMockTransport(async () => profileResp))
+    const resp = await runQuery('ROW x = 1', { profile: true })
+    assert.ok(Array.isArray(resp.profile?.drivers))
+    assert.equal(resp.profile?.drivers[0]?.description, 'driver-1')
   })
 })
 
 describe('runQuery — auth headers', () => {
-  afterEach(() => _testResetTransport())
-
-  it('sends ApiKey Authorization header for api_key auth', async () => {
-    const srv = await startMockServer((_req, res) => jsonResponse(res, 200, GOOD_RESPONSE))
-    setResolvedConfig(makeConfig(srv.url, { api_key: 'test-key-abc' }))
-    try {
-      await runQuery('ROW x = 1')
-      const auth = srv.lastRequest().headers.authorization
-      assert.ok(typeof auth === 'string' && auth.startsWith('ApiKey '), `expected ApiKey header, got: ${auth}`)
-    } finally {
-      await srv.close()
-    }
+  afterEach(() => {
+    _testResetTransport()
+    _testResetConfig()
   })
 
-  it('sends Basic Authorization header for username/password auth', async () => {
-    const srv = await startMockServer((_req, res) => jsonResponse(res, 200, GOOD_RESPONSE))
-    setResolvedConfig(makeConfig(srv.url, { username: 'elastic', password: 's3cret' }))
-    try {
-      await runQuery('ROW x = 1')
-      const auth = srv.lastRequest().headers.authorization
-      assert.ok(typeof auth === 'string' && auth.startsWith('Basic '), `expected Basic header, got: ${auth}`)
-      const decoded = Buffer.from(auth.slice('Basic '.length), 'base64').toString('utf-8')
-      assert.equal(decoded, 'elastic:s3cret')
-    } finally {
-      await srv.close()
-    }
+  it('sets ApiKey Authorization header for api_key auth', () => {
+    setResolvedConfig(makeConfig('http://localhost:9200', { api_key: 'test-key-abc' }))
+    const t = getTransport()
+    const auth = t.connectionPool.connections[0]?.headers?.authorization as string | undefined
+    assert.ok(typeof auth === 'string' && auth.startsWith('ApiKey '), `expected ApiKey header, got: ${auth}`)
+  })
+
+  it('sets Basic Authorization header for username/password auth', () => {
+    setResolvedConfig(makeConfig('http://localhost:9200', { username: 'elastic', password: 's3cret' }))
+    const t = getTransport()
+    const auth = t.connectionPool.connections[0]?.headers?.authorization as string | undefined
+    assert.ok(typeof auth === 'string' && auth.startsWith('Basic '), `expected Basic header, got: ${auth}`)
+    const decoded = Buffer.from(auth.slice('Basic '.length), 'base64').toString('utf-8')
+    assert.equal(decoded, 'elastic:s3cret')
   })
 })
 
@@ -204,86 +142,60 @@ describe('runQuery — error mapping', () => {
   afterEach(() => _testResetTransport())
 
   it('throws EsqlError with status on 400', async () => {
-    const srv = await startMockServer((_req, res) =>
-      jsonResponse(res, 400, {
-        error: { type: 'parsing_exception', reason: 'bad query syntax' },
-        status: 400,
-      }),
+    _testSetTransport(makeMockTransport(async () => {
+      throw makeResponseError(400, { error: { type: 'parsing_exception', reason: 'bad query syntax' }, status: 400 })
+    }))
+    await assert.rejects(
+      () => runQuery('BAD'),
+      (err: unknown) => {
+        assert.ok(err instanceof EsqlError)
+        assert.match(err.message, /parsing_exception/)
+        assert.equal(err.status, 400)
+        assert.equal(err.isConnection, false)
+        return true
+      },
     )
-    setResolvedConfig(makeConfig(srv.url))
-    try {
-      await assert.rejects(
-        () => runQuery('BAD'),
-        (err: unknown) => {
-          assert.ok(err instanceof EsqlError)
-          assert.match(err.message, /parsing_exception/)
-          assert.equal(err.status, 400)
-          assert.equal(err.isConnection, false)
-          return true
-        },
-      )
-    } finally {
-      await srv.close()
-    }
   })
 
   it('throws EsqlError with status on 401', async () => {
-    const srv = await startMockServer((_req, res) =>
-      jsonResponse(res, 401, { error: { type: 'security_exception', reason: 'missing auth' }, status: 401 }),
+    _testSetTransport(makeMockTransport(async () => {
+      throw makeResponseError(401, { error: { type: 'security_exception', reason: 'missing auth' }, status: 401 })
+    }))
+    await assert.rejects(
+      () => runQuery('ROW x = 1'),
+      (err: unknown) => {
+        assert.ok(err instanceof EsqlError)
+        assert.equal(err.status, 401)
+        return true
+      },
     )
-    setResolvedConfig(makeConfig(srv.url))
-    try {
-      await assert.rejects(
-        () => runQuery('ROW x = 1'),
-        (err: unknown) => {
-          assert.ok(err instanceof EsqlError)
-          assert.equal(err.status, 401)
-          return true
-        },
-      )
-    } finally {
-      await srv.close()
-    }
   })
 
   it('throws EsqlError with isConnection=true when server drops the connection', async () => {
-    const srv = await startRejectingServer()
-    // Use maxRetries: 0 so the test doesn't wait through backoff between retries
-    const pool = new WeightedConnectionPool({ Connection: UndiciConnection })
-    pool.addConnection(srv.url)
-    _testSetTransport(new Transport({ connectionPool: pool, maxRetries: 0 }))
-    try {
-      await assert.rejects(
-        () => runQuery('ROW x = 1'),
-        (err: unknown) => {
-          assert.ok(err instanceof EsqlError)
-          assert.equal(err.isConnection, true)
-          return true
-        },
-      )
-    } finally {
-      _testResetTransport()
-      await srv.close()
-    }
+    _testSetTransport(makeMockTransport(async () => {
+      throw makeConnectionError('connection refused', 'http://127.0.0.1:12345')
+    }))
+    await assert.rejects(
+      () => runQuery('ROW x = 1'),
+      (err: unknown) => {
+        assert.ok(err instanceof EsqlError)
+        assert.equal(err.isConnection, true)
+        return true
+      },
+    )
   })
 
   it('includes the server URL in the connection error message', async () => {
-    const srv = await startRejectingServer()
-    const pool = new WeightedConnectionPool({ Connection: UndiciConnection })
-    pool.addConnection(srv.url)
-    _testSetTransport(new Transport({ connectionPool: pool, maxRetries: 0 }))
-    try {
-      await assert.rejects(
-        () => runQuery('ROW x = 1'),
-        (err: unknown) => {
-          assert.ok(err instanceof EsqlError)
-          assert.ok(err.message.includes('127.0.0.1'), `expected URL in error: ${err.message}`)
-          return true
-        },
-      )
-    } finally {
-      _testResetTransport()
-      await srv.close()
-    }
+    _testSetTransport(makeMockTransport(async () => {
+      throw makeConnectionError('connection refused', 'http://127.0.0.1:12345')
+    }))
+    await assert.rejects(
+      () => runQuery('ROW x = 1'),
+      (err: unknown) => {
+        assert.ok(err instanceof EsqlError)
+        assert.ok(err.message.includes('127.0.0.1'), `expected URL in error: ${err.message}`)
+        return true
+      },
+    )
   })
 })

--- a/test/esql/client.test.ts
+++ b/test/esql/client.test.ts
@@ -1,0 +1,289 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, beforeEach, afterEach } from 'node:test'
+import assert from 'node:assert/strict'
+import * as http from 'node:http'
+import * as net from 'node:net'
+import { Transport, WeightedConnectionPool, UndiciConnection } from '@elastic/transport'
+import { runQuery, EsqlError } from '../../src/esql/esql-client.ts'
+import { setResolvedConfig } from '../../src/config/store.ts'
+import { _testResetTransport, _testSetTransport } from '../../src/lib/transport.ts'
+import type { ResolvedConfig } from '../../src/config/types.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface MockServerHandle {
+  url: string
+  lastRequest: () => { method: string; path: string; headers: http.IncomingHttpHeaders; body: unknown }
+  close: () => Promise<void>
+}
+
+/** HTTP server that calls `handler` for every request and records the last request. */
+function startMockServer (
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+): Promise<MockServerHandle> {
+  return new Promise((resolve, reject) => {
+    let lastReq: { method: string; path: string; headers: http.IncomingHttpHeaders; body: unknown } = {
+      method: '', path: '', headers: {}, body: undefined,
+    }
+    const server = http.createServer((req, res) => {
+      const chunks: Buffer[] = []
+      req.on('data', (c: Buffer) => chunks.push(c))
+      req.on('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf-8')
+        let body: unknown
+        try { body = JSON.parse(raw) } catch { body = raw }
+        lastReq = { method: req.method ?? '', path: req.url ?? '', headers: req.headers, body }
+        handler(req, res)
+      })
+    })
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number }
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        lastRequest: () => lastReq,
+        close: () => new Promise<void>(r => server.close(() => r())),
+      })
+    })
+    server.on('error', reject)
+  })
+}
+
+/**
+ * TCP server that accepts connections and immediately destroys them.
+ * Produces a near-instant ECONNRESET on each attempt — avoids long timeout
+ * waits even when the transport retries.
+ */
+function startRejectingServer (): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer(socket => { socket.destroy() })
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address() as { port: number }
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        close: () => new Promise<void>(r => server.close(() => r())),
+      })
+    })
+    server.on('error', reject)
+  })
+}
+
+function jsonResponse (res: http.ServerResponse, status: number, body: unknown): void {
+  const payload = JSON.stringify(body)
+  res.writeHead(status, { 'content-type': 'application/json', 'content-length': Buffer.byteLength(payload) })
+  res.end(payload)
+}
+
+const GOOD_RESPONSE = {
+  columns: [{ name: 'x', type: 'integer' }],
+  values: [[1]],
+  took: 3,
+}
+
+function makeConfig (url: string, auth?: ResolvedConfig['context']['elasticsearch']['auth']): ResolvedConfig {
+  return { context: { elasticsearch: { url, auth } } } as ResolvedConfig
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('runQuery — happy path', () => {
+  let server: MockServerHandle
+
+  beforeEach(async () => {
+    server = await startMockServer((_req, res) => jsonResponse(res, 200, GOOD_RESPONSE))
+    setResolvedConfig(makeConfig(server.url))
+  })
+
+  afterEach(async () => {
+    _testResetTransport()
+    await server.close()
+  })
+
+  it('POSTs to /_query and parses the response', async () => {
+    const resp = await runQuery('ROW x = 1')
+    assert.deepEqual(resp.columns, [{ name: 'x', type: 'integer' }])
+    assert.deepEqual(resp.values, [[1]])
+    assert.equal(resp.took, 3)
+    const req = server.lastRequest()
+    assert.equal(req.method, 'POST')
+    assert.equal(req.path, '/_query')
+  })
+
+  it('sends the query in the request body', async () => {
+    await runQuery('ROW x = 1')
+    const body = server.lastRequest().body as Record<string, unknown>
+    assert.equal(body.query, 'ROW x = 1')
+  })
+
+  it('omits the profile key from the request body by default', async () => {
+    await runQuery('ROW x = 1')
+    const body = server.lastRequest().body as Record<string, unknown>
+    assert.equal('profile' in body, false)
+  })
+
+  it('sends profile: true in the request body when requested', async () => {
+    await runQuery('ROW x = 1', { profile: true })
+    const body = server.lastRequest().body as Record<string, unknown>
+    assert.equal(body.profile, true)
+  })
+
+  it('preserves is_partial flag in the response', async () => {
+    _testResetTransport()
+    const partial = await startMockServer((_req, res) =>
+      jsonResponse(res, 200, { ...GOOD_RESPONSE, is_partial: true }),
+    )
+    setResolvedConfig(makeConfig(partial.url))
+    try {
+      const resp = await runQuery('ROW x = 1')
+      assert.equal(resp.is_partial, true)
+    } finally {
+      _testResetTransport()
+      await partial.close()
+    }
+  })
+
+  it('returns profile.drivers when profile: true is requested', async () => {
+    _testResetTransport()
+    const profileResp = {
+      ...GOOD_RESPONSE,
+      profile: {
+        drivers: [{ description: 'driver-1', took_nanos: 1_000_000, cpu_nanos: 500_000 }],
+      },
+    }
+    const profSrv = await startMockServer((_req, res) => jsonResponse(res, 200, profileResp))
+    setResolvedConfig(makeConfig(profSrv.url))
+    try {
+      const resp = await runQuery('ROW x = 1', { profile: true })
+      assert.ok(Array.isArray(resp.profile?.drivers))
+      assert.equal(resp.profile?.drivers[0]?.description, 'driver-1')
+    } finally {
+      _testResetTransport()
+      await profSrv.close()
+    }
+  })
+})
+
+describe('runQuery — auth headers', () => {
+  afterEach(() => _testResetTransport())
+
+  it('sends ApiKey Authorization header for api_key auth', async () => {
+    const srv = await startMockServer((_req, res) => jsonResponse(res, 200, GOOD_RESPONSE))
+    setResolvedConfig(makeConfig(srv.url, { api_key: 'test-key-abc' }))
+    try {
+      await runQuery('ROW x = 1')
+      const auth = srv.lastRequest().headers.authorization
+      assert.ok(typeof auth === 'string' && auth.startsWith('ApiKey '), `expected ApiKey header, got: ${auth}`)
+    } finally {
+      await srv.close()
+    }
+  })
+
+  it('sends Basic Authorization header for username/password auth', async () => {
+    const srv = await startMockServer((_req, res) => jsonResponse(res, 200, GOOD_RESPONSE))
+    setResolvedConfig(makeConfig(srv.url, { username: 'elastic', password: 's3cret' }))
+    try {
+      await runQuery('ROW x = 1')
+      const auth = srv.lastRequest().headers.authorization
+      assert.ok(typeof auth === 'string' && auth.startsWith('Basic '), `expected Basic header, got: ${auth}`)
+      const decoded = Buffer.from(auth.slice('Basic '.length), 'base64').toString('utf-8')
+      assert.equal(decoded, 'elastic:s3cret')
+    } finally {
+      await srv.close()
+    }
+  })
+})
+
+describe('runQuery — error mapping', () => {
+  afterEach(() => _testResetTransport())
+
+  it('throws EsqlError with status on 400', async () => {
+    const srv = await startMockServer((_req, res) =>
+      jsonResponse(res, 400, {
+        error: { type: 'parsing_exception', reason: 'bad query syntax' },
+        status: 400,
+      }),
+    )
+    setResolvedConfig(makeConfig(srv.url))
+    try {
+      await assert.rejects(
+        () => runQuery('BAD'),
+        (err: unknown) => {
+          assert.ok(err instanceof EsqlError)
+          assert.match(err.message, /parsing_exception/)
+          assert.equal(err.status, 400)
+          assert.equal(err.isConnection, false)
+          return true
+        },
+      )
+    } finally {
+      await srv.close()
+    }
+  })
+
+  it('throws EsqlError with status on 401', async () => {
+    const srv = await startMockServer((_req, res) =>
+      jsonResponse(res, 401, { error: { type: 'security_exception', reason: 'missing auth' }, status: 401 }),
+    )
+    setResolvedConfig(makeConfig(srv.url))
+    try {
+      await assert.rejects(
+        () => runQuery('ROW x = 1'),
+        (err: unknown) => {
+          assert.ok(err instanceof EsqlError)
+          assert.equal(err.status, 401)
+          return true
+        },
+      )
+    } finally {
+      await srv.close()
+    }
+  })
+
+  it('throws EsqlError with isConnection=true when server drops the connection', async () => {
+    const srv = await startRejectingServer()
+    // Use maxRetries: 0 so the test doesn't wait through backoff between retries
+    const pool = new WeightedConnectionPool({ Connection: UndiciConnection })
+    pool.addConnection(srv.url)
+    _testSetTransport(new Transport({ connectionPool: pool, maxRetries: 0 }))
+    try {
+      await assert.rejects(
+        () => runQuery('ROW x = 1'),
+        (err: unknown) => {
+          assert.ok(err instanceof EsqlError)
+          assert.equal(err.isConnection, true)
+          return true
+        },
+      )
+    } finally {
+      _testResetTransport()
+      await srv.close()
+    }
+  })
+
+  it('includes the server URL in the connection error message', async () => {
+    const srv = await startRejectingServer()
+    const pool = new WeightedConnectionPool({ Connection: UndiciConnection })
+    pool.addConnection(srv.url)
+    _testSetTransport(new Transport({ connectionPool: pool, maxRetries: 0 }))
+    try {
+      await assert.rejects(
+        () => runQuery('ROW x = 1'),
+        (err: unknown) => {
+          assert.ok(err instanceof EsqlError)
+          assert.ok(err.message.includes('127.0.0.1'), `expected URL in error: ${err.message}`)
+          return true
+        },
+      )
+    } finally {
+      _testResetTransport()
+      await srv.close()
+    }
+  })
+})

--- a/test/esql/formatter.test.ts
+++ b/test/esql/formatter.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { Writable } from 'node:stream'
+import { formatOutput } from '../../src/esql/formatter.ts'
+import type { EsqlResponse } from '../../src/esql/esql-client.ts'
+
+function capture (): { writer: Writable; get: () => string } {
+  const chunks: string[] = []
+  const writer = new Writable({
+    write (chunk: Buffer | string, _enc, cb) { chunks.push(chunk.toString()); cb() },
+  })
+  return { writer, get: () => chunks.join('') }
+}
+
+const resp: EsqlResponse = {
+  columns: [{ name: 'x', type: 'integer' }, { name: 'y', type: 'keyword' }],
+  values: [[1, 'hello'], [2, 'world']],
+  took: 5,
+}
+
+describe('formatOutput', () => {
+  it('renders json', () => {
+    const { writer, get } = capture()
+    formatOutput(resp, { format: 'json' }, writer)
+    const parsed = JSON.parse(get()) as unknown[]
+    assert.deepEqual(parsed, [{ x: 1, y: 'hello' }, { x: 2, y: 'world' }])
+  })
+
+  it('renders json as empty array when no rows', () => {
+    const { writer, get } = capture()
+    const empty: EsqlResponse = { columns: [{ name: 'x', type: 'integer' }], values: [], took: 1 }
+    formatOutput(empty, { format: 'json' }, writer)
+    assert.deepEqual(JSON.parse(get()), [])
+  })
+
+  it('preserves null values in json', () => {
+    const { writer, get } = capture()
+    const nullResp: EsqlResponse = {
+      columns: [{ name: 'x', type: 'integer' }, { name: 'y', type: 'keyword' }],
+      values: [[null, 'hello'], [1, null]],
+      took: 1,
+    }
+    formatOutput(nullResp, { format: 'json' }, writer)
+    const parsed = JSON.parse(get()) as unknown[]
+    assert.deepEqual(parsed, [{ x: null, y: 'hello' }, { x: 1, y: null }])
+  })
+
+  it('renders multivalue arrays in json', () => {
+    const { writer, get } = capture()
+    const mvResp: EsqlResponse = {
+      columns: [{ name: 'tags', type: 'keyword' }],
+      values: [[['a', 'b']]],
+      took: 1,
+    }
+    formatOutput(mvResp, { format: 'json' }, writer)
+    const parsed = JSON.parse(get()) as unknown[]
+    assert.deepEqual(parsed, [{ tags: ['a', 'b'] }])
+  })
+
+  it('renders ndjson', () => {
+    const { writer, get } = capture()
+    formatOutput(resp, { format: 'ndjson' }, writer)
+    const lines = get().trim().split('\n').map(l => JSON.parse(l))
+    assert.deepEqual(lines, [{ x: 1, y: 'hello' }, { x: 2, y: 'world' }])
+  })
+
+  it('renders csv with header', () => {
+    const { writer, get } = capture()
+    formatOutput(resp, { format: 'csv' }, writer)
+    const lines = get().trim().split('\n')
+    assert.equal(lines[0], 'x,y')
+    assert.equal(lines[1], '1,hello')
+    assert.equal(lines[2], '2,world')
+  })
+
+  it('renders csv without header when noHeader is true', () => {
+    const { writer, get } = capture()
+    formatOutput(resp, { format: 'csv', noHeader: true }, writer)
+    const lines = get().trim().split('\n')
+    assert.equal(lines[0], '1,hello')
+  })
+
+  it('renders tsv', () => {
+    const { writer, get } = capture()
+    formatOutput(resp, { format: 'tsv' }, writer)
+    const lines = get().trim().split('\n')
+    assert.equal(lines[0], 'x\ty')
+    assert.equal(lines[1], '1\thello')
+  })
+
+  it('filters columns', () => {
+    const { writer, get } = capture()
+    formatOutput(resp, { format: 'json', columns: ['y'] }, writer)
+    const parsed = JSON.parse(get()) as unknown[]
+    assert.deepEqual(parsed, [{ y: 'hello' }, { y: 'world' }])
+  })
+
+  it('column filter: nonexistent column names return all columns', () => {
+    const { writer, get } = capture()
+    formatOutput(resp, { format: 'json', columns: ['nonexistent'] }, writer)
+    const parsed = JSON.parse(get()) as unknown[]
+    assert.deepEqual(parsed, [{ x: 1, y: 'hello' }, { x: 2, y: 'world' }])
+  })
+
+  it('column filter: preserves response order, not filter order', () => {
+    const { writer, get } = capture()
+    // Filter specifies y before x, but response has x before y
+    formatOutput(resp, { format: 'json', columns: ['y', 'x'] }, writer)
+    const parsed = JSON.parse(get()) as Array<Record<string, unknown>>
+    // Keys should be in response order (x, y)
+    assert.deepEqual(Object.keys(parsed[0]!), ['x', 'y'])
+    assert.deepEqual(parsed, [{ x: 1, y: 'hello' }, { x: 2, y: 'world' }])
+  })
+
+  it('escapes csv values with commas', () => {
+    const csvResp: EsqlResponse = {
+      columns: [{ name: 'msg', type: 'keyword' }],
+      values: [['a,b'], ['no comma']],
+      took: 1,
+    }
+    const { writer, get } = capture()
+    formatOutput(csvResp, { format: 'csv', noHeader: true }, writer)
+    const lines = get().trim().split('\n')
+    assert.equal(lines[0], '"a,b"')
+    assert.equal(lines[1], 'no comma')
+  })
+
+  it('throws on unknown format', () => {
+    const { writer } = capture()
+    assert.throws(() => formatOutput(resp, { format: 'xml' }, writer), /unknown format/)
+  })
+})

--- a/test/esql/hints.test.ts
+++ b/test/esql/hints.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { errorHint, parsingSuggestion } from '../../src/esql/hints.ts'
+import { EsqlError } from '../../src/esql/esql-client.ts'
+
+describe('parsingSuggestion', () => {
+  it('extracts first expected token from mismatched input message', () => {
+    const reason = "mismatched input 'WHER' expecting {'WHERE', 'EVAL', 'STATS'}"
+    const s = parsingSuggestion(reason)
+    assert.ok(s.includes('WHERE'), `expected "WHERE" in suggestion, got: ${s}`)
+  })
+
+  it('echoes unknown function name', () => {
+    const reason = 'Unknown function [AVGG]'
+    const s = parsingSuggestion(reason)
+    assert.ok(s.includes('AVGG'), `expected "AVGG" in suggestion, got: ${s}`)
+  })
+
+  it('echoes unknown column name', () => {
+    const reason = 'Unknown column [hostt]'
+    const s = parsingSuggestion(reason)
+    assert.ok(s.includes('hostt'), `expected "hostt" in suggestion, got: ${s}`)
+  })
+
+  it('returns empty string for unrecognised error text', () => {
+    assert.equal(parsingSuggestion('some unrelated error reason'), '')
+  })
+})
+
+describe('errorHint', () => {
+  it('returns empty string for null', () => {
+    assert.equal(errorHint(null), '')
+  })
+
+  it('returns empty string for undefined', () => {
+    assert.equal(errorHint(undefined), '')
+  })
+
+  it('401 — includes status and authentication guidance', () => {
+    const hint = errorHint(new EsqlError('security_exception: missing credentials', 401))
+    assert.ok(hint.includes('401'), `hint missing "401": ${hint}`)
+    assert.ok(/auth/i.test(hint), `hint missing auth guidance: ${hint}`)
+  })
+
+  it('403 — includes status and privileges guidance', () => {
+    const hint = errorHint(new EsqlError('security_exception: forbidden', 403))
+    assert.ok(hint.includes('403'), `hint missing "403": ${hint}`)
+    assert.ok(/privileges/i.test(hint), `hint missing privileges: ${hint}`)
+  })
+
+  it('404 index_not_found_exception — says "Index not found"', () => {
+    const hint = errorHint(new EsqlError('index_not_found_exception: no such index [missing]', 404))
+    assert.ok(/index not found/i.test(hint), `expected "Index not found" in: ${hint}`)
+  })
+
+  it('404 generic — includes status code', () => {
+    const hint = errorHint(new EsqlError('resource_not_found: something missing', 404))
+    assert.ok(hint.includes('404'), `hint missing "404": ${hint}`)
+  })
+
+  it('400 parsing_exception — mentions ES|QL syntax', () => {
+    const hint = errorHint(new EsqlError('parsing_exception: Unknown command [FORM]', 400))
+    assert.ok(/syntax|ES\|QL/i.test(hint), `hint missing syntax guidance: ${hint}`)
+  })
+
+  it('503 — includes status code', () => {
+    const hint = errorHint(new EsqlError('service_unavailable', 503))
+    assert.ok(hint.includes('503'), `hint missing "503": ${hint}`)
+  })
+
+  it('429 — includes status code', () => {
+    const hint = errorHint(new EsqlError('too_many_requests', 429))
+    assert.ok(hint.includes('429'), `hint missing "429": ${hint}`)
+  })
+
+  it('connection refused — says "Connection refused"', () => {
+    const err = new EsqlError('dial tcp 127.0.0.1:9200: connection refused', undefined, true)
+    const hint = errorHint(err)
+    assert.ok(/connection refused/i.test(hint), `expected "Connection refused" in: ${hint}`)
+  })
+
+  it('TLS error — mentions TLS or certificate', () => {
+    const err = new EsqlError('tls: failed to verify certificate: x509', undefined, true)
+    const hint = errorHint(err)
+    assert.ok(/tls|certificate/i.test(hint), `expected TLS/certificate in: ${hint}`)
+  })
+
+  it('timeout error — mentions "timed out"', () => {
+    const err = new EsqlError('context deadline exceeded', undefined, true)
+    const hint = errorHint(err)
+    assert.ok(/timed out/i.test(hint), `expected "timed out" in: ${hint}`)
+  })
+
+  it('unknown status — returns empty string', () => {
+    const hint = errorHint(new EsqlError('some error', 418))
+    assert.equal(hint, '')
+  })
+})

--- a/test/esql/inject.test.ts
+++ b/test/esql/inject.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { isFromQuery, injectWhere, injectSort, hasAggregation } from '../../src/esql/inject.ts'
+
+describe('isFromQuery', () => {
+  it('returns true for FROM queries', () => {
+    assert.equal(isFromQuery('FROM logs-* | LIMIT 10'), true)
+    assert.equal(isFromQuery('  from logs-*'), true)
+  })
+
+  it('returns false for non-FROM queries', () => {
+    assert.equal(isFromQuery('ROW x = 1'), false)
+    assert.equal(isFromQuery('SHOW INFO'), false)
+    assert.equal(isFromQuery(''), false)
+  })
+})
+
+describe('injectWhere', () => {
+  it('bare FROM — appends WHERE', () => {
+    const q = injectWhere('FROM logs-*', '@timestamp > "2024-01-01"')
+    assert.equal(q, 'FROM logs-* | WHERE @timestamp > "2024-01-01"')
+  })
+
+  it('inserts WHERE before first pipe (KEEP)', () => {
+    const q = injectWhere('FROM logs-* | KEEP @timestamp, message', '@timestamp > "2024-01-01"')
+    assert.equal(q, 'FROM logs-* | WHERE @timestamp > "2024-01-01" | KEEP @timestamp, message')
+  })
+
+  it('inserts WHERE before LIMIT', () => {
+    const q = injectWhere('FROM logs-* | LIMIT 10', '@timestamp > "2024-01-01"')
+    assert.match(q, /WHERE .+ \| LIMIT/)
+  })
+
+  it('inserts WHERE before SORT', () => {
+    const q = injectWhere('FROM logs-* | SORT @timestamp DESC', '@timestamp > "2024-01-01"')
+    assert.match(q, /WHERE .+ \| SORT/)
+  })
+
+  it('inserts before existing WHERE (Go: FROM with existing WHERE)', () => {
+    const q = injectWhere(
+      'FROM logs-* | WHERE log.level == "error"',
+      '@timestamp >= "2026-01-01T00:00:00Z"',
+    )
+    assert.equal(q, 'FROM logs-* | WHERE @timestamp >= "2026-01-01T00:00:00Z" | WHERE log.level == "error"')
+  })
+
+  it('empty expr is no-op', () => {
+    const orig = 'FROM logs-* | LIMIT 10'
+    assert.equal(injectWhere(orig, ''), orig)
+  })
+
+  it('throws for ROW queries', () => {
+    assert.throws(() => injectWhere('ROW x = 1', 'x > 0'), /only FROM-based/)
+  })
+
+  it('throws for SHOW queries', () => {
+    assert.throws(() => injectWhere('SHOW INFO', 'x > 0'), /only FROM-based/)
+  })
+
+  it('pipe inside double-quoted string is not top-level', () => {
+    // The | inside "a|b" must not be treated as the first top-level pipe
+    const q = injectWhere('FROM logs-* | WHERE field == "a|b"', 'extra == true')
+    assert.match(q, /WHERE extra == true \| WHERE field == "a\|b"/)
+  })
+
+  it('pipe inside triple-quoted string is not top-level', () => {
+    const q = injectWhere('FROM logs-* | WHERE field == """a|b"""', 'extra == true')
+    assert.match(q, /WHERE extra == true \| WHERE field == """a\|b"""/)
+  })
+
+  it('pipe inside // line comment is not top-level', () => {
+    // FROM logs-* // some | comment
+    // | LIMIT 10
+    const query = 'FROM logs-* // comment | not-a-pipe\n| LIMIT 10'
+    const q = injectWhere(query, 'x > 0')
+    // The first real | is the one before LIMIT (the // comment's | doesn't count)
+    assert.match(q, /WHERE x > 0 \| LIMIT/)
+  })
+
+  it('pipe inside /* */ block comment is not top-level', () => {
+    const query = 'FROM logs-* /* | not a pipe */ | LIMIT 10'
+    const q = injectWhere(query, 'x > 0')
+    assert.match(q, /WHERE x > 0 \| LIMIT/)
+  })
+})
+
+describe('injectSort', () => {
+  it('appends SORT at end when no LIMIT', () => {
+    const q = injectSort('FROM logs-* | KEEP @timestamp', '@timestamp ASC')
+    assert.equal(q, 'FROM logs-* | KEEP @timestamp | SORT @timestamp ASC')
+  })
+
+  it('inserts SORT before LIMIT', () => {
+    const q = injectSort('FROM logs-* | LIMIT 10', '@timestamp ASC')
+    assert.match(q, /SORT @timestamp ASC \| LIMIT/)
+  })
+
+  it('preserves existing SORT (idempotent)', () => {
+    const orig = 'FROM logs-* | SORT @timestamp ASC | LIMIT 100'
+    assert.equal(injectSort(orig, '@timestamp ASC'), orig)
+  })
+
+  it('empty orderExpr is no-op', () => {
+    const orig = 'FROM logs-* | LIMIT 10'
+    assert.equal(injectSort(orig, ''), orig)
+  })
+})
+
+describe('hasAggregation', () => {
+  it('returns true for query with STATS', () => {
+    assert.equal(hasAggregation('FROM logs-* | STATS COUNT(*) BY service.name'), true)
+  })
+
+  it('returns true for lowercase stats', () => {
+    assert.equal(hasAggregation('FROM logs-* | stats count(*)'), true)
+  })
+
+  it('returns false for plain FROM/KEEP query', () => {
+    assert.equal(hasAggregation('FROM logs-* | KEEP @timestamp'), false)
+  })
+
+  it('returns false when STATS only in a string literal', () => {
+    assert.equal(hasAggregation('FROM logs-* | WHERE msg == "STATS something"'), false)
+  })
+})

--- a/test/esql/query.test.ts
+++ b/test/esql/query.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { splitQueries } from '../../src/esql/commands/query.ts'
+import { applyParams } from '../../src/esql/saved-queries.ts'
+
+describe('splitQueries', () => {
+  it('returns single query as-is', () => {
+    assert.deepEqual(splitQueries('FROM logs-* | LIMIT 10'), ['FROM logs-* | LIMIT 10'])
+  })
+
+  it('splits on semicolons', () => {
+    const result = splitQueries('ROW x = 1; ROW y = 2')
+    assert.deepEqual(result, ['ROW x = 1', 'ROW y = 2'])
+  })
+
+  it('trims whitespace from each query', () => {
+    const result = splitQueries('  ROW x = 1  ;  ROW y = 2  ')
+    assert.deepEqual(result, ['ROW x = 1', 'ROW y = 2'])
+  })
+
+  it('filters out empty segments', () => {
+    const result = splitQueries('ROW x = 1;;ROW y = 2;')
+    assert.deepEqual(result, ['ROW x = 1', 'ROW y = 2'])
+  })
+
+  it('returns empty array for blank input', () => {
+    assert.deepEqual(splitQueries(''), [])
+    assert.deepEqual(splitQueries('   '), [])
+  })
+})
+
+describe('applyParams', () => {
+  it('substitutes a single placeholder', () => {
+    assert.equal(applyParams('FROM {{index}}-*', ['index=logs']), 'FROM logs-*')
+  })
+
+  it('substitutes multiple placeholders', () => {
+    assert.equal(
+      applyParams('FROM {{index}}-* | WHERE level == "{{level}}"', ['index=logs', 'level=error']),
+      'FROM logs-* | WHERE level == "error"',
+    )
+  })
+
+  it('no-op when params is empty array', () => {
+    const q = 'FROM logs-*'
+    assert.equal(applyParams(q, []), q)
+  })
+
+  it('throws when param has no "="', () => {
+    assert.throws(
+      () => applyParams('FROM {{index}}-*', ['noequalssign']),
+      /has no "="/,
+    )
+  })
+
+  it('throws when param has empty key', () => {
+    assert.throws(
+      () => applyParams('FROM {{index}}-*', ['=value']),
+      /empty key/,
+    )
+  })
+
+  it('throws when param placeholder not in query (unused param)', () => {
+    assert.throws(
+      () => applyParams('FROM logs-*', ['unused=value']),
+      /has no placeholder/,
+    )
+  })
+
+  it('throws when placeholder remains unresolved after all substitutions', () => {
+    assert.throws(
+      () => applyParams('FROM {{index}}-* | WHERE x == "{{missing}}"', ['index=logs']),
+      /unresolved placeholder.*missing/,
+    )
+  })
+
+  it('substitutes all occurrences of the same placeholder', () => {
+    assert.equal(
+      applyParams('FROM {{index}}-* | WHERE index == "{{index}}"', ['index=logs']),
+      'FROM logs-* | WHERE index == "logs"',
+    )
+  })
+})

--- a/test/esql/repl.test.ts
+++ b/test/esql/repl.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { needsContinuation, getCandidates, extractIndexName } from '../../src/esql/repl.ts'
+
+describe('needsContinuation', () => {
+  it('true when line ends with |', () => {
+    assert.equal(needsContinuation('FROM logs |'), true)
+  })
+
+  it('true when line ends with \\', () => {
+    assert.equal(needsContinuation('FROM logs \\'), true)
+  })
+
+  it('true when | has trailing whitespace', () => {
+    assert.equal(needsContinuation('FROM logs |  '), true)
+  })
+
+  it('true when \\ has trailing whitespace', () => {
+    assert.equal(needsContinuation('FROM logs \\  '), true)
+  })
+
+  it('true for bare |', () => {
+    assert.equal(needsContinuation('|'), true)
+  })
+
+  it('false for a complete query', () => {
+    assert.equal(needsContinuation('FROM logs | LIMIT 10'), false)
+  })
+
+  it('false for empty string', () => {
+    assert.equal(needsContinuation(''), false)
+  })
+
+  it('false for query ending with normal text', () => {
+    assert.equal(needsContinuation('FROM logs | STATS COUNT(*) BY host'), false)
+  })
+})
+
+describe('getCandidates', () => {
+  it('empty line — offers source commands (FROM, ROW, SHOW, TS)', () => {
+    const candidates = getCandidates('')
+    for (const kw of ['FROM', 'ROW', 'SHOW', 'TS']) {
+      assert.ok(candidates.includes(kw), `expected ${kw} in candidates for empty line`)
+    }
+  })
+
+  it('"F" — offers FROM', () => {
+    const candidates = getCandidates('F')
+    assert.ok(candidates.includes('FROM'), `expected FROM: ${candidates.join(', ')}`)
+  })
+
+  it('"T" — offers TS', () => {
+    const candidates = getCandidates('T')
+    assert.ok(candidates.includes('TS'), `expected TS: ${candidates.join(', ')}`)
+  })
+
+  it('"FROM logs | W" — offers WHERE after pipe', () => {
+    const candidates = getCandidates('FROM logs | W')
+    assert.ok(candidates.includes('WHERE'), `expected WHERE: ${candidates.join(', ')}`)
+  })
+
+  it('"FROM logs | " — offers processing commands after pipe', () => {
+    const candidates = getCandidates('FROM logs | ')
+    for (const kw of ['WHERE', 'STATS', 'SORT', 'LIMIT']) {
+      assert.ok(candidates.includes(kw), `expected ${kw} after pipe`)
+    }
+  })
+
+  it('"FROM logs | MV" — offers MV_EXPAND after pipe', () => {
+    const candidates = getCandidates('FROM logs | MV')
+    assert.ok(candidates.includes('MV_EXPAND'), `expected MV_EXPAND: ${candidates.join(', ')}`)
+  })
+
+  it('returns non-empty list even when prefix matches nothing (falls back to full pool)', () => {
+    const candidates = getCandidates('FROM logs | ZZZNOMATCH')
+    assert.ok(candidates.length > 0, 'should fall back to full processing pool')
+  })
+})
+
+describe('extractIndexName', () => {
+  it('extracts index pattern from simple FROM', () => {
+    assert.equal(extractIndexName('FROM logs-*'), 'logs-*')
+  })
+
+  it('extracts index from FROM with pipe', () => {
+    assert.equal(extractIndexName('FROM logs-* | WHERE x > 1'), 'logs-*')
+  })
+
+  it('handles lowercase from', () => {
+    assert.equal(extractIndexName('from logs-*'), 'logs-*')
+  })
+
+  it('handles mixed case', () => {
+    assert.equal(extractIndexName('From my_index'), 'my_index')
+  })
+
+  it('extracts from TS source command', () => {
+    assert.equal(extractIndexName('TS metrics-*'), 'metrics-*')
+  })
+
+  it('extracts from TS with pipe', () => {
+    assert.equal(extractIndexName('TS metrics-* | STATS AVG(RATE(x)) BY t = TBUCKET(1 minute)'), 'metrics-*')
+  })
+
+  it('handles lowercase ts', () => {
+    assert.equal(extractIndexName('ts metrics-*'), 'metrics-*')
+  })
+
+  it('returns empty string for ROW query', () => {
+    assert.equal(extractIndexName('ROW x = 1'), '')
+  })
+
+  it('returns empty string for bare FROM with no index', () => {
+    assert.equal(extractIndexName('FROM '), '')
+  })
+
+  it('returns empty string for empty string', () => {
+    assert.equal(extractIndexName(''), '')
+  })
+
+  it('FROM with METADATA — stops at METADATA keyword', () => {
+    assert.equal(extractIndexName('FROM logs-* METADATA _id'), 'logs-*')
+  })
+})

--- a/test/esql/stats.test.ts
+++ b/test/esql/stats.test.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { Writable } from 'node:stream'
+import { printStats, warnIfPartial, formatNanos } from '../../src/esql/formatter.ts'
+import type { EsqlResponse } from '../../src/esql/esql-client.ts'
+
+function capture (): { writer: Writable; get: () => string } {
+  const chunks: string[] = []
+  const writer = new Writable({
+    write (chunk: Buffer | string, _enc, cb) { chunks.push(chunk.toString()); cb() },
+  })
+  return { writer, get: () => chunks.join('') }
+}
+
+const baseResp: EsqlResponse = {
+  columns: [{ name: 'x', type: 'integer' }],
+  values: [[1]],
+  took: 42,
+}
+
+describe('formatNanos', () => {
+  it('formats sub-microsecond as ns', () => {
+    assert.equal(formatNanos(500), '500ns')
+  })
+
+  it('formats microseconds', () => {
+    assert.equal(formatNanos(1_500), '1.5µs')
+  })
+
+  it('formats milliseconds', () => {
+    assert.equal(formatNanos(1_500_000), '1.5ms')
+  })
+
+  it('formats seconds', () => {
+    assert.equal(formatNanos(1_500_000_000), '1.50s')
+  })
+
+  it('formats whole nanoseconds without decimal', () => {
+    assert.equal(formatNanos(1), '1ns')
+  })
+})
+
+describe('printStats', () => {
+  it('writes row count and took time', () => {
+    const { writer, get } = capture()
+    printStats(baseResp, 10, writer)
+    assert.ok(get().includes('10'), 'should contain row count')
+    assert.ok(get().includes('42ms'), 'should contain took time')
+  })
+
+  it('includes partial warning when is_partial is true', () => {
+    const { writer, get } = capture()
+    printStats({ ...baseResp, is_partial: true }, 5, writer)
+    assert.ok(get().includes('partial'), 'should warn about partial results')
+  })
+
+  it('does not include partial warning when is_partial is false', () => {
+    const { writer, get } = capture()
+    printStats({ ...baseResp, is_partial: false }, 5, writer)
+    assert.ok(!get().includes('partial'), 'should not warn for non-partial results')
+  })
+
+  it('shows profile section when drivers are present', () => {
+    const { writer, get } = capture()
+    const resp: EsqlResponse = {
+      ...baseResp,
+      profile: {
+        drivers: [{ description: 'data', took_nanos: 50_000_000, cpu_nanos: 40_000_000 }],
+      },
+    }
+    printStats(resp, 1, writer)
+    assert.ok(get().includes('Profile'), 'should include profile section header')
+    assert.ok(get().includes('data'), 'should include driver description')
+  })
+
+  it('aggregates drivers with the same description (x2)', () => {
+    const { writer, get } = capture()
+    const resp: EsqlResponse = {
+      ...baseResp,
+      profile: {
+        drivers: [
+          { description: 'data', took_nanos: 50_000_000, cpu_nanos: 40_000_000 },
+          { description: 'data', took_nanos: 30_000_000, cpu_nanos: 25_000_000 },
+          { description: 'final', took_nanos: 10_000_000, cpu_nanos: 5_000_000 },
+        ],
+      },
+    }
+    printStats(resp, 100, writer)
+    const out = get()
+    assert.ok(out.includes('x2'), `expected "x2" for aggregated driver: ${out}`)
+    assert.ok(out.includes('data'), 'should include "data" description')
+    assert.ok(out.includes('final'), 'should include "final" description')
+  })
+
+  it('sorts drivers by total time descending', () => {
+    const { writer, get } = capture()
+    const resp: EsqlResponse = {
+      ...baseResp,
+      profile: {
+        drivers: [
+          { description: 'fast', took_nanos: 1_000_000, cpu_nanos: 500_000 },
+          { description: 'slow', took_nanos: 100_000_000, cpu_nanos: 80_000_000 },
+        ],
+      },
+    }
+    printStats(resp, 1, writer)
+    const out = get()
+    assert.ok(out.indexOf('slow') < out.indexOf('fast'), `expected "slow" before "fast": ${out}`)
+  })
+})
+
+describe('warnIfPartial', () => {
+  it('is silent for non-partial response', () => {
+    const { writer, get } = capture()
+    warnIfPartial(baseResp, writer)
+    assert.equal(get(), '')
+  })
+
+  it('writes a warning for partial response', () => {
+    const { writer, get } = capture()
+    warnIfPartial({ ...baseResp, is_partial: true }, writer)
+    assert.ok(get().includes('partial'), `expected "partial" in warning: ${get()}`)
+  })
+})

--- a/test/esql/tail.test.ts
+++ b/test/esql/tail.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildTailQuery, tsColumnIndex, extractMaxTimestamp } from '../../src/esql/commands/tail.ts'
+import type { EsqlResponse } from '../../src/esql/esql-client.ts'
+
+describe('buildTailQuery', () => {
+  it('bare FROM — injects WHERE and SORT', () => {
+    const q = buildTailQuery('FROM logs-*', '@timestamp', '2024-01-01T00:00:00.000Z')
+    assert.match(q, /WHERE @timestamp > "2024-01-01T00:00:00.000Z"/)
+    assert.match(q, /SORT @timestamp ASC/)
+  })
+
+  it('preserves existing SORT (does not duplicate)', () => {
+    // If the base query already has a SORT, injectSort is idempotent
+    const base = 'FROM logs-* | SORT @timestamp ASC | LIMIT 100'
+    const q = buildTailQuery(base, '@timestamp', '2024-01-01T00:00:00.000Z')
+    const sortCount = (q.match(/\bSORT\b/gi) ?? []).length
+    assert.equal(sortCount, 1)
+  })
+
+  it('uses custom ts field in WHERE and SORT', () => {
+    const q = buildTailQuery('FROM logs-*', 'event.created', '2024-01-01T00:00:00.000Z')
+    assert.match(q, /WHERE event\.created > "2024-01-01T00:00:00.000Z"/)
+    assert.match(q, /SORT event\.created ASC/)
+  })
+
+  it('WHERE comes before SORT in final query', () => {
+    const q = buildTailQuery('FROM logs-*', '@timestamp', '2024-01-01T00:00:00.000Z')
+    const wherePos = q.indexOf('WHERE')
+    const sortPos = q.indexOf('SORT')
+    assert.ok(wherePos < sortPos, `expected WHERE before SORT in: ${q}`)
+  })
+})
+
+describe('tsColumnIndex', () => {
+  const resp: EsqlResponse = {
+    columns: [
+      { name: '@timestamp', type: 'date' },
+      { name: 'message', type: 'keyword' },
+    ],
+    values: [],
+    took: 1,
+  }
+
+  it('finds the correct column index', () => {
+    assert.equal(tsColumnIndex(resp, '@timestamp'), 0)
+    assert.equal(tsColumnIndex(resp, 'message'), 1)
+  })
+
+  it('returns -1 for missing column', () => {
+    assert.equal(tsColumnIndex(resp, 'missing'), -1)
+  })
+})
+
+describe('extractMaxTimestamp', () => {
+  const resp: EsqlResponse = {
+    columns: [{ name: '@timestamp', type: 'date' }, { name: 'msg', type: 'keyword' }],
+    values: [
+      ['2024-01-01T00:00:00.000Z', 'a'],
+      ['2024-01-02T00:00:00.000Z', 'b'],
+      ['2024-01-03T00:00:00.000Z', 'c'],
+    ],
+    took: 1,
+  }
+
+  it('returns last non-null timestamp', () => {
+    assert.equal(extractMaxTimestamp(resp, 0), '2024-01-03T00:00:00.000Z')
+  })
+
+  it('returns null for empty response', () => {
+    const empty: EsqlResponse = { columns: [{ name: '@timestamp', type: 'date' }], values: [], took: 1 }
+    assert.equal(extractMaxTimestamp(empty, 0), null)
+  })
+
+  it('skips null values scanning from the end', () => {
+    const withNulls: EsqlResponse = {
+      columns: [{ name: '@timestamp', type: 'date' }],
+      values: [['2024-01-01T00:00:00.000Z'], ['2024-01-02T00:00:00.000Z'], [null]],
+      took: 1,
+    }
+    // Last row has null, should return second row's value
+    assert.equal(extractMaxTimestamp(withNulls, 0), '2024-01-02T00:00:00.000Z')
+  })
+
+  it('returns null when all values are null', () => {
+    const allNull: EsqlResponse = {
+      columns: [{ name: '@timestamp', type: 'date' }],
+      values: [[null], [null]],
+      took: 1,
+    }
+    assert.equal(extractMaxTimestamp(allNull, 0), null)
+  })
+})

--- a/test/esql/time-flags.test.ts
+++ b/test/esql/time-flags.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { applyTimeFlagsToQuery, parseRelativeTime } from '../../src/esql/commands/query.ts'
+
+const NOW = new Date('2026-04-22T10:00:00.000Z')
+
+describe('parseRelativeTime', () => {
+  it('parses seconds (30s)', () => {
+    const d = parseRelativeTime('30s', NOW)
+    assert.equal(d.toISOString(), '2026-04-22T09:59:30.000Z')
+  })
+
+  it('parses minutes (15m)', () => {
+    const d = parseRelativeTime('15m', NOW)
+    assert.equal(d.toISOString(), '2026-04-22T09:45:00.000Z')
+  })
+
+  it('parses hours (1h)', () => {
+    const d = parseRelativeTime('1h', NOW)
+    assert.equal(d.toISOString(), '2026-04-22T09:00:00.000Z')
+  })
+
+  it('parses days (2d)', () => {
+    const d = parseRelativeTime('2d', NOW)
+    assert.equal(d.toISOString(), '2026-04-20T10:00:00.000Z')
+  })
+
+  it('parses weeks (1w)', () => {
+    const d = parseRelativeTime('1w', NOW)
+    assert.equal(d.toISOString(), '2026-04-15T10:00:00.000Z')
+  })
+
+  it('parses absolute ISO date string', () => {
+    const d = parseRelativeTime('2026-01-01T00:00:00.000Z', NOW)
+    assert.equal(d.toISOString(), '2026-01-01T00:00:00.000Z')
+  })
+
+  it('throws for an invalid duration', () => {
+    assert.throws(() => parseRelativeTime('not-a-duration', NOW), /Invalid time value/)
+  })
+
+  it('throws for a garbage string', () => {
+    assert.throws(() => parseRelativeTime('xyz', NOW), /Invalid time value/)
+  })
+})
+
+describe('applyTimeFlagsToQuery', () => {
+  it('no flags — returns query unchanged', () => {
+    const q = applyTimeFlagsToQuery('FROM logs', undefined, undefined, NOW)
+    assert.equal(q, 'FROM logs')
+  })
+
+  it('--since 1h — injects WHERE before first pipe', () => {
+    const q = applyTimeFlagsToQuery('FROM logs', '1h', undefined, NOW)
+    assert.equal(q, 'FROM logs | WHERE @timestamp >= "2026-04-22T09:00:00.000Z"')
+  })
+
+  it('--since + --until — injects combined WHERE before LIMIT', () => {
+    const q = applyTimeFlagsToQuery('FROM logs | LIMIT 10', '2h', '1h', NOW)
+    assert.equal(
+      q,
+      'FROM logs | WHERE @timestamp >= "2026-04-22T08:00:00.000Z" AND @timestamp <= "2026-04-22T09:00:00.000Z" | LIMIT 10',
+    )
+  })
+
+  it('custom ts-field — uses supplied field name', () => {
+    const q = applyTimeFlagsToQuery('FROM logs', '1h', undefined, NOW, 'event.ingested')
+    assert.match(q, /event\.ingested >= /)
+    assert.doesNotMatch(q, /@timestamp/)
+  })
+
+  it('throws for invalid --since value', () => {
+    assert.throws(() => applyTimeFlagsToQuery('FROM logs', 'bad', undefined, NOW), /Invalid time value/)
+  })
+
+  it('throws for invalid --until value', () => {
+    assert.throws(() => applyTimeFlagsToQuery('FROM logs', undefined, 'bad', NOW), /Invalid time value/)
+  })
+
+  it('throws when --since is more recent than --until (reversed range)', () => {
+    // since='1h' (1h ago) is more recent than until='2h' (2h ago) → empty range
+    assert.throws(
+      () => applyTimeFlagsToQuery('FROM logs', '1h', '2h', NOW),
+      /must be earlier|reversed|empty/,
+    )
+  })
+
+  it('throws for non-FROM query when time flags are set', () => {
+    assert.throws(() => applyTimeFlagsToQuery('ROW x = 1', '1h', undefined, NOW), /only FROM-based/)
+  })
+
+  it('supports week durations', () => {
+    const q = applyTimeFlagsToQuery('FROM logs', '1w', undefined, NOW)
+    assert.match(q, /WHERE @timestamp >= "2026-04-15T10:00:00.000Z"/)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a new top-level `elastic esql` command group with sub-commands: `query`, `watch`, `tail`, `check`, `save`, and `queries`
- Launches an interactive REPL when `elastic esql` is invoked on a TTY with no sub-command
- Lazy-loads the module at CLI startup so other commands are unaffected

Ported from https://github.com/elastic/esqlcli.

## Commits

The work is split into 9 atomic commits: transport test seam → ES|QL client → formatter → inject/saved-queries → hints → sub-commands → REPL → CLI wiring → tests.

## Test plan

- [x] `npm test` passes (build + unit + license)
- [x] `elastic esql query 'FROM <index> | LIMIT 5'` returns results
- [x] `elastic esql` on a TTY launches the REPL
- [x] `elastic esql --help` lists all sub-commands
- [x] Pipe input: `echo "FROM logs | LIMIT 1" | elastic esql query -`