### PR TITLE
feat: startup banner with Elastic brand colors

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { defineCommand, defineGroup, hideBlockedCommands } from './factory.js'
 import type { OpaqueCommandHandle } from './factory.js'
 import { loadConfig, type LoadConfigResult } from './config/loader.ts'
 import { setResolvedConfig } from './config/store.ts'
+import { renderLogo } from './lib/logo.ts'
 
 // x-release-please-start-version
 const VERSION = '0.1.0-alpha.1';
@@ -158,6 +159,9 @@ if (firstArg !== 'version' && firstArg !== 'config') {
 }
 
 if (process.argv.slice(2).length === 0) {
+  if (!earlyConfig?.ok || earlyConfig.value.banner !== false) {
+    process.stdout.write(renderLogo(VERSION))
+  }
   program.outputHelp()
   process.exit(0)
 }

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -138,7 +138,7 @@ async function applyFieldUpdates (
   baseContext: RawContext,
   updates: FieldUpdate,
   contextName: string,
-  store: SecretStore,
+  store: SecretStore | null,
   inlineSecrets: boolean
 ): Promise<ApplyFieldUpdatesResult> {
   let ctx = baseContext as Record<string, unknown>
@@ -149,7 +149,8 @@ async function applyFieldUpdates (
     ctx = setPath(ctx, field.path, value)
   }
 
-  const storeAvailable = await store.isAvailable()
+  // When inlineSecrets is true we never use the store, so skip the probe entirely.
+  const storeAvailable = store != null && !inlineSecrets && await store.isAvailable()
   if (updates.secrets.length > 0 && !storeAvailable && !inlineSecrets) {
     warnings.push(
       'No OS secret store is available; secrets will be written inline to the config file. ' +
@@ -157,10 +158,10 @@ async function applyFieldUpdates (
     )
   }
 
-  const useStore = storeAvailable && !inlineSecrets
+  const useStore = storeAvailable && store != null
   for (const { field, value } of updates.secrets) {
     const account = `${contextName}:${field.path.join('.')}`
-    if (useStore) {
+    if (useStore && store != null) {
       await store.put(KEYCHAIN_SERVICE, account, value)
       const expr = store.resolverExpr(KEYCHAIN_SERVICE, account)
       ctx = setPath(ctx, field.path, expr)
@@ -253,7 +254,7 @@ async function handleContextAdd (parsed: {
     )
   }
 
-  const store = await getSecretStore()
+  const store = inlineSecrets ? null : await getSecretStore()
   const { context: ctx, secretsLog, warnings } = await applyFieldUpdates({}, updates, name, store, inlineSecrets)
 
   const contextValidation = ContextSchema.safeParse(resolveForValidation(ctx))
@@ -340,7 +341,7 @@ async function handleContextEdit (parsed: {
 
   if (hasFlagEdits) {
     // Flag-patch mode
-    const store = await getSecretStore()
+    const store = inlineSecrets ? null : await getSecretStore()
     const { context: ctx, secretsLog, warnings } = await applyFieldUpdates(
       extractContext(config, name),
       updates,

--- a/src/config/commands.ts
+++ b/src/config/commands.ts
@@ -189,14 +189,18 @@ function getPath (obj: Record<string, unknown>, path: string[]): unknown {
  * failures are swallowed so a `context remove` never fails because a specific
  * keychain entry was already deleted.
  */
-async function purgeContextSecrets (store: SecretStore, contextName: string, ctx: RawContext | undefined): Promise<void> {
+async function purgeContextSecrets (contextName: string, ctx: RawContext | undefined): Promise<void> {
   if (ctx == null) return
-  for (const field of SECRET_FIELDS) {
+  // Identify fields that have resolver expressions — these are the only ones
+  // stored in the OS keychain. Inline secrets have nothing to purge.
+  const keychainFields = SECRET_FIELDS.filter(field => {
     const val = getPath(ctx as Record<string, unknown>, field.path)
-    if (typeof val !== 'string') continue
-    // Only delete keychain entries we wrote (resolver expressions). Inline
-    // values would require parsing, and deleting them would do nothing useful.
-    if (!val.includes('$(')) continue
+    return typeof val === 'string' && val.includes('$(')
+  })
+  if (keychainFields.length === 0) return
+  // Only probe the secret store when there is actually something to delete.
+  const store = await getSecretStore()
+  for (const field of keychainFields) {
     const account = `${contextName}:${field.path.join('.')}`
     try {
       await store.delete(KEYCHAIN_SERVICE, account)
@@ -297,8 +301,7 @@ async function handleContextRemove (parsed: {
     )
   }
 
-  const store = await getSecretStore()
-  await purgeContextSecrets(store, name, config.contexts[name])
+  await purgeContextSecrets(name, config.contexts[name])
 
   const next = removeContext(config, name)
   if (Object.keys(next.contexts).length === 0) {

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -112,6 +112,7 @@ export function resolveContext (config: ConfigFile, contextName: string): Resolv
   if (ctx.cloud != null) resolved.cloud = ctx.cloud
   const result: ResolvedConfig = { context: resolved }
   if (config.commands != null) result.commands = config.commands
+  if (config.banner != null) result.banner = config.banner
   return result
 }
 
@@ -270,6 +271,7 @@ export async function loadConfig (options: LoadConfigOptions = {}): Promise<Load
     current_context: resolvedContextName,
     contexts: { [resolvedContextName]: contextParsed.data },
     ...(commands != null && { commands }),
+    ...(structural.data.banner != null && { banner: structural.data.banner }),
   }
   return { ok: true, value: resolveContext(config, resolvedContextName) }
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -77,6 +77,7 @@ export const ConfigFileSchema = z
       { error: 'contexts must contain at least one entry' },
     ),
     commands: CommandPolicySchema.optional(),
+    banner: z.boolean().optional(),
   })
   .refine(
     (cfg) => cfg.current_context in cfg.contexts,
@@ -96,4 +97,5 @@ export const StructuralConfigSchema = z
       { error: 'contexts must contain at least one entry' },
     ),
     commands: z.unknown().optional(),
+    banner: z.boolean().optional(),
   })

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -51,4 +51,6 @@ export interface ResolvedConfig {
   context: ResolvedContext
   /** Optional command allow/deny policy from the config file. */
   commands?: CommandPolicy
+  /** Whether to show the startup banner. Defaults to true when absent. */
+  banner?: boolean
 }

--- a/src/config/writer.ts
+++ b/src/config/writer.ts
@@ -283,8 +283,9 @@ export function serializeConfig (config: RawConfig): string {
   ordered.current_context = config.current_context
   ordered.contexts = config.contexts
   if (config.commands != null) ordered.commands = config.commands
+  if (config.banner != null) ordered.banner = config.banner
   for (const [k, v] of Object.entries(config)) {
-    if (k === 'current_context' || k === 'contexts' || k === 'commands') continue
+    if (k === 'current_context' || k === 'contexts' || k === 'commands' || k === 'banner') continue
     ordered[k] = v
   }
   return stringifyYaml(ordered, { lineWidth: 0 })
@@ -316,5 +317,6 @@ export async function readRawConfig (path: string): Promise<RawConfig> {
       ? obj.contexts as Record<string, RawContext>
       : {},
     ...(obj.commands != null ? { commands: obj.commands } : {}),
+    ...(typeof obj.banner === 'boolean' ? { banner: obj.banner } : {}),
   }
 }

--- a/src/lib/logo.ts
+++ b/src/lib/logo.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const RESET = '\x1b[0m'
+const BOLD = '\x1b[1m'
+const DIM = '\x1b[2m'
+
+function rgb(r: number, g: number, b: number): string {
+  return `\x1b[38;2;${r};${g};${b}m`
+}
+
+function color256(n: number): string {
+  return `\x1b[38;5;${n}m`
+}
+
+type ColorLevel = 0 | 1 | 2 | 3
+
+function isTTY(): boolean {
+  const force = process.env.FORCE_COLOR
+  return !!process.stdout.isTTY || (force !== undefined && force !== '0')
+}
+
+function detectColorLevel(): ColorLevel {
+  if (process.env.NO_COLOR !== undefined) return 0
+  if (process.env.COLORTERM === 'truecolor' || process.env.COLORTERM === '24bit') return 3
+  if (process.env.TERM?.includes('256')) return 2
+  return 1
+}
+
+// "elastic" in figlet standard font
+const ELASTIC_ASCII = [
+  '  _____ _           _   _      ',
+  ' | ____| | __ _ ___| |_(_) ___ ',
+  ' |  _| | |/ _` / __| __| |/ __|',
+  ' | |___| | (_| \\__ \\ |_| | (__ ',
+  ' |_____|_|\\__,_|___/\\__|_|\\___|',
+]
+
+// Elastic brand gradient: pink → yellow → teal → blue → light-blue
+const PALETTE_TC = [
+  rgb(240, 78, 152),   // #F04E98 Elastic Pink
+  rgb(254, 197, 20),   // #FEC514 Elastic Yellow
+  rgb(0, 191, 179),    // #00BFB3 Elastic Teal
+  rgb(0, 119, 204),    // #0077CC Elastic Blue
+  rgb(27, 169, 245),   // #1BA9F5 Elastic Light Blue
+]
+
+const PALETTE_256 = [205, 220, 43, 26, 39]
+
+const PALETTE_ANSI = ['\x1b[95m', '\x1b[93m', '\x1b[96m', '\x1b[94m', '\x1b[36m']
+
+export function renderLogo(version: string): string {
+  if (process.env.ELASTIC_NO_BANNER === '1') return ''
+  if (!isTTY()) return ''
+
+  const level = detectColorLevel()
+
+  if (level === 0) {
+    return `\n  elastic CLI  ${version}\n\n`
+  }
+
+  const lines = ELASTIC_ASCII.map((line, i) => {
+    const c =
+      level === 3 ? PALETTE_TC[i]! :
+      level === 2 ? color256(PALETTE_256[i]!) :
+      PALETTE_ANSI[i]!
+    const suffix = i === ELASTIC_ASCII.length - 1
+      ? `  ${BOLD}CLI${RESET}  ${DIM}${version}${RESET}`
+      : ''
+    return `${c}${line}${RESET}${suffix}`
+  })
+
+  return `\n${lines.join('\n')}\n\n`
+}


### PR DESCRIPTION
## Summary

<img width="622" height="156" alt="image" src="https://github.com/user-attachments/assets/ba38859d-7000-4012-a786-0e5c52eb6a1f" />


Adds a multi-color ASCII art startup banner shown when the CLI is invoked with no arguments (the help/landing screen). The Elastic brand gradient sweeps across five rows: pink → yellow → teal → blue → light-blue.

- New `src/lib/logo.ts` module handles detection and rendering
- `banner: false` config file field to suppress per-user
- `ELASTIC_NO_BANNER=1` env var to suppress globally
- Automatically silent when stdout is not a TTY

## Token-safe by default

When an LLM or script invokes the CLI as a subprocess, stdout is piped (no TTY). `renderLogo` detects this and returns an empty string — no tokens wasted on decorative output. This is unconditional: no env var or flag needed on the caller side.

The suppression hierarchy (highest to lowest precedence):
1. No TTY — always silent (LLM tool use, pipes, CI)
2. `ELASTIC_NO_BANNER=1` — always silent
3. `banner: false` in config file — silent for that user's session
4. Default — shown

## Color tiers

The banner degrades gracefully based on terminal capability:

| Env | Escape format | Colors |
|---|---|---|
| `COLORTERM=truecolor` | `\x1b[38;2;R;G;Bm` | Exact Elastic brand hex values |
| `TERM=*256*` | `\x1b[38;5;Nm` | Closest 256-color approximations |
| Basic ANSI TTY | `\x1b[9Xm` | Bright named colors |
| No TTY / `NO_COLOR` | — | Silent or plain text |

## Config schema changes

`banner` is a top-level field alongside `commands`:

```yaml
current_context: default
banner: false
contexts:
  default:
    elasticsearch:
      url: https://...
```

Threaded through the full config pipeline: `StructuralConfigSchema` → `ConfigFileSchema` → `resolveContext` → `ResolvedConfig`. Also preserved on read/write round-trips in `writer.ts` with stable key ordering (`current_context` → `contexts` → `commands` → `banner`).

## Open question: scope of the banner

Currently the banner only appears on bare `elastic` (no args). This is intentional — showing it on every subcommand invocation would quickly become noise. If we want to show it in other contexts (e.g. `elastic --help`, or a future interactive/REPL mode), we should be deliberate about which entry points trigger it rather than adding it broadly.

## Test plan

- [ ] `elastic` (no args, real TTY) — banner renders with Elastic gradient colors
- [ ] `elastic | cat` (piped) — no banner output
- [ ] `ELASTIC_NO_BANNER=1 elastic` — no banner output
- [ ] `NO_COLOR=1 elastic` — plain text fallback (`  elastic CLI  v0.1.0-alpha.1`)
- [ ] Config with `banner: false` — no banner output
- [ ] Config without `banner` field — banner shows (default enabled)
- [ ] `elastic stack es search ...` — no banner (banner is no-args only)
- [ ] `elastic config context list` — no banner
