### PR TITLE
fix(ci): replace npm install with npm ci in all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install
-        run: npm install
+        run: npm ci
       - name: Run unit tests
         run: npm test
         shell: bash
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       - name: Install
-        run: npm install
+        run: npm ci
       - name: License header check
         run: npm run test:spdx
 
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       - name: Install
-        run: npm install
+        run: npm ci
       - name: Verify NOTICE.txt
         run: npm run test:notice
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: 24
           registry-url: https://registry.npmjs.org
       - name: Install
-        run: npm install
+        run: npm ci
       - name: Run tests
         run: npm test
       - name: Publish


### PR DESCRIPTION
## Summary

- Replaces all bare `npm install` calls in CI/release workflows with `npm ci`
- Covers 4 occurrences: `test-node`, `license-header`, `notice-file` (ci.yml), and the release publish step (release.yml)
- `npm ci` enforces exact lockfile resolution and fails on drift; `npm install` can silently rewrite `package-lock.json` and pick up drifted transitive deps

Fixes #238 (ECLI-001 from Infosec review)

## Test plan

- [ ] Verify CI passes on this PR (the `npm ci` calls succeed with the existing lockfile)
- [ ] Confirm no remaining `npm install` in `.github/workflows/`
