### PR TITLE
fix(ci): scope workflow permissions to minimum per-job (ECLI-004)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,7 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  issues: write
-  pull-requests: write
+permissions: {}
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -18,6 +15,8 @@ concurrency:
 jobs:
   test-node:
     name: Test Node.js
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -40,6 +39,8 @@ jobs:
 
   license-header:
     name: Check SPDX license header
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -51,6 +52,8 @@ jobs:
 
   notice-file:
     name: Check NOTICE.txt is up to date
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -62,6 +65,8 @@ jobs:
 
   test-bun:
     name: Test Bun
+    permissions:
+      contents: read
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -83,6 +88,8 @@ jobs:
   validate-pr-title:
     if: github.event_name == 'pull_request'
     name: Validate PR title
+    permissions:
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: PR Conventional Commit Validation
@@ -93,6 +100,9 @@ jobs:
 
   megalinter:
     name: MegaLinter
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   release-please:


### PR DESCRIPTION
## Summary

Fixes #241 — infosec finding ECLI-004: workflow-level permissions over-scoped.

Both workflow files previously granted broad permissions at the workflow level, which every job (and every third-party action inside them) inherited.

### ci.yml

- `issues: write` — removed entirely; no job used it.
- `pull-requests: write` — moved to the `megalinter` job only, which is the only job posting PR annotations via `GITHUB_TOKEN`.
- `contents: read` — added per-job to the five jobs that run `actions/checkout`.
- `validate-pr-title` — gets `pull-requests: read` (reads PR data; does not write/label because `add_label: "false"` is set).
- `ci` rollup job — no permissions block needed (runs a shell expression only).

### release.yml

- `contents: write` and `pull-requests: write` — removed from workflow level. The `release-please` job uses a vault-fetched custom token (`token: ${{ steps.fetch-token.outputs.token }}`), not `GITHUB_TOKEN`, for all release-please API calls, so these scopes on `GITHUB_TOKEN` were unused.
- `release-please` job — retains `id-token: write` only (needed for OIDC vault auth).
- `publish` job — retains `contents: read` (unchanged).

## Test plan

- [ ] Open this PR and verify the CI workflow runs successfully (all jobs pass with their new per-job permissions).
- [ ] Confirm `megalinter` still posts PR annotations (requires `pull-requests: write`).
- [ ] Confirm `validate-pr-title` still validates the PR title convention.
- [ ] Release workflow change is validated on next merge to main.