### PR TITLE
docs: warn that cmd/file resolvers execute on behalf of the user (ECLI-005)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,12 @@ Instead of storing secrets in plaintext, any string value in the config file can
 use `$(resolver:params)` expressions to fetch values from external sources at
 runtime.
 
+> **Security note.** Review config files before using them if you didn't write
+> them yourself — the `$(cmd:...)` and `$(file:...)` resolvers execute programs
+> and read files on your behalf. This applies especially to CI/CD environments
+> where a repo-checked-in config (e.g. via `ELASTIC_CLI_CONFIG_FILE`) can run
+> arbitrary commands on the runner.
+
 #### `file` - read from a file
 
 Reads the contents of a file (trimmed). Useful for Docker/Kubernetes secrets


### PR DESCRIPTION
## Summary

- Adds a security caution blockquote to the "External credentials" section of `README.md`
- Warns users that `$(cmd:...)` and `$(file:...)` resolvers execute programs and read files on their behalf
- Specifically calls out the CI/CD exposure where a repo-checked-in config passed via `ELASTIC_CLI_CONFIG_FILE` can run arbitrary commands on the runner

Closes #242 (ECLI-005 — documentation-only fix; no behavior changes)

## Test plan

- [ ] Confirm the note renders correctly as a blockquote in the GitHub README preview
- [ ] Confirm it appears in the right position: after the intro paragraph, before the `#### file` subsection
