### PR TITLE
fix: use URL parser for loopback check in HTTP clients

### DIFF
--- a/src/lib/cloud-client.ts
+++ b/src/lib/cloud-client.ts
@@ -5,6 +5,7 @@
 
 import type { HttpMethod } from '../cloud/types.ts'
 import { getResolvedConfig } from '../config/store.ts'
+import { isLoopbackUrl } from './is-loopback-host.ts'
 
 /**
  * Parameters for a single Cloud API request.
@@ -31,7 +32,7 @@ export class CloudClient {
   constructor(baseUrl: string, apiKey: string) {
     this.baseUrl = baseUrl.replace(/\/+$/, '')
     this.apiKey = apiKey
-    if (this.baseUrl.startsWith('http://') && !/localhost|127\.0\.0\.1/.test(this.baseUrl)) {
+    if (this.baseUrl.startsWith('http://') && !isLoopbackUrl(this.baseUrl)) {
       process.stderr.write('Warning: using plaintext HTTP. Credentials will be sent unencrypted.\n')
     }
   }

--- a/src/lib/is-loopback-host.ts
+++ b/src/lib/is-loopback-host.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]'])
+
+/**
+ * Returns true when the given URL targets a loopback address.
+ * Parses the URL with the built-in URL constructor and compares
+ * the hostname exactly against known loopback values.
+ */
+export function isLoopbackUrl (url: string): boolean {
+  try {
+    const { hostname } = new URL(url)
+    return LOOPBACK_HOSTNAMES.has(hostname)
+  } catch {
+    return false
+  }
+}

--- a/src/lib/kibana-client.ts
+++ b/src/lib/kibana-client.ts
@@ -4,6 +4,7 @@
  */
 
 import { getResolvedConfig } from '../config/store.ts'
+import { isLoopbackUrl } from './is-loopback-host.ts'
 
 export type KibanaHttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD' | 'PATCH'
 
@@ -41,7 +42,7 @@ export class KibanaClient {
       const encoded = Buffer.from(`${auth.username}:${auth.password}`).toString('base64')
       this.authHeader = `Basic ${encoded}`
     }
-    if (this.baseUrl.startsWith('http://') && !/localhost|127\.0\.0\.1/.test(this.baseUrl)) {
+    if (this.baseUrl.startsWith('http://') && !isLoopbackUrl(this.baseUrl)) {
       process.stderr.write('Warning: using plaintext HTTP. Credentials will be sent unencrypted.\n')
     }
   }

--- a/test/lib/is-loopback-host.test.ts
+++ b/test/lib/is-loopback-host.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { isLoopbackUrl } from '../../src/lib/is-loopback-host.ts'
+
+describe('isLoopbackUrl', () => {
+  it('returns true for http://localhost', () => {
+    assert.equal(isLoopbackUrl('http://localhost'), true)
+  })
+
+  it('returns true for http://localhost:9200', () => {
+    assert.equal(isLoopbackUrl('http://localhost:9200'), true)
+  })
+
+  it('returns true for https://localhost:5601/path', () => {
+    assert.equal(isLoopbackUrl('https://localhost:5601/path'), true)
+  })
+
+  it('returns true for http://127.0.0.1', () => {
+    assert.equal(isLoopbackUrl('http://127.0.0.1'), true)
+  })
+
+  it('returns true for http://127.0.0.1:9200', () => {
+    assert.equal(isLoopbackUrl('http://127.0.0.1:9200'), true)
+  })
+
+  it('returns true for http://[::1]:9200', () => {
+    assert.equal(isLoopbackUrl('http://[::1]:9200'), true)
+  })
+
+  it('returns false for http://localhost.attacker.com', () => {
+    assert.equal(isLoopbackUrl('http://localhost.attacker.com'), false)
+  })
+
+  it('returns false for http://not-localhost:9200', () => {
+    assert.equal(isLoopbackUrl('http://not-localhost:9200'), false)
+  })
+
+  it('returns false for http://example.com/localhost', () => {
+    assert.equal(isLoopbackUrl('http://example.com/localhost'), false)
+  })
+
+  it('returns false for http://127.0.0.1.evil.com', () => {
+    assert.equal(isLoopbackUrl('http://127.0.0.1.evil.com'), false)
+  })
+
+  it('returns false for a remote HTTPS URL', () => {
+    assert.equal(isLoopbackUrl('https://my-cluster.es.cloud.elastic.co:9243'), false)
+  })
+
+  it('returns false for an invalid URL', () => {
+    assert.equal(isLoopbackUrl('not-a-url'), false)
+  })
+})


### PR DESCRIPTION
Closes https://github.com/elastic/cli/issues/243
### Summary
- The old regex `/localhost|127\.0\.0\.1/.test(baseUrl)` substring-matched the full URL string, so a URL like `http://localhost.attacker.com` would suppress the plaintext HTTP warning
- Extracted `isLoopbackUrl()` helper in `src/lib/is-loopback-host.ts` using `new URL(baseUrl).hostname` for exact hostname comparison against `localhost`, `127.0.0.1`, and `[::1]`
- Applied fix to both `CloudClient` and `KibanaClient`
### Test plan
- [x] `http://localhost.attacker.com` now triggers the plaintext HTTP warning
- [x] `http://localhost:9200`, `http://127.0.0.1`, `http://[::1]:9200` still suppress the warning
- [x] 12 unit tests in `test/lib/is-loopback-host.test.ts` covering bypass and loopback scenarios
- [x] All existing cloud-client tests pass