### PR TITLE
fix: correct text output for cat APIs

### DIFF
--- a/src/es/register.ts
+++ b/src/es/register.ts
@@ -22,12 +22,16 @@ function buildLeafHandle (
 ): OpaqueCommandHandle {
   const schema = def.input != null ? resolveInput(def.input) : z.looseObject({})
   const schemaArgs = defSchemaArgs.get(def) ?? []
-  return defineCommand({
+  const config: Parameters<typeof defineCommand>[0] = {
     name: def.name,
     description: def.description,
     input: schema,
-    handler: createEsHandler(def, schemaArgs)
-  })
+    handler: createEsHandler(def, schemaArgs),
+  }
+  if (def.responseType === 'text') {
+    config.formatOutput = (result) => String(result)
+  }
+  return defineCommand(config)
 }
 
 /**


### PR DESCRIPTION
Closes https://github.com/elastic/cli/issues/112
### Summary
- Cat API text responses (e.g. `elastic es cat indices`) were getting an extra trailing newline because `renderText()` appended `\n` to the already-newline-terminated string returned by Elasticsearch
- Added `formatOutput` on text-response API commands to pass the response through as-is, without double-newline
- The `--json` path (injecting `format=json` into the querystring) was already working correctly
### Test plan
- [x] `elastic es cat indices` no longer prints a blank line after the table
- [x] `elastic es cat indices --json` returns a proper JSON array
- [x] All existing handler tests pass