### PR TITLE
feat(kb): add kibana functional tests

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -41,7 +41,8 @@ steps:
               - "24"
         agents:
           provider: gcp
-          image: family/core-ubuntu-2204
+          image: family/kibana-ubuntu-2404
+          machineType: n2-standard-4
         env:
           NODE_VERSION: "{{matrix.node}}"
           STACK_VERSION: "9.3.0"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,6 +30,23 @@ steps:
           STACK_VERSION: "9.3.0"
         command: ".buildkite/run-es-tests.sh"
 
+  - group: "KB Functional Tests"
+    steps:
+      - label: ":kibana: KB functional tests — Node {{matrix.node}}"
+        key: "kb-functional"
+        matrix:
+          setup:
+            node:
+              - "22"
+              - "24"
+        agents:
+          provider: gcp
+          image: family/core-ubuntu-2204
+        env:
+          NODE_VERSION: "{{matrix.node}}"
+          STACK_VERSION: "9.3.0"
+        command: ".buildkite/run-kb-tests.sh"
+
   - group: "Cloud Smoke Tests"
     steps:
       - label: ":cloud: Cloud smoke tests — Node {{matrix.node}}"

--- a/.buildkite/run-kb-tests-runner.sh
+++ b/.buildkite/run-kb-tests-runner.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Runs INSIDE the test-runner container on the same Docker network as ES/Kibana.
+# Uses Docker DNS aliases (elasticsearch:9200, kibana:5601) for all connectivity,
+# which is the only networking that works reliably on kibana-ubuntu-2404 agents.
+
+set -euo pipefail
+
+ES_PASSWORD="${ES_PASSWORD:-changeme}"
+
+echo "--- Installing curl and jq"
+apt-get update -qq && apt-get install -y -q --no-install-recommends curl jq
+
+echo "--- Waiting for Elasticsearch to be healthy"
+RETRIES=0
+MAX_RETRIES=180
+until curl -sf -u "elastic:${ES_PASSWORD}" "http://elasticsearch:9200/_cluster/health" > /dev/null 2>&1; do
+  RETRIES=$((RETRIES + 1))
+  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+    echo "Elasticsearch did not become healthy in time after $((MAX_RETRIES * 2))s"
+    exit 1
+  fi
+  if [ $((RETRIES % 15)) -eq 0 ]; then
+    echo "  still waiting for Elasticsearch... (${RETRIES}/${MAX_RETRIES})"
+  fi
+  sleep 2
+done
+echo "Elasticsearch cluster is up"
+
+# The cluster can report healthy before the .security index is fully bootstrapped.
+# Kibana's alerting/connectors plugins depend on ES API keys (encryptedSavedObjects),
+# so we must confirm the security index is ready.
+# Technique borrowed from Kibana's own kbn-es tooling (wait_for_security_index.ts).
+echo "--- Waiting for Elasticsearch security index to be ready"
+RETRIES=0
+MAX_RETRIES=60
+until curl -sf -u "elastic:${ES_PASSWORD}" \
+    -X POST "http://elasticsearch:9200/_security/api_key" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"healthcheck","expiration":"1m"}' > /dev/null 2>&1; do
+  RETRIES=$((RETRIES + 1))
+  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+    echo "Elasticsearch security index did not become ready in time"
+    exit 1
+  fi
+  sleep 2
+done
+echo "Elasticsearch is ready"
+
+echo "--- Waiting for Kibana to be healthy"
+RETRIES=0
+MAX_RETRIES=90
+until curl -sf -u "elastic:${ES_PASSWORD}" "http://kibana:5601/api/status" \
+      | jq -e '.status.overall.level == "available"' > /dev/null 2>&1; do
+  RETRIES=$((RETRIES + 1))
+  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+    echo "Kibana did not become healthy in time"
+    exit 1
+  fi
+  sleep 3
+done
+echo "Kibana core is ready"
+
+# The actions and alerting plugins initialise after the main health check passes.
+echo "--- Waiting for alerting and actions plugins to be ready"
+RETRIES=0
+MAX_RETRIES=30
+until curl -sf -u "elastic:${ES_PASSWORD}" "http://kibana:5601/api/actions/connector_types" > /dev/null 2>&1 && \
+      curl -sf -u "elastic:${ES_PASSWORD}" "http://kibana:5601/api/alerting/rules/_find" > /dev/null 2>&1; do
+  RETRIES=$((RETRIES + 1))
+  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+    echo "Alerting/actions plugins did not become ready in time"
+    exit 1
+  fi
+  sleep 3
+done
+echo "Kibana plugins are ready"
+
+echo "--- Generating CLI config file"
+cat > /tmp/elastic-rc.yml <<EOF
+contexts:
+  ci:
+    elasticsearch:
+      url: http://elasticsearch:9200
+      auth:
+        username: elastic
+        password: "${ES_PASSWORD}"
+    kibana:
+      url: http://kibana:5601
+      auth:
+        username: elastic
+        password: "${ES_PASSWORD}"
+current_context: ci
+EOF
+export ELASTIC_CLI_CONFIG_FILE="/tmp/elastic-rc.yml"
+
+echo "+++ Running KB functional tests"
+npm run test:functional:kb

--- a/.buildkite/run-kb-tests-runner.sh
+++ b/.buildkite/run-kb-tests-runner.sh
@@ -112,26 +112,31 @@ until curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_HOST}:5601/api/status" \
 done
 echo "Kibana core is ready"
 
-# Poll the actions API directly — it requires the license to be loaded from ES.
-# Kibana's actions plugin returns 403 with "license information is not available"
-# until its licensing subscription fires (usually a few seconds after "available",
-# but can be longer on cold starts).  Polling the real endpoint is more reliable
-# than a fixed sleep.
-echo "--- Waiting for Kibana actions API (license must be loaded)"
+# Wait for the actions and alerting plugins to be individually "available" by
+# polling /api/status.  That endpoint always returns HTTP 200, so it never
+# causes the 500 Server Error noise in Kibana logs that polling the actions
+# endpoint directly does (the actions HTTP context isn't wired until slightly
+# after overall "available", returning 500 during that window).
+# Fleet being degraded shows up only in plugins.fleet — it does not affect
+# plugins.actions or plugins.alerting.
+echo "--- Waiting for actions + alerting plugins to be available"
 RETRIES=0
 MAX_RETRIES=60
-until curl -sf -u "elastic:${ES_PASSWORD}" \
-    "http://${KB_HOST}:5601/api/actions/connector_types" > /dev/null 2>&1; do
+until curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_HOST}:5601/api/status" \
+    | jq -e '
+        (.status.plugins.actions.level   // "") == "available" and
+        (.status.plugins.alerting.level  // "") == "available"
+      ' > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
-    echo "Kibana actions API did not become ready in time"
-    echo "Last response:"
-    curl -u "elastic:${ES_PASSWORD}" \
-        "http://${KB_HOST}:5601/api/actions/connector_types" 2>&1 || true
+    echo "Actions/alerting plugins did not reach 'available' in time"
+    echo "Last plugin statuses:"
+    curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_HOST}:5601/api/status" \
+      | jq '.status.plugins | with_entries(select(.value.level != "available"))' 2>&1 || true
     exit 1
   fi
   if [ $((RETRIES % 10)) -eq 0 ]; then
-    echo "  still waiting for actions API... (${RETRIES}/${MAX_RETRIES})"
+    echo "  still waiting... (${RETRIES}/${MAX_RETRIES})"
   fi
   sleep 2
 done

--- a/.buildkite/run-kb-tests-runner.sh
+++ b/.buildkite/run-kb-tests-runner.sh
@@ -112,20 +112,12 @@ until curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_HOST}:5601/api/status" \
 done
 echo "Kibana core is ready"
 
-# The actions and alerting plugins initialise after the main health check passes.
-echo "--- Waiting for alerting and actions plugins to be ready"
-RETRIES=0
-MAX_RETRIES=30
-until curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_HOST}:5601/api/actions/connector_types" > /dev/null 2>&1 && \
-      curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_HOST}:5601/api/alerting/rules/_find" > /dev/null 2>&1; do
-  RETRIES=$((RETRIES + 1))
-  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
-    echo "Alerting/actions plugins did not become ready in time"
-    exit 1
-  fi
-  sleep 3
-done
-echo "Kibana plugins are ready"
+# Give essential plugins (alerting, actions) a moment to finish initialising
+# after the overall status flips to "available". Fleet may be retrying in the
+# background (it needs an encrypted API key for agent binary source) but that
+# does not block the plugins we actually test.
+sleep 15
+echo "Kibana is ready"
 
 echo "--- Generating CLI config file"
 cat > /tmp/elastic-rc.yml <<EOF

--- a/.buildkite/run-kb-tests-runner.sh
+++ b/.buildkite/run-kb-tests-runner.sh
@@ -112,11 +112,29 @@ until curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_HOST}:5601/api/status" \
 done
 echo "Kibana core is ready"
 
-# Give essential plugins (alerting, actions) a moment to finish initialising
-# after the overall status flips to "available". Fleet may be retrying in the
-# background (it needs an encrypted API key for agent binary source) but that
-# does not block the plugins we actually test.
-sleep 15
+# Poll the actions API directly — it requires the license to be loaded from ES.
+# Kibana's actions plugin returns 403 with "license information is not available"
+# until its licensing subscription fires (usually a few seconds after "available",
+# but can be longer on cold starts).  Polling the real endpoint is more reliable
+# than a fixed sleep.
+echo "--- Waiting for Kibana actions API (license must be loaded)"
+RETRIES=0
+MAX_RETRIES=60
+until curl -sf -u "elastic:${ES_PASSWORD}" \
+    "http://${KB_HOST}:5601/api/actions/connector_types" > /dev/null 2>&1; do
+  RETRIES=$((RETRIES + 1))
+  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+    echo "Kibana actions API did not become ready in time"
+    echo "Last response:"
+    curl -u "elastic:${ES_PASSWORD}" \
+        "http://${KB_HOST}:5601/api/actions/connector_types" 2>&1 || true
+    exit 1
+  fi
+  if [ $((RETRIES % 10)) -eq 0 ]; then
+    echo "  still waiting for actions API... (${RETRIES}/${MAX_RETRIES})"
+  fi
+  sleep 2
+done
 echo "Kibana is ready"
 
 echo "--- Generating CLI config file"

--- a/.buildkite/run-kb-tests-runner.sh
+++ b/.buildkite/run-kb-tests-runner.sh
@@ -14,48 +14,20 @@ ES_PASSWORD="${ES_PASSWORD:-changeme}"
 echo "--- Installing curl and jq"
 apt-get update -qq && apt-get install -y -q --no-install-recommends curl jq
 
-# ── Network diagnostics ──────────────────────────────────────────────────────
-echo "--- Network diagnostics"
-echo "resolv.conf:"
-cat /etc/resolv.conf || true
-echo "Routes:"
-ip route 2>/dev/null || true
-
-# Determine whether to use DNS names or IPs.
+# Prefer Docker DNS aliases; fall back to container IPs if DNS is unavailable.
 ES_HOST="elasticsearch"
 KB_HOST="kibana"
 
-if getent hosts elasticsearch > /dev/null 2>&1; then
-  RESOLVED=$(getent hosts elasticsearch | awk '{print $1}')
-  echo "DNS OK: elasticsearch -> $RESOLVED"
-else
-  echo "DNS lookup for 'elasticsearch' failed"
-  if [[ -n "${ES_IP:-}" ]]; then
-    echo "Falling back to ES_IP=${ES_IP}"
-    ES_HOST="$ES_IP"
-  else
-    echo "No ES_IP provided and DNS failed — health checks will fail"
-  fi
+if ! getent hosts elasticsearch > /dev/null 2>&1; then
+  echo "DNS for 'elasticsearch' unavailable; falling back to ES_IP=${ES_IP:-<unset>}"
+  ES_HOST="${ES_IP:-elasticsearch}"
+fi
+if ! getent hosts kibana > /dev/null 2>&1; then
+  echo "DNS for 'kibana' unavailable; falling back to KB_IP=${KB_IP:-<unset>}"
+  KB_HOST="${KB_IP:-kibana}"
 fi
 
-if getent hosts kibana > /dev/null 2>&1; then
-  RESOLVED=$(getent hosts kibana | awk '{print $1}')
-  echo "DNS OK: kibana -> $RESOLVED"
-else
-  echo "DNS lookup for 'kibana' failed"
-  if [[ -n "${KB_IP:-}" ]]; then
-    echo "Falling back to KB_IP=${KB_IP}"
-    KB_HOST="$KB_IP"
-  else
-    echo "No KB_IP provided and DNS failed — health checks will fail"
-  fi
-fi
-
-echo "Using ES_HOST=${ES_HOST}, KB_HOST=${KB_HOST}"
-
-# First connection attempt with full output for debugging.
-echo "First curl attempt (verbose):"
-curl -v -u "elastic:${ES_PASSWORD}" "http://${ES_HOST}:9200/_cluster/health" 2>&1 || true
+echo "ES_HOST=${ES_HOST}  KB_HOST=${KB_HOST}"
 
 # ── Wait for Elasticsearch ───────────────────────────────────────────────────
 echo "--- Waiting for Elasticsearch to be healthy"
@@ -64,9 +36,8 @@ MAX_RETRIES=180
 until curl -sf -u "elastic:${ES_PASSWORD}" "http://${ES_HOST}:9200/_cluster/health" > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
-    echo "Elasticsearch did not become healthy in time after $((MAX_RETRIES * 2))s"
-    echo "Last curl attempt:"
-    curl -v -u "elastic:${ES_PASSWORD}" "http://${ES_HOST}:9200/_cluster/health" 2>&1 || true
+    echo "Elasticsearch did not become healthy after $((MAX_RETRIES * 2))s"
+    curl -s -u "elastic:${ES_PASSWORD}" "http://${ES_HOST}:9200/_cluster/health" 2>&1 || true
     exit 1
   fi
   if [ $((RETRIES % 15)) -eq 0 ]; then
@@ -112,13 +83,10 @@ until curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_HOST}:5601/api/status" \
 done
 echo "Kibana core is ready"
 
-# Wait for the actions and alerting plugins to be individually "available" by
-# polling /api/status.  That endpoint always returns HTTP 200, so it never
-# causes the 500 Server Error noise in Kibana logs that polling the actions
-# endpoint directly does (the actions HTTP context isn't wired until slightly
-# after overall "available", returning 500 during that window).
-# Fleet being degraded shows up only in plugins.fleet — it does not affect
-# plugins.actions or plugins.alerting.
+# Poll /api/status for plugin-level readiness rather than calling the actions
+# endpoint directly (the actions HTTP context returns 500 briefly after
+# Kibana's overall "available", and Fleet degradation is isolated to
+# plugins.fleet and does not affect plugins.actions or plugins.alerting).
 echo "--- Waiting for actions + alerting plugins to be available"
 RETRIES=0
 MAX_RETRIES=60

--- a/.buildkite/run-kb-tests-runner.sh
+++ b/.buildkite/run-kb-tests-runner.sh
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Runs INSIDE the test-runner container on the same Docker network as ES/Kibana.
-# Uses Docker DNS aliases (elasticsearch:9200, kibana:5601) for all connectivity,
-# which is the only networking that works reliably on kibana-ubuntu-2404 agents.
+# Prefers Docker DNS aliases (elasticsearch / kibana) but falls back to the
+# container IPs passed via ES_IP / KB_IP if the embedded DNS server is
+# unavailable (known issue with some rootless/userns Docker configurations).
 
 set -euo pipefail
 
@@ -13,13 +14,59 @@ ES_PASSWORD="${ES_PASSWORD:-changeme}"
 echo "--- Installing curl and jq"
 apt-get update -qq && apt-get install -y -q --no-install-recommends curl jq
 
+# ── Network diagnostics ──────────────────────────────────────────────────────
+echo "--- Network diagnostics"
+echo "resolv.conf:"
+cat /etc/resolv.conf || true
+echo "Routes:"
+ip route 2>/dev/null || true
+
+# Determine whether to use DNS names or IPs.
+ES_HOST="elasticsearch"
+KB_HOST="kibana"
+
+if getent hosts elasticsearch > /dev/null 2>&1; then
+  RESOLVED=$(getent hosts elasticsearch | awk '{print $1}')
+  echo "DNS OK: elasticsearch -> $RESOLVED"
+else
+  echo "DNS lookup for 'elasticsearch' failed"
+  if [[ -n "${ES_IP:-}" ]]; then
+    echo "Falling back to ES_IP=${ES_IP}"
+    ES_HOST="$ES_IP"
+  else
+    echo "No ES_IP provided and DNS failed — health checks will fail"
+  fi
+fi
+
+if getent hosts kibana > /dev/null 2>&1; then
+  RESOLVED=$(getent hosts kibana | awk '{print $1}')
+  echo "DNS OK: kibana -> $RESOLVED"
+else
+  echo "DNS lookup for 'kibana' failed"
+  if [[ -n "${KB_IP:-}" ]]; then
+    echo "Falling back to KB_IP=${KB_IP}"
+    KB_HOST="$KB_IP"
+  else
+    echo "No KB_IP provided and DNS failed — health checks will fail"
+  fi
+fi
+
+echo "Using ES_HOST=${ES_HOST}, KB_HOST=${KB_HOST}"
+
+# First connection attempt with full output for debugging.
+echo "First curl attempt (verbose):"
+curl -v -u "elastic:${ES_PASSWORD}" "http://${ES_HOST}:9200/_cluster/health" 2>&1 || true
+
+# ── Wait for Elasticsearch ───────────────────────────────────────────────────
 echo "--- Waiting for Elasticsearch to be healthy"
 RETRIES=0
 MAX_RETRIES=180
-until curl -sf -u "elastic:${ES_PASSWORD}" "http://elasticsearch:9200/_cluster/health" > /dev/null 2>&1; do
+until curl -sf -u "elastic:${ES_PASSWORD}" "http://${ES_HOST}:9200/_cluster/health" > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
     echo "Elasticsearch did not become healthy in time after $((MAX_RETRIES * 2))s"
+    echo "Last curl attempt:"
+    curl -v -u "elastic:${ES_PASSWORD}" "http://${ES_HOST}:9200/_cluster/health" 2>&1 || true
     exit 1
   fi
   if [ $((RETRIES % 15)) -eq 0 ]; then
@@ -37,7 +84,7 @@ echo "--- Waiting for Elasticsearch security index to be ready"
 RETRIES=0
 MAX_RETRIES=60
 until curl -sf -u "elastic:${ES_PASSWORD}" \
-    -X POST "http://elasticsearch:9200/_security/api_key" \
+    -X POST "http://${ES_HOST}:9200/_security/api_key" \
     -H "Content-Type: application/json" \
     -d '{"name":"healthcheck","expiration":"1m"}' > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
@@ -52,11 +99,13 @@ echo "Elasticsearch is ready"
 echo "--- Waiting for Kibana to be healthy"
 RETRIES=0
 MAX_RETRIES=90
-until curl -sf -u "elastic:${ES_PASSWORD}" "http://kibana:5601/api/status" \
+until curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_HOST}:5601/api/status" \
       | jq -e '.status.overall.level == "available"' > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
     echo "Kibana did not become healthy in time"
+    echo "Last Kibana status:"
+    curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_HOST}:5601/api/status" 2>&1 || true
     exit 1
   fi
   sleep 3
@@ -67,8 +116,8 @@ echo "Kibana core is ready"
 echo "--- Waiting for alerting and actions plugins to be ready"
 RETRIES=0
 MAX_RETRIES=30
-until curl -sf -u "elastic:${ES_PASSWORD}" "http://kibana:5601/api/actions/connector_types" > /dev/null 2>&1 && \
-      curl -sf -u "elastic:${ES_PASSWORD}" "http://kibana:5601/api/alerting/rules/_find" > /dev/null 2>&1; do
+until curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_HOST}:5601/api/actions/connector_types" > /dev/null 2>&1 && \
+      curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_HOST}:5601/api/alerting/rules/_find" > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
     echo "Alerting/actions plugins did not become ready in time"
@@ -83,12 +132,12 @@ cat > /tmp/elastic-rc.yml <<EOF
 contexts:
   ci:
     elasticsearch:
-      url: http://elasticsearch:9200
+      url: http://${ES_HOST}:9200
       auth:
         username: elastic
         password: "${ES_PASSWORD}"
     kibana:
-      url: http://kibana:5601
+      url: http://${KB_HOST}:5601
       auth:
         username: elastic
         password: "${ES_PASSWORD}"

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -3,22 +3,33 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Buildkite entry point for Kibana functional tests.
-# Starts Elasticsearch and Kibana using --network host so both services are
-# reachable at localhost:9200 and localhost:5601 from the host — no Docker
-# port publishing or bridge routing needed. This mirrors how Kibana's own CI
-# runs ES natively (via node scripts/es snapshot) and avoids iptables/nftables
-# issues present on Ubuntu 24.04 agents.
+#
+# On kibana-ubuntu-2404 agents, host→container networking is restricted:
+#   - --network host  → blocked (user namespace remapping is enabled)
+#   - --publish ports → broken (nftables replaces iptables, Docker NAT doesn't work)
+#   - direct bridge IP → not routed to host
+#
+# Solution: mirror Kibana's approach of running ES natively by putting all
+# connectivity inside Docker. Health checks and tests run in a dedicated
+# test-runner container on the same network as ES and Kibana, using Docker
+# DNS aliases (elasticsearch:9200, kibana:5601) which always work for
+# inter-container communication.
 
 set -euo pipefail
 
 STACK_VERSION="${STACK_VERSION:-9.3.0}"
 ES_CONTAINER_NAME="elastic-cli-kb-es"
 KB_CONTAINER_NAME="elastic-cli-kb"
+TEST_RUNNER_NAME="elastic-cli-kb-runner"
+NETWORK_NAME="elastic-cli-kb-net"
+NODE_RUNNER_IMAGE="node:${NODE_VERSION}-bookworm-slim"
 
 cleanup() {
   echo "--- Cleaning up"
+  docker rm -f "$TEST_RUNNER_NAME" 2>/dev/null || true
   docker rm -f "$KB_CONTAINER_NAME" 2>/dev/null || true
   docker rm -f "$ES_CONTAINER_NAME" 2>/dev/null || true
+  docker network rm "$NETWORK_NAME" 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -30,15 +41,10 @@ ES_IMAGE="docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}"
 KB_IMAGE="docker.elastic.co/kibana/kibana:${STACK_VERSION}"
 
 # ── Docker setup ────────────────────────────────────────────────────────────
-# Start containers as early as possible so ES and Kibana boot in the background
-# while npm install + build run.
-#
-# Both containers use --network host so they bind directly to the host's network
-# stack. This means:
-#   - ES is reachable at localhost:9200 from the host and from Kibana
-#   - Kibana is reachable at localhost:5601 from the host
-#   - No iptables/nftables port forwarding rules are needed
-# This is functionally equivalent to Kibana's approach of running ES natively.
+# Start all containers as early as possible so they boot while the CLI builds.
+
+echo "--- Creating Docker network"
+docker network create "$NETWORK_NAME" 2>/dev/null || true
 
 # Use the pre-cached ES snapshot on kibana-ubuntu-2404 agents if available,
 # otherwise fall back to a registry pull.
@@ -54,10 +60,17 @@ fi
 echo "--- Loading Kibana image"
 docker pull "$KB_IMAGE"
 
+# Pull the test-runner image in the background while ES/Kibana boot and the
+# CLI builds — it's only needed at the very end.
+echo "--- Pulling test-runner image (background)"
+docker pull "$NODE_RUNNER_IMAGE" &
+NODE_PULL_PID=$!
+
 echo "--- Starting Elasticsearch ${STACK_VERSION} (background)"
 docker run \
   --name "$ES_CONTAINER_NAME" \
-  --network host \
+  --network "$NETWORK_NAME" \
+  --network-alias elasticsearch \
   --env "discovery.type=single-node" \
   --env "xpack.license.self_generated.type=trial" \
   --env "action.destructive_requires_name=false" \
@@ -67,12 +80,12 @@ docker run \
   --rm \
   "$ES_IMAGE"
 
-# Kibana connects to ES at localhost:9200 since both share the host network.
 echo "--- Starting Kibana ${STACK_VERSION} (background)"
 docker run \
   --name "$KB_CONTAINER_NAME" \
-  --network host \
-  --env "ELASTICSEARCH_HOSTS=http://localhost:9200" \
+  --network "$NETWORK_NAME" \
+  --network-alias kibana \
+  --env "ELASTICSEARCH_HOSTS=http://elasticsearch:9200" \
   --env "ELASTICSEARCH_USERNAME=elastic" \
   --env "ELASTICSEARCH_PASSWORD=${ES_PASSWORD}" \
   --env "xpack.encryptedSavedObjects.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
@@ -82,7 +95,7 @@ docker run \
   --rm \
   "$KB_IMAGE"
 
-# ── Build CLI (runs concurrently with ES + Kibana startup) ──────────────────
+# ── Build CLI (concurrent with container startup + test-runner image pull) ──
 
 echo "--- Setting up Node.js ${NODE_VERSION}"
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
@@ -115,99 +128,21 @@ export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=6144"
 
 echo "--- Building CLI"
 npm run build
-npm link
 
-# ── Wait for services (should be near-instant after the build) ──────────────
+echo "--- Waiting for test-runner image pull to finish"
+wait "$NODE_PULL_PID"
 
-echo "--- Waiting for Elasticsearch to be healthy"
-RETRIES=0
-MAX_RETRIES=180
-until curl -sf -u "elastic:${ES_PASSWORD}" "http://localhost:9200/_cluster/health" > /dev/null 2>&1; do
-  RETRIES=$((RETRIES + 1))
-  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
-    echo "Elasticsearch did not become healthy in time after $((MAX_RETRIES * 2))s"
-    docker logs "$ES_CONTAINER_NAME"
-    exit 1
-  fi
-  if [ $((RETRIES % 15)) -eq 0 ]; then
-    echo "  still waiting for Elasticsearch... (${RETRIES}/${MAX_RETRIES})"
-  fi
-  sleep 2
-done
-echo "Elasticsearch cluster is up"
+# ── Run health checks and tests inside the Docker network ───────────────────
+# The test-runner container has access to ES and Kibana via Docker DNS aliases.
+# The workspace (including the built CLI at dist/cli.js) is mounted read-only.
 
-# The cluster can report healthy before the .security index is fully bootstrapped.
-# Kibana's alerting/connectors plugins depend on ES API keys (encryptedSavedObjects),
-# so we must confirm the security index is ready.
-# Technique borrowed from Kibana's own kbn-es tooling (wait_for_security_index.ts).
-echo "--- Waiting for Elasticsearch security index to be ready"
-RETRIES=0
-MAX_RETRIES=60
-until curl -sf -u "elastic:${ES_PASSWORD}" \
-    -X POST "http://localhost:9200/_security/api_key" \
-    -H "Content-Type: application/json" \
-    -d '{"name":"healthcheck","expiration":"1m"}' > /dev/null 2>&1; do
-  RETRIES=$((RETRIES + 1))
-  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
-    echo "Elasticsearch security index did not become ready in time"
-    docker logs "$ES_CONTAINER_NAME"
-    exit 1
-  fi
-  sleep 2
-done
-echo "Elasticsearch is ready"
-
-echo "--- Waiting for Kibana to be healthy"
-RETRIES=0
-MAX_RETRIES=90
-until curl -sf -u "elastic:${ES_PASSWORD}" "http://localhost:5601/api/status" \
-      | jq -e '.status.overall.level == "available"' > /dev/null 2>&1; do
-  RETRIES=$((RETRIES + 1))
-  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
-    echo "Kibana did not become healthy in time"
-    docker logs "$KB_CONTAINER_NAME"
-    exit 1
-  fi
-  sleep 3
-done
-echo "Kibana core is ready"
-
-# The actions and alerting plugins initialise after the main health check passes.
-echo "--- Waiting for alerting and actions plugins to be ready"
-RETRIES=0
-MAX_RETRIES=30
-until curl -sf -u "elastic:${ES_PASSWORD}" "http://localhost:5601/api/actions/connector_types" > /dev/null 2>&1 && \
-      curl -sf -u "elastic:${ES_PASSWORD}" "http://localhost:5601/api/alerting/rules/_find" > /dev/null 2>&1; do
-  RETRIES=$((RETRIES + 1))
-  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
-    echo "Alerting/actions plugins did not become ready in time"
-    docker logs "$KB_CONTAINER_NAME" --tail 50
-    exit 1
-  fi
-  sleep 3
-done
-echo "Kibana plugins are ready"
-
-# ── Run tests ────────────────────────────────────────────────────────────────
-
-echo "--- Generating CI config file"
-CI_CONFIG_FILE="$(pwd)/.elasticrc-kb-ci.yml"
-cat > "$CI_CONFIG_FILE" <<EOF
-contexts:
-  ci:
-    elasticsearch:
-      url: http://localhost:9200
-      auth:
-        username: elastic
-        password: "${ES_PASSWORD}"
-    kibana:
-      url: http://localhost:5601
-      auth:
-        username: elastic
-        password: "${ES_PASSWORD}"
-current_context: ci
-EOF
-export ELASTIC_CLI_CONFIG_FILE="$CI_CONFIG_FILE"
-
-echo "+++ Running KB functional tests"
-npm run test:functional:kb
+echo "--- Running tests inside Docker network"
+docker run \
+  --name "$TEST_RUNNER_NAME" \
+  --network "$NETWORK_NAME" \
+  --rm \
+  --volume "$(pwd):/workspace" \
+  --workdir /workspace \
+  --env "ES_PASSWORD=${ES_PASSWORD}" \
+  "$NODE_RUNNER_IMAGE" \
+  bash /workspace/.buildkite/run-kb-tests-runner.sh

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -30,8 +30,11 @@ KB_IMAGE="docker.elastic.co/kibana/kibana:${STACK_VERSION}"
 
 # ── Docker setup ────────────────────────────────────────────────────────────
 # Start containers as early as possible so ES and Kibana boot in the background
-# while npm install + build run (~15-20 min). On slow CI agents ES overlay2
-# setup + security bootstrap alone can take 7-10 min, so the head start is critical.
+# while npm install + build run.
+#
+# Note: we do NOT use --publish to expose ports on the host. Ubuntu 24.04 agents
+# use nftables, which can break Docker port publishing. Instead we connect directly
+# to the container IPs on the bridge network, which always works on Linux hosts.
 
 echo "--- Creating Docker network"
 docker network create "$NETWORK_NAME" 2>/dev/null || true
@@ -55,7 +58,6 @@ docker run \
   --name "$ES_CONTAINER_NAME" \
   --network "$NETWORK_NAME" \
   --network-alias elasticsearch \
-  --publish 9200:9200 \
   --env "discovery.type=single-node" \
   --env "xpack.license.self_generated.type=trial" \
   --env "action.destructive_requires_name=false" \
@@ -71,7 +73,6 @@ echo "--- Starting Kibana ${STACK_VERSION} (background)"
 docker run \
   --name "$KB_CONTAINER_NAME" \
   --network "$NETWORK_NAME" \
-  --publish 5601:5601 \
   --env "ELASTICSEARCH_HOSTS=http://elasticsearch:9200" \
   --env "ELASTICSEARCH_USERNAME=elastic" \
   --env "ELASTICSEARCH_PASSWORD=${ES_PASSWORD}" \
@@ -81,6 +82,14 @@ docker run \
   --detach \
   --rm \
   "$KB_IMAGE"
+
+# Resolve container IPs on the Docker bridge network.
+# We use these directly instead of published ports to avoid iptables/nftables issues
+# on Ubuntu 24.04 agents. On Linux the host can always reach bridge network IPs.
+ES_IP=$(docker inspect --format='{{(index .NetworkSettings.Networks "'"$NETWORK_NAME"'").IPAddress}}' "$ES_CONTAINER_NAME")
+KB_IP=$(docker inspect --format='{{(index .NetworkSettings.Networks "'"$NETWORK_NAME"'").IPAddress}}' "$KB_CONTAINER_NAME")
+echo "Elasticsearch IP: ${ES_IP}"
+echo "Kibana IP: ${KB_IP}"
 
 # ── Build CLI (runs concurrently with ES + Kibana startup) ──────────────────
 
@@ -117,12 +126,12 @@ echo "--- Building CLI"
 npm run build
 npm link
 
-# ── Wait for services (should be near-instant after the ~15 min build) ──────
+# ── Wait for services (should be near-instant after the build) ──────────────
 
 echo "--- Waiting for Elasticsearch to be healthy"
 RETRIES=0
 MAX_RETRIES=180
-until curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:9200/_cluster/health > /dev/null 2>&1; do
+until curl -sf -u "elastic:${ES_PASSWORD}" "http://${ES_IP}:9200/_cluster/health" > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
     echo "Elasticsearch did not become healthy in time after $((MAX_RETRIES * 2))s"
@@ -144,7 +153,7 @@ echo "--- Waiting for Elasticsearch security index to be ready"
 RETRIES=0
 MAX_RETRIES=60
 until curl -sf -u "elastic:${ES_PASSWORD}" \
-    -X POST "http://localhost:9200/_security/api_key" \
+    -X POST "http://${ES_IP}:9200/_security/api_key" \
     -H "Content-Type: application/json" \
     -d '{"name":"healthcheck","expiration":"1m"}' > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
@@ -160,7 +169,7 @@ echo "Elasticsearch is ready"
 echo "--- Waiting for Kibana to be healthy"
 RETRIES=0
 MAX_RETRIES=90
-until curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:5601/api/status \
+until curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_IP}:5601/api/status" \
       | jq -e '.status.overall.level == "available"' > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
@@ -176,8 +185,8 @@ echo "Kibana core is ready"
 echo "--- Waiting for alerting and actions plugins to be ready"
 RETRIES=0
 MAX_RETRIES=30
-until curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:5601/api/actions/connector_types > /dev/null 2>&1 && \
-      curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:5601/api/alerting/rules/_find > /dev/null 2>&1; do
+until curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_IP}:5601/api/actions/connector_types" > /dev/null 2>&1 && \
+      curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_IP}:5601/api/alerting/rules/_find" > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
     echo "Alerting/actions plugins did not become ready in time"
@@ -196,12 +205,12 @@ cat > "$CI_CONFIG_FILE" <<EOF
 contexts:
   ci:
     elasticsearch:
-      url: http://localhost:9200
+      url: http://${ES_IP}:9200
       auth:
         username: elastic
         password: "${ES_PASSWORD}"
     kibana:
-      url: http://localhost:5601
+      url: http://${KB_IP}:5601
       auth:
         username: elastic
         password: "${ES_PASSWORD}"

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Buildkite entry point for Kibana functional tests.
+# Starts an Elasticsearch container, then a Kibana container that connects to it,
+# generates a CLI config pointing at both, and runs the hand-authored KB test suite.
+
+set -euo pipefail
+
+STACK_VERSION="${STACK_VERSION:-9.3.0}"
+ES_CONTAINER_NAME="elastic-cli-kb-es"
+KB_CONTAINER_NAME="elastic-cli-kb"
+NETWORK_NAME="elastic-cli-kb-net"
+
+cleanup() {
+  echo "--- Cleaning up"
+  docker rm -f "$KB_CONTAINER_NAME" 2>/dev/null || true
+  docker rm -f "$ES_CONTAINER_NAME" 2>/dev/null || true
+  docker network rm "$NETWORK_NAME" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "--- Setting up Node.js ${NODE_VERSION}"
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ ! -s "$NVM_DIR/nvm.sh" ]; then
+  echo "nvm not found, installing..."
+  mkdir -p "$NVM_DIR"
+  NVM_VERSION=$(curl -s https://api.github.com/repos/nvm-sh/nvm/releases/latest | jq -r '.tag_name // "v0.39.7"')
+  echo "Installing nvm ${NVM_VERSION}"
+  curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_VERSION}/install.sh" | bash
+fi
+# shellcheck source=/dev/null
+. "$NVM_DIR/nvm.sh"
+nvm install "$NODE_VERSION"
+nvm use "$NODE_VERSION"
+
+echo "--- Installing jq 1.7.1"
+JQ_VERSION="1.7.1"
+if ! jq --version 2>/dev/null | grep -q "$JQ_VERSION"; then
+  mkdir -p "$HOME/.local/bin"
+  curl -sfL "https://github.com/jqlang/jq/releases/download/jq-${JQ_VERSION}/jq-linux-amd64" -o "$HOME/.local/bin/jq"
+  chmod +x "$HOME/.local/bin/jq"
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+echo "Using jq $(jq --version)"
+
+echo "--- Installing dependencies"
+npm ci
+
+export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=6144"
+
+echo "--- Building CLI"
+npm run build
+npm link
+
+echo "--- Creating Docker network"
+docker network create "$NETWORK_NAME" 2>/dev/null || true
+
+echo "--- Starting Elasticsearch ${STACK_VERSION}"
+docker run \
+  --name "$ES_CONTAINER_NAME" \
+  --network "$NETWORK_NAME" \
+  --network-alias elasticsearch \
+  --env "discovery.type=single-node" \
+  --env "xpack.security.enabled=false" \
+  --env "xpack.license.self_generated.type=trial" \
+  --env "action.destructive_requires_name=false" \
+  --env "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
+  --detach \
+  --rm \
+  "docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}"
+
+echo "--- Waiting for Elasticsearch to be healthy"
+RETRIES=0
+MAX_RETRIES=60
+until docker exec "$ES_CONTAINER_NAME" curl -sf http://localhost:9200/_cluster/health > /dev/null 2>&1; do
+  RETRIES=$((RETRIES + 1))
+  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+    echo "Elasticsearch did not become healthy in time"
+    docker logs "$ES_CONTAINER_NAME"
+    exit 1
+  fi
+  sleep 2
+done
+echo "Elasticsearch is ready"
+
+echo "--- Starting Kibana ${STACK_VERSION}"
+docker run \
+  --name "$KB_CONTAINER_NAME" \
+  --network "$NETWORK_NAME" \
+  --publish 5601:5601 \
+  --env "ELASTICSEARCH_HOSTS=http://elasticsearch:9200" \
+  --env "xpack.security.enabled=false" \
+  --env "xpack.encryptedSavedObjects.encryptionKey=aaaabbbbccccddddeeeeffffgggghhhh" \
+  --env "xpack.reporting.encryptionKey=aaaabbbbccccddddeeeeffffgggghhhh" \
+  --env "xpack.security.encryptionKey=aaaabbbbccccddddeeeeffffgggghhhh" \
+  --detach \
+  --rm \
+  "docker.elastic.co/kibana/kibana:${STACK_VERSION}"
+
+echo "--- Waiting for Kibana to be healthy"
+RETRIES=0
+MAX_RETRIES=90
+until curl -sf http://localhost:5601/api/status | jq -e '.status.overall.level == "available"' > /dev/null 2>&1; do
+  RETRIES=$((RETRIES + 1))
+  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+    echo "Kibana did not become healthy in time"
+    docker logs "$KB_CONTAINER_NAME"
+    exit 1
+  fi
+  sleep 3
+done
+echo "Kibana is ready"
+
+echo "--- Generating CI config file"
+CI_CONFIG_FILE="$(pwd)/.elasticrc-kb-ci.yml"
+cat > "$CI_CONFIG_FILE" <<EOF
+contexts:
+  ci:
+    elasticsearch:
+      url: http://localhost:9200
+    kibana:
+      url: http://localhost:5601
+current_context: ci
+EOF
+export ELASTIC_CLI_CONFIG_FILE="$CI_CONFIG_FILE"
+
+echo "+++ Running KB functional tests"
+npm run test:functional:kb

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -9,11 +9,10 @@
 #   - --publish ports → broken (nftables replaces iptables, Docker NAT doesn't work)
 #   - direct bridge IP → not routed to host
 #
-# Solution: mirror Kibana's approach of running ES natively by putting all
-# connectivity inside Docker. Health checks and tests run in a dedicated
-# test-runner container on the same network as ES and Kibana, using Docker
-# DNS aliases (elasticsearch:9200, kibana:5601) which always work for
-# inter-container communication.
+# Solution: health checks and tests run in a dedicated test-runner container on
+# the same Docker bridge network as ES and Kibana. Container IPs are fetched via
+# docker inspect on the host and passed to the runner in case embedded DNS is
+# unavailable (known issue with some rootless/userns Docker configurations).
 
 set -euo pipefail
 
@@ -25,6 +24,10 @@ NETWORK_NAME="elastic-cli-kb-net"
 NODE_RUNNER_IMAGE="node:${NODE_VERSION}-bookworm-slim"
 
 cleanup() {
+  echo "--- ES logs (last 50 lines)"
+  docker logs "$ES_CONTAINER_NAME" 2>&1 | tail -50 || true
+  echo "--- Kibana logs (last 20 lines)"
+  docker logs "$KB_CONTAINER_NAME" 2>&1 | tail -20 || true
   echo "--- Cleaning up"
   docker rm -f "$TEST_RUNNER_NAME" 2>/dev/null || true
   docker rm -f "$KB_CONTAINER_NAME" 2>/dev/null || true
@@ -95,6 +98,15 @@ docker run \
   --rm \
   "$KB_IMAGE"
 
+# Fetch container IPs immediately after starting — Docker assigns them before
+# the main process runs. We pass these to the test runner as a fallback in case
+# the embedded DNS server (127.0.0.11) is unavailable on this agent.
+ES_IP=$(docker inspect "$ES_CONTAINER_NAME" \
+  --format="{{(index .NetworkSettings.Networks \"$NETWORK_NAME\").IPAddress}}")
+KB_IP=$(docker inspect "$KB_CONTAINER_NAME" \
+  --format="{{(index .NetworkSettings.Networks \"$NETWORK_NAME\").IPAddress}}")
+echo "Container IPs — ES: ${ES_IP}, Kibana: ${KB_IP}"
+
 # ── Build CLI (concurrent with container startup + test-runner image pull) ──
 
 echo "--- Setting up Node.js ${NODE_VERSION}"
@@ -124,7 +136,7 @@ echo "Using jq $(jq --version)"
 echo "--- Installing dependencies"
 npm ci
 
-export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=6144"
+export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=4096"
 
 echo "--- Building CLI"
 npm run build
@@ -133,8 +145,7 @@ echo "--- Waiting for test-runner image pull to finish"
 wait "$NODE_PULL_PID"
 
 # ── Run health checks and tests inside the Docker network ───────────────────
-# The test-runner container has access to ES and Kibana via Docker DNS aliases.
-# The workspace (including the built CLI at dist/cli.js) is mounted read-only.
+# The test-runner container uses ES_IP / KB_IP directly if DNS is unavailable.
 
 echo "--- Running tests inside Docker network"
 docker run \
@@ -144,5 +155,7 @@ docker run \
   --volume "$(pwd):/workspace" \
   --workdir /workspace \
   --env "ES_PASSWORD=${ES_PASSWORD}" \
+  --env "ES_IP=${ES_IP}" \
+  --env "KB_IP=${KB_IP}" \
   "$NODE_RUNNER_IMAGE" \
   bash /workspace/.buildkite/run-kb-tests-runner.sh

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -111,7 +111,24 @@ until curl -sf http://localhost:5601/api/status | jq -e '.status.overall.level =
   fi
   sleep 3
 done
-echo "Kibana is ready"
+echo "Kibana core is ready"
+
+# The actions and alerting plugins initialise after the main health check passes.
+# Wait until their APIs return 200 before running tests.
+echo "--- Waiting for alerting and actions plugins to be ready"
+RETRIES=0
+MAX_RETRIES=30
+until curl -sf http://localhost:5601/api/actions/connector_types > /dev/null 2>&1 && \
+      curl -sf "http://localhost:5601/api/alerting/rules/_find" > /dev/null 2>&1; do
+  RETRIES=$((RETRIES + 1))
+  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+    echo "Alerting/actions plugins did not become ready in time"
+    docker logs "$KB_CONTAINER_NAME" --tail 50
+    exit 1
+  fi
+  sleep 3
+done
+echo "Kibana plugins are ready"
 
 echo "--- Generating CI config file"
 CI_CONFIG_FILE="$(pwd)/.elasticrc-kb-ci.yml"

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -158,9 +158,9 @@ docker run \
   --env "ELASTICSEARCH_HOSTS=http://elasticsearch:9200" \
   --env "ELASTICSEARCH_USERNAME=kibana_system" \
   --env "ELASTICSEARCH_PASSWORD=${ES_PASSWORD}" \
-  --env "xpack.encryptedSavedObjects.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
-  --env "xpack.reporting.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
-  --env "xpack.security.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
+  --env "XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY=${KIBANA_ENCRYPTION_KEY}" \
+  --env "XPACK_REPORTING_ENCRYPTIONKEY=${KIBANA_ENCRYPTION_KEY}" \
+  --env "XPACK_SECURITY_ENCRYPTIONKEY=${KIBANA_ENCRYPTION_KEY}" \
   --detach \
   "$KB_IMAGE"
 

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -65,6 +65,7 @@ docker run \
   --name "$ES_CONTAINER_NAME" \
   --network "$NETWORK_NAME" \
   --network-alias elasticsearch \
+  --publish 9200:9200 \
   --env "discovery.type=single-node" \
   --env "xpack.license.self_generated.type=trial" \
   --env "action.destructive_requires_name=false" \
@@ -76,8 +77,9 @@ docker run \
 
 echo "--- Waiting for Elasticsearch to be healthy"
 RETRIES=0
-MAX_RETRIES=60
-until curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:9200/_cluster/health > /dev/null 2>&1; do
+MAX_RETRIES=90
+until docker exec "$ES_CONTAINER_NAME" \
+    curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:9200/_cluster/health > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
     echo "Elasticsearch did not become healthy in time"

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Buildkite entry point for Kibana functional tests.
-# Starts an Elasticsearch container, then a Kibana container that connects to it,
-# generates a CLI config pointing at both, and runs the hand-authored KB test suite.
+# Starts Elasticsearch and Kibana containers in the background, then builds the
+# CLI concurrently, and runs the hand-authored KB test suite once everything is ready.
 
 set -euo pipefail
 
@@ -25,14 +25,30 @@ trap cleanup EXIT
 ES_PASSWORD="changeme"
 KIBANA_ENCRYPTION_KEY="xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj" # gitleaks:allow
 
-# Pull images and start ES as early as possible so it can boot in the background
-# while npm install and the CLI build run (which together take ~15-20 minutes).
-# On slow CI agents, Docker container startup + ES security bootstrap alone can
-# take 7-10 minutes, so giving it a head start is critical.
-echo "--- Pulling Docker images"
+ES_IMAGE="docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}"
+KB_IMAGE="docker.elastic.co/kibana/kibana:${STACK_VERSION}"
+
+# ── Docker setup ────────────────────────────────────────────────────────────
+# Start containers as early as possible so ES and Kibana boot in the background
+# while npm install + build run (~15-20 min). On slow CI agents ES overlay2
+# setup + security bootstrap alone can take 7-10 min, so the head start is critical.
+
+echo "--- Creating Docker network"
 docker network create "$NETWORK_NAME" 2>/dev/null || true
-docker pull "docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}"
-docker pull "docker.elastic.co/kibana/kibana:${STACK_VERSION}"
+
+# Use the pre-cached ES snapshot on kibana-ubuntu-2404 agents if available,
+# otherwise fall back to a registry pull (same technique as Kibana's kbn-es tooling).
+echo "--- Loading Elasticsearch image"
+ES_CACHE_DIR="${ES_CACHE_DIR:-}"
+if [[ -n "$ES_CACHE_DIR" ]] && compgen -G "$ES_CACHE_DIR/elasticsearch-$STACK_VERSION*.tar.gz" > /dev/null 2>&1; then
+  echo "  Loading from agent cache: $ES_CACHE_DIR"
+  docker load < "$(ls "$ES_CACHE_DIR/elasticsearch-$STACK_VERSION"*.tar.gz | head -1)"
+else
+  docker pull "$ES_IMAGE"
+fi
+
+echo "--- Loading Kibana image"
+docker pull "$KB_IMAGE"
 
 echo "--- Starting Elasticsearch ${STACK_VERSION} (background)"
 docker run \
@@ -47,7 +63,26 @@ docker run \
   --env "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
   --detach \
   --rm \
-  "docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}"
+  "$ES_IMAGE"
+
+# Start Kibana immediately alongside ES — Kibana will retry the ES connection
+# until ES is ready, so the order doesn't matter for correctness.
+echo "--- Starting Kibana ${STACK_VERSION} (background)"
+docker run \
+  --name "$KB_CONTAINER_NAME" \
+  --network "$NETWORK_NAME" \
+  --publish 5601:5601 \
+  --env "ELASTICSEARCH_HOSTS=http://elasticsearch:9200" \
+  --env "ELASTICSEARCH_USERNAME=elastic" \
+  --env "ELASTICSEARCH_PASSWORD=${ES_PASSWORD}" \
+  --env "xpack.encryptedSavedObjects.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
+  --env "xpack.reporting.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
+  --env "xpack.security.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
+  --detach \
+  --rm \
+  "$KB_IMAGE"
+
+# ── Build CLI (runs concurrently with ES + Kibana startup) ──────────────────
 
 echo "--- Setting up Node.js ${NODE_VERSION}"
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
@@ -82,8 +117,8 @@ echo "--- Building CLI"
 npm run build
 npm link
 
-# ES has been running in the background during the entire npm install + build phase.
-# It should be healthy (or close to it) by now.
+# ── Wait for services (should be near-instant after the ~15 min build) ──────
+
 echo "--- Waiting for Elasticsearch to be healthy"
 RETRIES=0
 MAX_RETRIES=180
@@ -103,7 +138,7 @@ echo "Elasticsearch cluster is up"
 
 # The cluster can report healthy before the .security index is fully bootstrapped.
 # Kibana's alerting/connectors plugins depend on ES API keys (encryptedSavedObjects),
-# so we must wait for the security index to be ready before starting Kibana.
+# so we must confirm the security index is ready.
 # Technique borrowed from Kibana's own kbn-es tooling (wait_for_security_index.ts).
 echo "--- Waiting for Elasticsearch security index to be ready"
 RETRIES=0
@@ -122,21 +157,6 @@ until curl -sf -u "elastic:${ES_PASSWORD}" \
 done
 echo "Elasticsearch is ready"
 
-echo "--- Starting Kibana ${STACK_VERSION}"
-docker run \
-  --name "$KB_CONTAINER_NAME" \
-  --network "$NETWORK_NAME" \
-  --publish 5601:5601 \
-  --env "ELASTICSEARCH_HOSTS=http://elasticsearch:9200" \
-  --env "ELASTICSEARCH_USERNAME=elastic" \
-  --env "ELASTICSEARCH_PASSWORD=${ES_PASSWORD}" \
-  --env "xpack.encryptedSavedObjects.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
-  --env "xpack.reporting.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
-  --env "xpack.security.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
-  --detach \
-  --rm \
-  "docker.elastic.co/kibana/kibana:${STACK_VERSION}"
-
 echo "--- Waiting for Kibana to be healthy"
 RETRIES=0
 MAX_RETRIES=90
@@ -153,7 +173,6 @@ done
 echo "Kibana core is ready"
 
 # The actions and alerting plugins initialise after the main health check passes.
-# Wait until their APIs return 200 before running tests.
 echo "--- Waiting for alerting and actions plugins to be ready"
 RETRIES=0
 MAX_RETRIES=30
@@ -168,6 +187,8 @@ until curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:5601/api/actions/con
   sleep 3
 done
 echo "Kibana plugins are ready"
+
+# ── Run tests ────────────────────────────────────────────────────────────────
 
 echo "--- Generating CI config file"
 CI_CONFIG_FILE="$(pwd)/.elasticrc-kb-ci.yml"

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -126,7 +126,25 @@ export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=4096"
 echo "--- Building CLI"
 npm run build
 
-# ── Start Kibana (after build, so ES has had ~3 min to fully boot) ───────────
+# ── Configure kibana_system user (after build, ES has had ~3 min to boot) ───
+# Kibana 9.x forbids using the elastic superuser as ELASTICSEARCH_USERNAME.
+# We must use kibana_system instead, which requires setting its password via the
+# ES API. A one-shot Node.js container on the same network handles this without
+# needing the host to reach ES directly.
+
+echo "--- Waiting for node runner image pull to finish"
+wait "$NODE_PULL_PID"
+
+echo "--- Configuring kibana_system user"
+docker run \
+  --rm \
+  --network "$NETWORK_NAME" \
+  --volume "$(pwd):/workspace:ro" \
+  --env "ES_PASSWORD=${ES_PASSWORD}" \
+  "$NODE_RUNNER_IMAGE" \
+  node /workspace/.buildkite/setup-kibana.js
+
+# ── Start Kibana ─────────────────────────────────────────────────────────────
 
 echo "--- Waiting for Kibana image pull to finish"
 wait "$KB_PULL_PID"
@@ -138,7 +156,7 @@ docker run \
   --network "$NETWORK_NAME" \
   --network-alias kibana \
   --env "ELASTICSEARCH_HOSTS=http://elasticsearch:9200" \
-  --env "ELASTICSEARCH_USERNAME=elastic" \
+  --env "ELASTICSEARCH_USERNAME=kibana_system" \
   --env "ELASTICSEARCH_PASSWORD=${ES_PASSWORD}" \
   --env "xpack.encryptedSavedObjects.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
   --env "xpack.reporting.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
@@ -156,9 +174,6 @@ KB_IP=$(docker inspect "$KB_CONTAINER_NAME" \
 echo "Container IPs — ES: ${ES_IP}, Kibana: ${KB_IP}"
 
 # ── Run health checks and tests inside the Docker network ───────────────────
-
-echo "--- Waiting for test-runner image pull to finish"
-wait "$NODE_PULL_PID"
 
 echo "--- Running tests inside Docker network"
 docker run \

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -78,13 +78,17 @@ docker run \
 
 echo "--- Waiting for Elasticsearch to be healthy"
 RETRIES=0
-MAX_RETRIES=120
+MAX_RETRIES=180
 until curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:9200/_cluster/health > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
-    echo "Elasticsearch did not become healthy in time"
+    echo "Elasticsearch did not become healthy in time after $((MAX_RETRIES * 2))s"
     docker logs "$ES_CONTAINER_NAME"
     exit 1
+  fi
+  # Print progress every 30 seconds so CI logs show we are still waiting.
+  if [ $((RETRIES % 15)) -eq 0 ]; then
+    echo "  still waiting for Elasticsearch... (${RETRIES}/${MAX_RETRIES})"
   fi
   sleep 2
 done

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -13,6 +13,12 @@
 # the same Docker bridge network as ES and Kibana. Container IPs are fetched via
 # docker inspect on the host and passed to the runner in case embedded DNS is
 # unavailable (known issue with some rootless/userns Docker configurations).
+#
+# Startup order:
+#   1. Start ES early so it is fully ready before Kibana connects.
+#   2. Pull Kibana + test-runner images while the CLI builds.
+#   3. Start Kibana only after the build completes (~3 min buffer for ES).
+#   4. Run the test-runner container for health checks + tests.
 
 set -euo pipefail
 
@@ -26,8 +32,8 @@ NODE_RUNNER_IMAGE="node:${NODE_VERSION}-bookworm-slim"
 cleanup() {
   echo "--- ES logs (last 50 lines)"
   docker logs "$ES_CONTAINER_NAME" 2>&1 | tail -50 || true
-  echo "--- Kibana logs (last 20 lines)"
-  docker logs "$KB_CONTAINER_NAME" 2>&1 | tail -20 || true
+  echo "--- Kibana logs (last 50 lines)"
+  docker logs "$KB_CONTAINER_NAME" 2>&1 | tail -50 || true
   echo "--- Cleaning up"
   docker rm -f "$TEST_RUNNER_NAME" 2>/dev/null || true
   docker rm -f "$KB_CONTAINER_NAME" 2>/dev/null || true
@@ -43,14 +49,15 @@ KIBANA_ENCRYPTION_KEY="xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj" # gitleaks:allow
 ES_IMAGE="docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}"
 KB_IMAGE="docker.elastic.co/kibana/kibana:${STACK_VERSION}"
 
-# ── Docker setup ────────────────────────────────────────────────────────────
-# Start all containers as early as possible so they boot while the CLI builds.
-
+# ── Docker network ───────────────────────────────────────────────────────────
 echo "--- Creating Docker network"
 docker network create "$NETWORK_NAME" 2>/dev/null || true
 
-# Use the pre-cached ES snapshot on kibana-ubuntu-2404 agents if available,
-# otherwise fall back to a registry pull.
+# ── Elasticsearch ────────────────────────────────────────────────────────────
+# Start ES as early as possible. It needs ~1-2 minutes to bootstrap the
+# security index. Kibana will not start until after the build so ES has
+# plenty of time to be fully ready before Kibana connects.
+
 echo "--- Loading Elasticsearch image"
 ES_CACHE_DIR="${ES_CACHE_DIR:-}"
 if [[ -n "$ES_CACHE_DIR" ]] && compgen -G "$ES_CACHE_DIR/elasticsearch-$STACK_VERSION*.tar.gz" > /dev/null 2>&1; then
@@ -59,15 +66,6 @@ if [[ -n "$ES_CACHE_DIR" ]] && compgen -G "$ES_CACHE_DIR/elasticsearch-$STACK_VE
 else
   docker pull "$ES_IMAGE"
 fi
-
-echo "--- Loading Kibana image"
-docker pull "$KB_IMAGE"
-
-# Pull the test-runner image in the background while ES/Kibana boot and the
-# CLI builds — it's only needed at the very end.
-echo "--- Pulling test-runner image (background)"
-docker pull "$NODE_RUNNER_IMAGE" &
-NODE_PULL_PID=$!
 
 echo "--- Starting Elasticsearch ${STACK_VERSION} (background)"
 docker run \
@@ -79,36 +77,22 @@ docker run \
   --env "action.destructive_requires_name=false" \
   --env "ELASTIC_PASSWORD=${ES_PASSWORD}" \
   --env "xpack.security.http.ssl.enabled=false" \
+  --env "xpack.security.transport.ssl.enabled=false" \
   --env "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
   --detach \
   --rm \
   "$ES_IMAGE"
 
-echo "--- Starting Kibana ${STACK_VERSION} (background)"
-docker run \
-  --name "$KB_CONTAINER_NAME" \
-  --network "$NETWORK_NAME" \
-  --network-alias kibana \
-  --env "ELASTICSEARCH_HOSTS=http://elasticsearch:9200" \
-  --env "ELASTICSEARCH_USERNAME=elastic" \
-  --env "ELASTICSEARCH_PASSWORD=${ES_PASSWORD}" \
-  --env "xpack.encryptedSavedObjects.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
-  --env "xpack.reporting.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
-  --env "xpack.security.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
-  --detach \
-  --rm \
-  "$KB_IMAGE"
+# Pull Kibana and the test-runner images while ES boots and the CLI builds.
+echo "--- Pulling Kibana image (background)"
+docker pull "$KB_IMAGE" &
+KB_PULL_PID=$!
 
-# Fetch container IPs immediately after starting — Docker assigns them before
-# the main process runs. We pass these to the test runner as a fallback in case
-# the embedded DNS server (127.0.0.11) is unavailable on this agent.
-ES_IP=$(docker inspect "$ES_CONTAINER_NAME" \
-  --format="{{(index .NetworkSettings.Networks \"$NETWORK_NAME\").IPAddress}}")
-KB_IP=$(docker inspect "$KB_CONTAINER_NAME" \
-  --format="{{(index .NetworkSettings.Networks \"$NETWORK_NAME\").IPAddress}}")
-echo "Container IPs — ES: ${ES_IP}, Kibana: ${KB_IP}"
+echo "--- Pulling test-runner image (background)"
+docker pull "$NODE_RUNNER_IMAGE" &
+NODE_PULL_PID=$!
 
-# ── Build CLI (concurrent with container startup + test-runner image pull) ──
+# ── Build CLI (concurrent with ES startup + image pulls) ────────────────────
 
 echo "--- Setting up Node.js ${NODE_VERSION}"
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
@@ -142,11 +126,39 @@ export NODE_OPTIONS="${NODE_OPTIONS:-} --max-old-space-size=4096"
 echo "--- Building CLI"
 npm run build
 
-echo "--- Waiting for test-runner image pull to finish"
-wait "$NODE_PULL_PID"
+# ── Start Kibana (after build, so ES has had ~3 min to fully boot) ───────────
+
+echo "--- Waiting for Kibana image pull to finish"
+wait "$KB_PULL_PID"
+
+echo "--- Starting Kibana ${STACK_VERSION}"
+# Intentionally no --rm so crash logs are always available in cleanup.
+docker run \
+  --name "$KB_CONTAINER_NAME" \
+  --network "$NETWORK_NAME" \
+  --network-alias kibana \
+  --env "ELASTICSEARCH_HOSTS=http://elasticsearch:9200" \
+  --env "ELASTICSEARCH_USERNAME=elastic" \
+  --env "ELASTICSEARCH_PASSWORD=${ES_PASSWORD}" \
+  --env "xpack.encryptedSavedObjects.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
+  --env "xpack.reporting.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
+  --env "xpack.security.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
+  --detach \
+  "$KB_IMAGE"
+
+# Fetch container IPs immediately after starting — Docker assigns them before
+# the main process runs. We pass these to the test runner as a fallback in case
+# the embedded DNS server (127.0.0.11) is unavailable on this agent.
+ES_IP=$(docker inspect "$ES_CONTAINER_NAME" \
+  --format="{{(index .NetworkSettings.Networks \"$NETWORK_NAME\").IPAddress}}")
+KB_IP=$(docker inspect "$KB_CONTAINER_NAME" \
+  --format="{{(index .NetworkSettings.Networks \"$NETWORK_NAME\").IPAddress}}")
+echo "Container IPs — ES: ${ES_IP}, Kibana: ${KB_IP}"
 
 # ── Run health checks and tests inside the Docker network ───────────────────
-# The test-runner container uses ES_IP / KB_IP directly if DNS is unavailable.
+
+echo "--- Waiting for test-runner image pull to finish"
+wait "$NODE_PULL_PID"
 
 echo "--- Running tests inside Docker network"
 docker run \

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -57,8 +57,10 @@ npm link
 echo "--- Creating Docker network"
 docker network create "$NETWORK_NAME" 2>/dev/null || true
 
-# Use a fixed password so the CLI config can reference it without secrets management.
+# Use fixed dummy values so the CLI config can reference them without secrets management.
 ES_PASSWORD="changeme"
+# Dummy key used only for local/CI testing — not a real secret. # gitleaks:allow
+KIBANA_ENCRYPTION_KEY="xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj"
 
 echo "--- Starting Elasticsearch ${STACK_VERSION}"
 docker run \
@@ -97,9 +99,9 @@ docker run \
   --env "ELASTICSEARCH_HOSTS=http://elasticsearch:9200" \
   --env "ELASTICSEARCH_USERNAME=elastic" \
   --env "ELASTICSEARCH_PASSWORD=${ES_PASSWORD}" \
-  --env "xpack.encryptedSavedObjects.encryptionKey=xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj" \
-  --env "xpack.reporting.encryptionKey=xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj" \
-  --env "xpack.security.encryptionKey=xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj" \
+  --env "xpack.encryptedSavedObjects.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
+  --env "xpack.reporting.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
+  --env "xpack.security.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
   --detach \
   --rm \
   "docker.elastic.co/kibana/kibana:${STACK_VERSION}"

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -86,9 +86,29 @@ until curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:9200/_cluster/health
     docker logs "$ES_CONTAINER_NAME"
     exit 1
   fi
-  # Print progress every 30 seconds so CI logs show we are still waiting.
   if [ $((RETRIES % 15)) -eq 0 ]; then
     echo "  still waiting for Elasticsearch... (${RETRIES}/${MAX_RETRIES})"
+  fi
+  sleep 2
+done
+echo "Elasticsearch cluster is up"
+
+# The cluster can report healthy before the .security index is fully bootstrapped.
+# Kibana's alerting/connectors plugins depend on ES API keys (encryptedSavedObjects),
+# so we must wait for the security index to be ready before starting Kibana.
+# Technique borrowed from Kibana's own kbn-es tooling (wait_for_security_index.ts).
+echo "--- Waiting for Elasticsearch security index to be ready"
+RETRIES=0
+MAX_RETRIES=60
+until curl -sf -u "elastic:${ES_PASSWORD}" \
+    -X POST "http://localhost:9200/_security/api_key" \
+    -H "Content-Type: application/json" \
+    -d '{"name":"healthcheck","expiration":"1m"}' > /dev/null 2>&1; do
+  RETRIES=$((RETRIES + 1))
+  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+    echo "Elasticsearch security index did not become ready in time"
+    docker logs "$ES_CONTAINER_NAME"
+    exit 1
   fi
   sleep 2
 done

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -142,7 +142,7 @@ docker run \
   --volume "$(pwd):/workspace:ro" \
   --env "ES_PASSWORD=${ES_PASSWORD}" \
   "$NODE_RUNNER_IMAGE" \
-  node /workspace/.buildkite/setup-kibana.js
+  node /workspace/.buildkite/setup-kibana.cjs
 
 # ── Start Kibana ─────────────────────────────────────────────────────────────
 

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -57,15 +57,18 @@ npm link
 echo "--- Creating Docker network"
 docker network create "$NETWORK_NAME" 2>/dev/null || true
 
+# Use a fixed password so the CLI config can reference it without secrets management.
+ES_PASSWORD="changeme"
+
 echo "--- Starting Elasticsearch ${STACK_VERSION}"
 docker run \
   --name "$ES_CONTAINER_NAME" \
   --network "$NETWORK_NAME" \
   --network-alias elasticsearch \
   --env "discovery.type=single-node" \
-  --env "xpack.security.enabled=false" \
   --env "xpack.license.self_generated.type=trial" \
   --env "action.destructive_requires_name=false" \
+  --env "ELASTIC_PASSWORD=${ES_PASSWORD}" \
   --env "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
   --detach \
   --rm \
@@ -74,7 +77,7 @@ docker run \
 echo "--- Waiting for Elasticsearch to be healthy"
 RETRIES=0
 MAX_RETRIES=60
-until docker exec "$ES_CONTAINER_NAME" curl -sf http://localhost:9200/_cluster/health > /dev/null 2>&1; do
+until curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:9200/_cluster/health > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
     echo "Elasticsearch did not become healthy in time"
@@ -91,10 +94,11 @@ docker run \
   --network "$NETWORK_NAME" \
   --publish 5601:5601 \
   --env "ELASTICSEARCH_HOSTS=http://elasticsearch:9200" \
-  --env "xpack.security.enabled=false" \
-  --env "xpack.encryptedSavedObjects.encryptionKey=aaaabbbbccccddddeeeeffffgggghhhh" \
-  --env "xpack.reporting.encryptionKey=aaaabbbbccccddddeeeeffffgggghhhh" \
-  --env "xpack.security.encryptionKey=aaaabbbbccccddddeeeeffffgggghhhh" \
+  --env "ELASTICSEARCH_USERNAME=elastic" \
+  --env "ELASTICSEARCH_PASSWORD=${ES_PASSWORD}" \
+  --env "xpack.encryptedSavedObjects.encryptionKey=xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj" \
+  --env "xpack.reporting.encryptionKey=xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj" \
+  --env "xpack.security.encryptionKey=xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj" \
   --detach \
   --rm \
   "docker.elastic.co/kibana/kibana:${STACK_VERSION}"
@@ -102,7 +106,8 @@ docker run \
 echo "--- Waiting for Kibana to be healthy"
 RETRIES=0
 MAX_RETRIES=90
-until curl -sf http://localhost:5601/api/status | jq -e '.status.overall.level == "available"' > /dev/null 2>&1; do
+until curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:5601/api/status \
+      | jq -e '.status.overall.level == "available"' > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
     echo "Kibana did not become healthy in time"
@@ -118,8 +123,8 @@ echo "Kibana core is ready"
 echo "--- Waiting for alerting and actions plugins to be ready"
 RETRIES=0
 MAX_RETRIES=30
-until curl -sf http://localhost:5601/api/actions/connector_types > /dev/null 2>&1 && \
-      curl -sf "http://localhost:5601/api/alerting/rules/_find" > /dev/null 2>&1; do
+until curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:5601/api/actions/connector_types > /dev/null 2>&1 && \
+      curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:5601/api/alerting/rules/_find > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
     echo "Alerting/actions plugins did not become ready in time"
@@ -137,8 +142,14 @@ contexts:
   ci:
     elasticsearch:
       url: http://localhost:9200
+      auth:
+        username: elastic
+        password: "${ES_PASSWORD}"
     kibana:
       url: http://localhost:5601
+      auth:
+        username: elastic
+        password: "${ES_PASSWORD}"
 current_context: ci
 EOF
 export ELASTIC_CLI_CONFIG_FILE="$CI_CONFIG_FILE"

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -78,6 +78,7 @@ docker run \
   --env "xpack.license.self_generated.type=trial" \
   --env "action.destructive_requires_name=false" \
   --env "ELASTIC_PASSWORD=${ES_PASSWORD}" \
+  --env "xpack.security.http.ssl.enabled=false" \
   --env "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
   --detach \
   --rm \

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -77,9 +77,8 @@ docker run \
 
 echo "--- Waiting for Elasticsearch to be healthy"
 RETRIES=0
-MAX_RETRIES=90
-until docker exec "$ES_CONTAINER_NAME" \
-    curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:9200/_cluster/health > /dev/null 2>&1; do
+MAX_RETRIES=120
+until curl -sf -u "elastic:${ES_PASSWORD}" http://localhost:9200/_cluster/health > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
     echo "Elasticsearch did not become healthy in time"

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -21,6 +21,34 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# Use fixed dummy values so the CLI config can reference them without secrets management.
+ES_PASSWORD="changeme"
+KIBANA_ENCRYPTION_KEY="xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj" # gitleaks:allow
+
+# Pull images and start ES as early as possible so it can boot in the background
+# while npm install and the CLI build run (which together take ~15-20 minutes).
+# On slow CI agents, Docker container startup + ES security bootstrap alone can
+# take 7-10 minutes, so giving it a head start is critical.
+echo "--- Pulling Docker images"
+docker network create "$NETWORK_NAME" 2>/dev/null || true
+docker pull "docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}"
+docker pull "docker.elastic.co/kibana/kibana:${STACK_VERSION}"
+
+echo "--- Starting Elasticsearch ${STACK_VERSION} (background)"
+docker run \
+  --name "$ES_CONTAINER_NAME" \
+  --network "$NETWORK_NAME" \
+  --network-alias elasticsearch \
+  --publish 9200:9200 \
+  --env "discovery.type=single-node" \
+  --env "xpack.license.self_generated.type=trial" \
+  --env "action.destructive_requires_name=false" \
+  --env "ELASTIC_PASSWORD=${ES_PASSWORD}" \
+  --env "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
+  --detach \
+  --rm \
+  "docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}"
+
 echo "--- Setting up Node.js ${NODE_VERSION}"
 export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
 if [ ! -s "$NVM_DIR/nvm.sh" ]; then
@@ -54,34 +82,8 @@ echo "--- Building CLI"
 npm run build
 npm link
 
-echo "--- Creating Docker network"
-docker network create "$NETWORK_NAME" 2>/dev/null || true
-
-# Use fixed dummy values so the CLI config can reference them without secrets management.
-ES_PASSWORD="changeme"
-KIBANA_ENCRYPTION_KEY="xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj" # gitleaks:allow
-
-# Pull images up front so the health-check timer measures actual startup time,
-# not image download time (image pull can take several minutes on cold CI agents).
-echo "--- Pulling Docker images"
-docker pull "docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}"
-docker pull "docker.elastic.co/kibana/kibana:${STACK_VERSION}"
-
-echo "--- Starting Elasticsearch ${STACK_VERSION}"
-docker run \
-  --name "$ES_CONTAINER_NAME" \
-  --network "$NETWORK_NAME" \
-  --network-alias elasticsearch \
-  --publish 9200:9200 \
-  --env "discovery.type=single-node" \
-  --env "xpack.license.self_generated.type=trial" \
-  --env "action.destructive_requires_name=false" \
-  --env "ELASTIC_PASSWORD=${ES_PASSWORD}" \
-  --env "ES_JAVA_OPTS=-Xms512m -Xmx512m" \
-  --detach \
-  --rm \
-  "docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}"
-
+# ES has been running in the background during the entire npm install + build phase.
+# It should be healthy (or close to it) by now.
 echo "--- Waiting for Elasticsearch to be healthy"
 RETRIES=0
 MAX_RETRIES=180

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -59,8 +59,7 @@ docker network create "$NETWORK_NAME" 2>/dev/null || true
 
 # Use fixed dummy values so the CLI config can reference them without secrets management.
 ES_PASSWORD="changeme"
-# Dummy key used only for local/CI testing — not a real secret. # gitleaks:allow
-KIBANA_ENCRYPTION_KEY="xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj"
+KIBANA_ENCRYPTION_KEY="xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj" # gitleaks:allow
 
 echo "--- Starting Elasticsearch ${STACK_VERSION}"
 docker run \

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -61,6 +61,12 @@ docker network create "$NETWORK_NAME" 2>/dev/null || true
 ES_PASSWORD="changeme"
 KIBANA_ENCRYPTION_KEY="xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj" # gitleaks:allow
 
+# Pull images up front so the health-check timer measures actual startup time,
+# not image download time (image pull can take several minutes on cold CI agents).
+echo "--- Pulling Docker images"
+docker pull "docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}"
+docker pull "docker.elastic.co/kibana/kibana:${STACK_VERSION}"
+
 echo "--- Starting Elasticsearch ${STACK_VERSION}"
 docker run \
   --name "$ES_CONTAINER_NAME" \

--- a/.buildkite/run-kb-tests.sh
+++ b/.buildkite/run-kb-tests.sh
@@ -3,21 +3,22 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Buildkite entry point for Kibana functional tests.
-# Starts Elasticsearch and Kibana containers in the background, then builds the
-# CLI concurrently, and runs the hand-authored KB test suite once everything is ready.
+# Starts Elasticsearch and Kibana using --network host so both services are
+# reachable at localhost:9200 and localhost:5601 from the host — no Docker
+# port publishing or bridge routing needed. This mirrors how Kibana's own CI
+# runs ES natively (via node scripts/es snapshot) and avoids iptables/nftables
+# issues present on Ubuntu 24.04 agents.
 
 set -euo pipefail
 
 STACK_VERSION="${STACK_VERSION:-9.3.0}"
 ES_CONTAINER_NAME="elastic-cli-kb-es"
 KB_CONTAINER_NAME="elastic-cli-kb"
-NETWORK_NAME="elastic-cli-kb-net"
 
 cleanup() {
   echo "--- Cleaning up"
   docker rm -f "$KB_CONTAINER_NAME" 2>/dev/null || true
   docker rm -f "$ES_CONTAINER_NAME" 2>/dev/null || true
-  docker network rm "$NETWORK_NAME" 2>/dev/null || true
 }
 trap cleanup EXIT
 
@@ -32,15 +33,15 @@ KB_IMAGE="docker.elastic.co/kibana/kibana:${STACK_VERSION}"
 # Start containers as early as possible so ES and Kibana boot in the background
 # while npm install + build run.
 #
-# Note: we do NOT use --publish to expose ports on the host. Ubuntu 24.04 agents
-# use nftables, which can break Docker port publishing. Instead we connect directly
-# to the container IPs on the bridge network, which always works on Linux hosts.
-
-echo "--- Creating Docker network"
-docker network create "$NETWORK_NAME" 2>/dev/null || true
+# Both containers use --network host so they bind directly to the host's network
+# stack. This means:
+#   - ES is reachable at localhost:9200 from the host and from Kibana
+#   - Kibana is reachable at localhost:5601 from the host
+#   - No iptables/nftables port forwarding rules are needed
+# This is functionally equivalent to Kibana's approach of running ES natively.
 
 # Use the pre-cached ES snapshot on kibana-ubuntu-2404 agents if available,
-# otherwise fall back to a registry pull (same technique as Kibana's kbn-es tooling).
+# otherwise fall back to a registry pull.
 echo "--- Loading Elasticsearch image"
 ES_CACHE_DIR="${ES_CACHE_DIR:-}"
 if [[ -n "$ES_CACHE_DIR" ]] && compgen -G "$ES_CACHE_DIR/elasticsearch-$STACK_VERSION*.tar.gz" > /dev/null 2>&1; then
@@ -56,8 +57,7 @@ docker pull "$KB_IMAGE"
 echo "--- Starting Elasticsearch ${STACK_VERSION} (background)"
 docker run \
   --name "$ES_CONTAINER_NAME" \
-  --network "$NETWORK_NAME" \
-  --network-alias elasticsearch \
+  --network host \
   --env "discovery.type=single-node" \
   --env "xpack.license.self_generated.type=trial" \
   --env "action.destructive_requires_name=false" \
@@ -67,13 +67,12 @@ docker run \
   --rm \
   "$ES_IMAGE"
 
-# Start Kibana immediately alongside ES — Kibana will retry the ES connection
-# until ES is ready, so the order doesn't matter for correctness.
+# Kibana connects to ES at localhost:9200 since both share the host network.
 echo "--- Starting Kibana ${STACK_VERSION} (background)"
 docker run \
   --name "$KB_CONTAINER_NAME" \
-  --network "$NETWORK_NAME" \
-  --env "ELASTICSEARCH_HOSTS=http://elasticsearch:9200" \
+  --network host \
+  --env "ELASTICSEARCH_HOSTS=http://localhost:9200" \
   --env "ELASTICSEARCH_USERNAME=elastic" \
   --env "ELASTICSEARCH_PASSWORD=${ES_PASSWORD}" \
   --env "xpack.encryptedSavedObjects.encryptionKey=${KIBANA_ENCRYPTION_KEY}" \
@@ -82,14 +81,6 @@ docker run \
   --detach \
   --rm \
   "$KB_IMAGE"
-
-# Resolve container IPs on the Docker bridge network.
-# We use these directly instead of published ports to avoid iptables/nftables issues
-# on Ubuntu 24.04 agents. On Linux the host can always reach bridge network IPs.
-ES_IP=$(docker inspect --format='{{(index .NetworkSettings.Networks "'"$NETWORK_NAME"'").IPAddress}}' "$ES_CONTAINER_NAME")
-KB_IP=$(docker inspect --format='{{(index .NetworkSettings.Networks "'"$NETWORK_NAME"'").IPAddress}}' "$KB_CONTAINER_NAME")
-echo "Elasticsearch IP: ${ES_IP}"
-echo "Kibana IP: ${KB_IP}"
 
 # ── Build CLI (runs concurrently with ES + Kibana startup) ──────────────────
 
@@ -131,7 +122,7 @@ npm link
 echo "--- Waiting for Elasticsearch to be healthy"
 RETRIES=0
 MAX_RETRIES=180
-until curl -sf -u "elastic:${ES_PASSWORD}" "http://${ES_IP}:9200/_cluster/health" > /dev/null 2>&1; do
+until curl -sf -u "elastic:${ES_PASSWORD}" "http://localhost:9200/_cluster/health" > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
     echo "Elasticsearch did not become healthy in time after $((MAX_RETRIES * 2))s"
@@ -153,7 +144,7 @@ echo "--- Waiting for Elasticsearch security index to be ready"
 RETRIES=0
 MAX_RETRIES=60
 until curl -sf -u "elastic:${ES_PASSWORD}" \
-    -X POST "http://${ES_IP}:9200/_security/api_key" \
+    -X POST "http://localhost:9200/_security/api_key" \
     -H "Content-Type: application/json" \
     -d '{"name":"healthcheck","expiration":"1m"}' > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
@@ -169,7 +160,7 @@ echo "Elasticsearch is ready"
 echo "--- Waiting for Kibana to be healthy"
 RETRIES=0
 MAX_RETRIES=90
-until curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_IP}:5601/api/status" \
+until curl -sf -u "elastic:${ES_PASSWORD}" "http://localhost:5601/api/status" \
       | jq -e '.status.overall.level == "available"' > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
@@ -185,8 +176,8 @@ echo "Kibana core is ready"
 echo "--- Waiting for alerting and actions plugins to be ready"
 RETRIES=0
 MAX_RETRIES=30
-until curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_IP}:5601/api/actions/connector_types" > /dev/null 2>&1 && \
-      curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_IP}:5601/api/alerting/rules/_find" > /dev/null 2>&1; do
+until curl -sf -u "elastic:${ES_PASSWORD}" "http://localhost:5601/api/actions/connector_types" > /dev/null 2>&1 && \
+      curl -sf -u "elastic:${ES_PASSWORD}" "http://localhost:5601/api/alerting/rules/_find" > /dev/null 2>&1; do
   RETRIES=$((RETRIES + 1))
   if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
     echo "Alerting/actions plugins did not become ready in time"
@@ -205,12 +196,12 @@ cat > "$CI_CONFIG_FILE" <<EOF
 contexts:
   ci:
     elasticsearch:
-      url: http://${ES_IP}:9200
+      url: http://localhost:9200
       auth:
         username: elastic
         password: "${ES_PASSWORD}"
     kibana:
-      url: http://${KB_IP}:5601
+      url: http://localhost:5601
       auth:
         username: elastic
         password: "${ES_PASSWORD}"

--- a/.buildkite/setup-kibana.cjs
+++ b/.buildkite/setup-kibana.cjs
@@ -33,6 +33,7 @@ function request(method, path, body) {
         });
       }
     );
+    req.setTimeout(5000, () => { req.destroy(new Error('request timed out')); });
     req.on('error', reject);
     if (data) req.write(data);
     req.end();

--- a/.buildkite/setup-kibana.cjs
+++ b/.buildkite/setup-kibana.cjs
@@ -1,4 +1,6 @@
-'use strict';
+// Copyright Elasticsearch B.V. and contributors
+// SPDX-License-Identifier: Apache-2.0
+//
 // Runs inside a Node.js container on the same Docker network as Elasticsearch.
 // Waits for ES to be fully ready (cluster health + security index), then sets
 // the kibana_system password so Kibana can connect as that user.

--- a/.buildkite/setup-kibana.js
+++ b/.buildkite/setup-kibana.js
@@ -1,0 +1,75 @@
+'use strict';
+// Runs inside a Node.js container on the same Docker network as Elasticsearch.
+// Waits for ES to be fully ready (cluster health + security index), then sets
+// the kibana_system password so Kibana can connect as that user.
+const http = require('http');
+
+const ES_PASSWORD = process.env.ES_PASSWORD || 'changeme';
+const KB_PASSWORD = process.env.KB_PASSWORD || ES_PASSWORD;
+const auth = 'Basic ' + Buffer.from(`elastic:${ES_PASSWORD}`).toString('base64');
+
+function request(method, path, body) {
+  return new Promise((resolve, reject) => {
+    const data = body ? JSON.stringify(body) : null;
+    const req = http.request(
+      {
+        hostname: 'elasticsearch',
+        port: 9200,
+        path,
+        method,
+        headers: {
+          Authorization: auth,
+          ...(data && { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(data) }),
+        },
+      },
+      res => {
+        let raw = '';
+        res.on('data', chunk => (raw += chunk));
+        res.on('end', () => {
+          try { resolve({ status: res.statusCode, body: JSON.parse(raw) }); }
+          catch { resolve({ status: res.statusCode, body: raw }); }
+        });
+      }
+    );
+    req.on('error', reject);
+    if (data) req.write(data);
+    req.end();
+  });
+}
+
+function delay(ms) { return new Promise(r => setTimeout(r, ms)); }
+
+async function retry(fn, label, maxRetries = 180, intervalMs = 2000) {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const ok = await fn();
+      if (ok) return;
+    } catch { /* not ready yet */ }
+    if (i > 0 && i % 15 === 0) console.log(`  still waiting for ${label}... (${i}/${maxRetries})`);
+    await delay(intervalMs);
+  }
+  throw new Error(`${label} did not become ready in time`);
+}
+
+async function main() {
+  console.log('Waiting for Elasticsearch cluster health...');
+  await retry(async () => {
+    const { body } = await request('GET', '/_cluster/health');
+    return ['green', 'yellow'].includes(body.status);
+  }, 'ES cluster health');
+  console.log('ES cluster is up');
+
+  console.log('Waiting for ES security index...');
+  await retry(async () => {
+    const { status } = await request('POST', '/_security/api_key', { name: 'setup-check', expiration: '1m' });
+    return status >= 200 && status < 300;
+  }, 'ES security index', 60);
+  console.log('ES security index is ready');
+
+  console.log('Setting kibana_system password...');
+  const { status } = await request('POST', '/_security/user/kibana_system/_password', { password: KB_PASSWORD });
+  if (status < 200 || status >= 300) throw new Error(`HTTP ${status}`);
+  console.log('kibana_system password configured');
+}
+
+main().catch(e => { console.error('Setup failed:', e.message); process.exit(1); });

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+[extend]
+# Extend the default gitleaks ruleset.
+useDefault = true
+
+[[allowlist]]
+description = "Dummy Kibana encryption key used only in CI test scripts"
+regexTarget = "line"
+regex = '''xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj'''

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -2,7 +2,10 @@
 # Extend the default gitleaks ruleset.
 useDefault = true
 
-[[allowlist]]
-description = "Dummy Kibana encryption key used only in CI test scripts"
+[allowlist]
+description = "Dummy values used only in CI test scripts — not real secrets"
 regexTarget = "line"
-regex = '''xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj'''
+regexes = [
+  # Dummy Kibana encryption key in run-kb-tests.sh
+  '''xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj''',
+]

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "codegen:functional": "npx tsx codegen/functional/index.ts --tests-dir ../elasticsearch-clients-tests/tests",
     "test:functional:es": "bash test/functional/es/run.sh",
     "test:functional:cloud": "bash test/functional/cloud/smoke.sh",
+    "test:functional:kb": "bash test/functional/kb/run.sh",
     "test:license": "license-checker --production",
     "test:spdx": "./scripts/check-spdx",
     "generate:notice": "node scripts/generate-notice.mjs",

--- a/src/kb/apis/alerting.ts
+++ b/src/kb/apis/alerting.ts
@@ -54,7 +54,7 @@ export const alertingApis: KbApiDefinition[] = [
     { name: "schedule", type: "object", description: "The check interval, which specifies how frequently the rule conditions are checked.", required: true },
     { name: "tags", type: "array", description: "The tags for the rule." },
     { name: "throttle", type: "string", description: "Use the `throttle` property in the action `frequency` object instead. The throttle interval, which defines how often an alert generates repeated actions. NOTE: You cannot specify the throttle interval at both the rule and action level. If you set it at the rule level then update the rule in Kibana, it is automatically changed to use action-specific values." },
-    { name: "params", type: "string", description: "The parameters for the rule." },
+    { name: "params", type: "object", description: "The parameters for the rule." },
     ],
   },
   {

--- a/src/kb/apis/connectors.ts
+++ b/src/kb/apis/connectors.ts
@@ -68,8 +68,8 @@ export const connectorsApis: KbApiDefinition[] = [
     bodyParams: [
     { name: "connector_type_id", type: "string", description: "The type of connector.", required: true },
     { name: "name", type: "string", description: "The display name for the connector.", required: true },
-    { name: "config", cliFlag: "kb-config", type: "string", description: "The connector configuration details." },
-    { name: "secrets", type: "string", description: "" },
+    { name: "config", cliFlag: "kb-config", type: "object", description: "The connector configuration details." },
+    { name: "secrets", type: "object", description: "" },
     ],
   },
   {
@@ -83,8 +83,8 @@ export const connectorsApis: KbApiDefinition[] = [
     ],
     bodyParams: [
     { name: "name", type: "string", description: "The display name for the connector.", required: true },
-    { name: "config", cliFlag: "kb-config", type: "string", description: "The connector configuration details." },
-    { name: "secrets", type: "string", description: "" },
+    { name: "config", cliFlag: "kb-config", type: "object", description: "The connector configuration details." },
+    { name: "secrets", type: "object", description: "" },
     ],
   },
   {
@@ -97,7 +97,7 @@ export const connectorsApis: KbApiDefinition[] = [
     { name: "id", description: "An identifier for the connector.", required: true },
     ],
     bodyParams: [
-    { name: "params", type: "string", description: "", required: true },
+    { name: "params", type: "object", description: "", required: true },
     ],
   },
   {

--- a/src/kb/apis/saved-objects.ts
+++ b/src/kb/apis/saved-objects.ts
@@ -26,6 +26,7 @@ export const savedObjectsApis: KbApiDefinition[] = [
     { name: "search", type: "string", description: "Search for documents to export using the Elasticsearch Simple Query String syntax." },
     { name: "type", type: "string", description: "The saved object types to include in the export. Use `*` to export all the types. Valid options depend on enabled plugins, but may include `visualization`, `dashboard`, `search`, `index-pattern`, `tag`, `config`, `config-global`, `lens`, `map`, `event-annotation-group`, `query`, `url`, `action`, `alert`, `alerting_rule_template`, `apm-indices`, `cases-user-actions`, `cases`, `cases-comments`, `infrastructure-monitoring-log-view`, `ml-trained-model`, `osquery-saved-query`, `osquery-pack`, `osquery-pack-asset`." },
     ],
+    responseType: "ndjson",
   },
   {
     name: "post-saved-objects-import",
@@ -38,5 +39,25 @@ export const savedObjectsApis: KbApiDefinition[] = [
     { name: "createNewCopies", type: "boolean", description: "Creates copies of saved objects, regenerates each object ID, and resets the origin. When used, potential conflict errors are avoided. NOTE: This option cannot be used with the `overwrite` and `compatibilityMode` options." },
     { name: "compatibilityMode", type: "boolean", description: "Applies various adjustments to the saved objects that are being imported to maintain compatibility between different Kibana versions. Use this option only if you encounter issues with imported saved objects. NOTE: This option cannot be used with the `createNewCopies` option." },
     ],
+    bodyParams: [
+    { name: "file", type: "string", description: "A file exported using the export API. Changing the contents of the exported file in any way before importing it can cause errors, crashes or data loss. NOTE: The `savedObjects.maxImportExportSize` configuration setting limits the number of saved objects which may be included in this file. Similarly, the `savedObjects.maxImportPayloadBytes` setting limits the overall size of the file that can be imported.", required: true },
+    ],
+    requestType: "multipart",
+  },
+  {
+    name: "post-saved-objects-resolve-import-errors",
+    namespace: "saved-objects",
+    description: "Resolve import errors",
+    method: "POST",
+    path: "/api/saved_objects/_resolve_import_errors",
+    queryParams: [
+    { name: "createNewCopies", type: "boolean", description: "Creates copies of saved objects, regenerates each object ID, and resets the origin." },
+    { name: "compatibilityMode", type: "boolean", description: "Applies adjustments to maintain compatibility between different Kibana versions." },
+    ],
+    bodyParams: [
+    { name: "file", type: "string", description: "", required: true },
+    { name: "retries", type: "string", description: "", required: true },
+    ],
+    requestType: "multipart",
   },
 ]

--- a/src/kb/request-builder.ts
+++ b/src/kb/request-builder.ts
@@ -27,11 +27,17 @@ export function buildKibanaRequestParams (
 
   const path = interpolatePath(def, input)
   const querystring = buildQuerystring(def, input)
-  const body = collectBody(def, input)
 
   const params: KibanaRequestParams = { method: def.method, path }
   if (Object.keys(querystring).length > 0) params.querystring = querystring
-  if (body !== undefined) params.body = body
+
+  if (def.requestType === 'multipart') {
+    const fields = collectMultipartFields(def, input)
+    if (fields != null) params.multipartFields = fields
+  } else {
+    const body = collectBody(def, input)
+    if (body !== undefined) params.body = body
+  }
 
   return params
 }
@@ -70,6 +76,24 @@ function buildQuerystring (
     if (value !== undefined) qs[param.name] = value
   }
   return qs
+}
+
+/**
+ * Collects multipart form fields from body params.
+ * Each body param value is treated as a string (file path or literal value).
+ * Returns `undefined` when no fields are present.
+ */
+function collectMultipartFields (
+  def: KbApiDefinition,
+  input: Record<string, unknown>
+): Record<string, string> | undefined {
+  const fields: Record<string, string> = {}
+  for (const param of def.bodyParams ?? []) {
+    const key = param.cliFlag ?? param.name
+    const value = input[key]
+    if (value !== undefined) fields[param.name] = String(value)
+  }
+  return Object.keys(fields).length === 0 ? undefined : fields
 }
 
 /**

--- a/src/kb/types.ts
+++ b/src/kb/types.ts
@@ -70,6 +70,10 @@ export interface KbApiDefinition {
   pathParams?: KbPathParam[]
   queryParams?: KbQueryParam[]
   bodyParams?: KbBodyParam[]
+  /** When 'multipart', the request body must be sent as multipart/form-data. */
+  requestType?: 'multipart'
+  /** When 'ndjson', the success response is newline-delimited JSON (parsed into an array). */
+  responseType?: 'ndjson'
 }
 
 const VALID_NAME = /^[a-z0-9][a-z0-9-]*$/

--- a/src/lib/kibana-client.ts
+++ b/src/lib/kibana-client.ts
@@ -3,6 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import fs from 'node:fs'
+import path from 'node:path'
 import { getResolvedConfig } from '../config/store.ts'
 import { isLoopbackUrl } from './is-loopback-host.ts'
 
@@ -16,6 +18,8 @@ export interface KibanaRequestParams {
   path: string
   querystring?: Record<string, unknown>
   body?: unknown
+  /** When set, the request is sent as multipart/form-data. Keys map to form field names; string values that resolve to an existing file path are sent as file uploads. */
+  multipartFields?: Record<string, string>
 }
 
 /**
@@ -66,7 +70,6 @@ export class KibanaClient {
     const headers: Record<string, string> = {
       'Authorization': this.authHeader,
       'Accept': 'application/json',
-      'Content-Type': 'application/json',
     }
 
     // Kibana requires kbn-xsrf for all state-mutating requests to protect against CSRF
@@ -76,7 +79,21 @@ export class KibanaClient {
 
     const init: RequestInit = { method, headers, redirect: 'error' }
 
-    if (params.body !== undefined) {
+    if (params.multipartFields != null) {
+      // Send as multipart/form-data; do NOT set Content-Type manually (fetch sets it with the boundary)
+      const form = new FormData()
+      for (const [field, value] of Object.entries(params.multipartFields)) {
+        const resolved = path.resolve(value)
+        if (fs.existsSync(resolved)) {
+          const blob = new Blob([fs.readFileSync(resolved)], { type: 'application/octet-stream' })
+          form.append(field, blob, path.basename(resolved))
+        } else {
+          form.append(field, value)
+        }
+      }
+      init.body = form
+    } else if (params.body !== undefined) {
+      headers['Content-Type'] = 'application/json'
       init.body = JSON.stringify(params.body)
     }
 
@@ -88,7 +105,15 @@ export class KibanaClient {
     }
 
     const text = await response.text()
-    return text.length > 0 ? JSON.parse(text) : {}
+    if (text.length === 0) return {}
+
+    // application/x-ndjson: parse each non-empty line as a JSON object
+    const contentType = response.headers.get('content-type') ?? ''
+    if (contentType.includes('ndjson')) {
+      return text.split('\n').filter((l) => l.trim().length > 0).map((l) => JSON.parse(l))
+    }
+
+    return JSON.parse(text)
   }
 
   /**

--- a/src/lib/kibana-client.ts
+++ b/src/lib/kibana-client.ts
@@ -35,12 +35,14 @@ export interface KibanaRequestParams {
  */
 export class KibanaClient {
   readonly baseUrl: string
-  private readonly authHeader: string
+  private readonly authHeader: string | undefined
   private _fetch: typeof fetch = globalThis.fetch
 
-  constructor (baseUrl: string, auth: { api_key: string } | { username: string; password: string }) {
+  constructor (baseUrl: string, auth?: { api_key: string } | { username: string; password: string }) {
     this.baseUrl = baseUrl.replace(/\/+$/, '')
-    if ('api_key' in auth) {
+    if (auth == null) {
+      this.authHeader = undefined
+    } else if ('api_key' in auth) {
       this.authHeader = `ApiKey ${auth.api_key}`
     } else {
       const encoded = Buffer.from(`${auth.username}:${auth.password}`).toString('base64')
@@ -68,8 +70,10 @@ export class KibanaClient {
 
     const method = params.method.toUpperCase()
     const headers: Record<string, string> = {
-      'Authorization': this.authHeader,
       'Accept': 'application/json',
+    }
+    if (this.authHeader != null) {
+      headers['Authorization'] = this.authHeader
     }
 
     // Kibana requires kbn-xsrf for all state-mutating requests to protect against CSRF
@@ -148,19 +152,15 @@ export function getKibanaClient (): KibanaClient {
   }
 
   const { url, auth } = kb
-  const authRecord = auth as Record<string, unknown>
+  const authRecord = auth as Record<string, unknown> | undefined
 
-  let typedAuth: { api_key: string } | { username: string; password: string }
-  if (typeof authRecord['api_key'] === 'string') {
-    typedAuth = { api_key: authRecord['api_key'] }
-  } else if (typeof authRecord['username'] === 'string' && typeof authRecord['password'] === 'string') {
-    typedAuth = { username: authRecord['username'], password: authRecord['password'] }
-  } else {
-    throw new Error(
-      'missing_config: Kibana auth requires either api_key or username/password. ' +
-      'Check your .elasticrc.yml config file.'
-    )
+  let typedAuth: { api_key: string } | { username: string; password: string } | undefined
+  if (typeof authRecord?.['api_key'] === 'string') {
+    typedAuth = { api_key: authRecord['api_key'] as string }
+  } else if (typeof authRecord?.['username'] === 'string' && typeof authRecord?.['password'] === 'string') {
+    typedAuth = { username: authRecord['username'] as string, password: authRecord['password'] as string }
   }
+  // auth is optional — when absent (e.g. security disabled), requests are sent without credentials
 
   _client = new KibanaClient(url, typedAuth)
   return _client

--- a/test/functional/kb/alerting.sh
+++ b/test/functional/kb/alerting.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Functional tests for the Kibana alerting API namespace.
+# Exercises create rule / get rule / find rules / delete rule.
+
+set -euo pipefail
+exec < /dev/null
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CLI="node $REPO_ROOT/dist/cli.js"
+
+RULE_ID="cli-ft-rule"
+
+# Use the built-in .es-query rule type (available in all Kibana deployments).
+RULE_PARAMS='{"searchType":"esqlQuery","esqlQuery":{"esql":"FROM * | LIMIT 1"},"timeWindowSize":5,"timeWindowUnit":"m","threshold":[0],"thresholdComparator":">","size":0,"timeField":"@timestamp"}'
+
+teardown() {
+  $CLI stack kb alerting delete-alerting-rule-id --id "$RULE_ID" --json >/dev/null 2>&1 || true
+}
+trap teardown EXIT
+
+# ── create ────────────────────────────────────────────────────────────
+
+output=$($CLI stack kb alerting post-alerting-rule-id \
+  --id "$RULE_ID" \
+  --consumer "alerts" \
+  --name "CLI FT Rule" \
+  --rule-type-id ".es-query" \
+  --schedule '{"interval":"1m"}' \
+  --params "$RULE_PARAMS" \
+  --json 2>/dev/null)
+[ "$(echo "$output" | jq -r '.id')" = "$RULE_ID" ] \
+  || { echo "FAIL: alerting create — id mismatch"; exit 1; }
+[ "$(echo "$output" | jq -r '.name')" = "CLI FT Rule" ] \
+  || { echo "FAIL: alerting create — name mismatch"; exit 1; }
+[ "$(echo "$output" | jq -r '.rule_type_id')" = ".es-query" ] \
+  || { echo "FAIL: alerting create — rule_type_id mismatch"; exit 1; }
+
+# ── get ───────────────────────────────────────────────────────────────
+
+output=$($CLI stack kb alerting get-alerting-rule-id --id "$RULE_ID" --json 2>/dev/null)
+[ "$(echo "$output" | jq -r '.id')" = "$RULE_ID" ] \
+  || { echo "FAIL: alerting get — id mismatch"; exit 1; }
+[ "$(echo "$output" | jq -r '.enabled')" = "true" ] \
+  || { echo "FAIL: alerting get — rule should be enabled by default"; exit 1; }
+
+# ── find ──────────────────────────────────────────────────────────────
+
+output=$($CLI stack kb alerting get-alerting-rules-find --json 2>/dev/null)
+count=$(echo "$output" | jq '[.data[] | select(.id == "'"$RULE_ID"'")] | length')
+[ "$count" -eq 1 ] || { echo "FAIL: alerting find — created rule not found"; exit 1; }
+
+# ── delete ────────────────────────────────────────────────────────────
+
+$CLI stack kb alerting delete-alerting-rule-id --id "$RULE_ID" --json >/dev/null 2>/dev/null
+
+output=$($CLI stack kb alerting get-alerting-rules-find --json 2>/dev/null)
+count=$(echo "$output" | jq '[.data[] | select(.id == "'"$RULE_ID"'")] | length')
+[ "$count" -eq 0 ] || { echo "FAIL: alerting delete — rule still present after delete"; exit 1; }
+
+echo "PASS: kb/alerting.sh"

--- a/test/functional/kb/alerting.sh
+++ b/test/functional/kb/alerting.sh
@@ -26,12 +26,13 @@ trap teardown EXIT
 
 output=$($CLI stack kb alerting post-alerting-rule-id \
   --id "$RULE_ID" \
-  --consumer "alerts" \
+  --consumer "stackAlerts" \
   --name "CLI FT Rule" \
   --rule-type-id ".es-query" \
   --schedule '{"interval":"1m"}' \
   --params "$RULE_PARAMS" \
-  --json 2>/dev/null)
+  --json 2>/dev/null) \
+  || { echo "FAIL: alerting create — command failed"; exit 1; }
 [ "$(echo "$output" | jq -r '.id')" = "$RULE_ID" ] \
   || { echo "FAIL: alerting create — id mismatch"; exit 1; }
 [ "$(echo "$output" | jq -r '.name')" = "CLI FT Rule" ] \

--- a/test/functional/kb/alerting.sh
+++ b/test/functional/kb/alerting.sh
@@ -31,8 +31,8 @@ output=$($CLI stack kb alerting post-alerting-rule-id \
   --rule-type-id ".es-query" \
   --schedule '{"interval":"1m"}' \
   --params "$RULE_PARAMS" \
-  --json 2>/dev/null) \
-  || { echo "FAIL: alerting create — command failed"; exit 1; }
+  --json 2>/tmp/cli-err.txt) \
+  || { echo "FAIL: alerting create — command failed"; cat /tmp/cli-err.txt; exit 1; }
 [ "$(echo "$output" | jq -r '.id')" = "$RULE_ID" ] \
   || { echo "FAIL: alerting create — id mismatch"; exit 1; }
 [ "$(echo "$output" | jq -r '.name')" = "CLI FT Rule" ] \

--- a/test/functional/kb/connectors.sh
+++ b/test/functional/kb/connectors.sh
@@ -23,8 +23,8 @@ trap teardown EXIT
 
 # ── list connector types ───────────────────────────────────────────────
 
-output=$($CLI stack kb connectors get-actions-connector-types --json 2>/dev/null) \
-  || { echo "FAIL: connectors list-types — command failed"; exit 1; }
+output=$($CLI stack kb connectors get-actions-connector-types --json 2>/tmp/cli-err.txt) \
+  || { echo "FAIL: connectors list-types — command failed"; cat /tmp/cli-err.txt; exit 1; }
 count=$(echo "$output" | jq 'length')
 [ "$count" -gt 0 ] || { echo "FAIL: connectors list-types — empty list"; exit 1; }
 
@@ -44,8 +44,8 @@ output=$($CLI stack kb connectors post-actions-connector-id \
   --connector-type-id ".index" \
   --name "CLI FT Index Connector" \
   --kb-config '{"index":"cli-ft-connector-*"}' \
-  --json 2>/dev/null) \
-  || { echo "FAIL: connectors create — command failed"; exit 1; }
+  --json 2>/tmp/cli-err.txt) \
+  || { echo "FAIL: connectors create — command failed"; cat /tmp/cli-err.txt; exit 1; }
 [ "$(echo "$output" | jq -r '.id')" = "$CONNECTOR_UUID" ] \
   || { echo "FAIL: connectors create — id mismatch"; exit 1; }
 [ "$(echo "$output" | jq -r '.name')" = "CLI FT Index Connector" ] \

--- a/test/functional/kb/connectors.sh
+++ b/test/functional/kb/connectors.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Functional tests for the Kibana connectors API namespace.
+# Exercises list-types / create / get / list / delete.
+
+set -euo pipefail
+exec < /dev/null
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CLI="node $REPO_ROOT/dist/cli.js"
+
+CONNECTOR_ID=""
+
+teardown() {
+  if [ -n "$CONNECTOR_ID" ]; then
+    $CLI stack kb connectors delete-actions-connector-id --id "$CONNECTOR_ID" --json >/dev/null 2>&1 || true
+  fi
+}
+trap teardown EXIT
+
+# ── list connector types ───────────────────────────────────────────────
+
+output=$($CLI stack kb connectors get-actions-connector-types --json 2>/dev/null)
+count=$(echo "$output" | jq 'length')
+[ "$count" -gt 0 ] || { echo "FAIL: connectors list-types — empty list"; exit 1; }
+
+# The .index connector type ships with all Kibana deployments.
+index_type=$(echo "$output" | jq -r '[.[] | select(.id == ".index")] | .[0].id')
+[ "$index_type" = ".index" ] \
+  || { echo "FAIL: connectors list-types — .index type not found"; exit 1; }
+
+# ── create ────────────────────────────────────────────────────────────
+
+# Kibana requires a UUID for connectors with encrypted secrets (most types).
+# The .index connector does not have encrypted secrets so any UUID works.
+CONNECTOR_UUID=$(python3 -c "import uuid; print(str(uuid.uuid4()))" 2>/dev/null \
+  || uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]')
+CONNECTOR_ID="$CONNECTOR_UUID"
+
+output=$($CLI stack kb connectors post-actions-connector-id \
+  --id "$CONNECTOR_UUID" \
+  --connector-type-id ".index" \
+  --name "CLI FT Index Connector" \
+  --kb-config '{"index":"cli-ft-connector-*"}' \
+  --json 2>/dev/null)
+[ "$(echo "$output" | jq -r '.id')" = "$CONNECTOR_UUID" ] \
+  || { echo "FAIL: connectors create — id mismatch"; exit 1; }
+[ "$(echo "$output" | jq -r '.name')" = "CLI FT Index Connector" ] \
+  || { echo "FAIL: connectors create — name mismatch"; exit 1; }
+[ "$(echo "$output" | jq -r '.connector_type_id')" = ".index" ] \
+  || { echo "FAIL: connectors create — connector_type_id mismatch"; exit 1; }
+
+# ── get ───────────────────────────────────────────────────────────────
+
+output=$($CLI stack kb connectors get-actions-connector-id --id "$CONNECTOR_ID" --json 2>/dev/null)
+[ "$(echo "$output" | jq -r '.id')" = "$CONNECTOR_ID" ] \
+  || { echo "FAIL: connectors get — id mismatch"; exit 1; }
+[ "$(echo "$output" | jq -r '.name')" = "CLI FT Index Connector" ] \
+  || { echo "FAIL: connectors get — name mismatch"; exit 1; }
+
+# ── list ──────────────────────────────────────────────────────────────
+
+output=$($CLI stack kb connectors get-actions-connectors --json 2>/dev/null)
+count=$(echo "$output" | jq '[.[] | select(.id == "'"$CONNECTOR_ID"'")] | length')
+[ "$count" -eq 1 ] || { echo "FAIL: connectors list — created connector not found"; exit 1; }
+
+# ── delete ────────────────────────────────────────────────────────────
+
+$CLI stack kb connectors delete-actions-connector-id --id "$CONNECTOR_ID" --json >/dev/null 2>/dev/null
+CONNECTOR_ID=""
+
+output=$($CLI stack kb connectors get-actions-connectors --json 2>/dev/null)
+count=$(echo "$output" | jq '[.[] | select(.name == "CLI FT Index Connector")] | length')
+[ "$count" -eq 0 ] || { echo "FAIL: connectors delete — connector still present after delete"; exit 1; }
+
+echo "PASS: kb/connectors.sh"

--- a/test/functional/kb/connectors.sh
+++ b/test/functional/kb/connectors.sh
@@ -23,7 +23,8 @@ trap teardown EXIT
 
 # ── list connector types ───────────────────────────────────────────────
 
-output=$($CLI stack kb connectors get-actions-connector-types --json 2>/dev/null)
+output=$($CLI stack kb connectors get-actions-connector-types --json 2>/dev/null) \
+  || { echo "FAIL: connectors list-types — command failed"; exit 1; }
 count=$(echo "$output" | jq 'length')
 [ "$count" -gt 0 ] || { echo "FAIL: connectors list-types — empty list"; exit 1; }
 
@@ -34,10 +35,8 @@ index_type=$(echo "$output" | jq -r '[.[] | select(.id == ".index")] | .[0].id')
 
 # ── create ────────────────────────────────────────────────────────────
 
-# Kibana requires a UUID for connectors with encrypted secrets (most types).
-# The .index connector does not have encrypted secrets so any UUID works.
-CONNECTOR_UUID=$(python3 -c "import uuid; print(str(uuid.uuid4()))" 2>/dev/null \
-  || uuidgen 2>/dev/null | tr '[:upper:]' '[:lower:]')
+# Use Node.js crypto to generate a UUID (Node is always available in CI).
+CONNECTOR_UUID=$(node -e "process.stdout.write(require('crypto').randomUUID())")
 CONNECTOR_ID="$CONNECTOR_UUID"
 
 output=$($CLI stack kb connectors post-actions-connector-id \
@@ -45,7 +44,8 @@ output=$($CLI stack kb connectors post-actions-connector-id \
   --connector-type-id ".index" \
   --name "CLI FT Index Connector" \
   --kb-config '{"index":"cli-ft-connector-*"}' \
-  --json 2>/dev/null)
+  --json 2>/dev/null) \
+  || { echo "FAIL: connectors create — command failed"; exit 1; }
 [ "$(echo "$output" | jq -r '.id')" = "$CONNECTOR_UUID" ] \
   || { echo "FAIL: connectors create — id mismatch"; exit 1; }
 [ "$(echo "$output" | jq -r '.name')" = "CLI FT Index Connector" ] \

--- a/test/functional/kb/data_views.sh
+++ b/test/functional/kb/data_views.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Functional tests for the Kibana data-views API namespace.
+# Exercises create / get / list / delete for a single data view.
+
+set -euo pipefail
+exec < /dev/null
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CLI="node $REPO_ROOT/dist/cli.js"
+
+VIEW_ID=""
+
+teardown() {
+  if [ -n "$VIEW_ID" ]; then
+    $CLI stack kb data-views delete-data-view-default --view-id "$VIEW_ID" --json >/dev/null 2>&1 || true
+  fi
+}
+trap teardown EXIT
+
+# ── create ────────────────────────────────────────────────────────────
+
+output=$(echo '{"data_view":{"title":"cli-ft-dv-*","name":"cli-ft-dv"}}' \
+  | $CLI stack kb data-views create-data-view-defaultw --json 2>/dev/null)
+VIEW_ID=$(echo "$output" | jq -r '.data_view.id')
+[ -n "$VIEW_ID" ] || { echo "FAIL: data_views create — empty id"; exit 1; }
+[ "$(echo "$output" | jq -r '.data_view.name')" = "cli-ft-dv" ] \
+  || { echo "FAIL: data_views create — name mismatch"; exit 1; }
+[ "$(echo "$output" | jq -r '.data_view.title')" = "cli-ft-dv-*" ] \
+  || { echo "FAIL: data_views create — title mismatch"; exit 1; }
+
+# ── get ───────────────────────────────────────────────────────────────
+
+output=$($CLI stack kb data-views get-data-view-default --view-id "$VIEW_ID" --json 2>/dev/null)
+[ "$(echo "$output" | jq -r '.data_view.id')" = "$VIEW_ID" ] \
+  || { echo "FAIL: data_views get — id mismatch"; exit 1; }
+[ "$(echo "$output" | jq -r '.data_view.name')" = "cli-ft-dv" ] \
+  || { echo "FAIL: data_views get — name mismatch"; exit 1; }
+
+# ── list ──────────────────────────────────────────────────────────────
+
+output=$($CLI stack kb data-views get-all-data-views-default --json 2>/dev/null)
+count=$(echo "$output" | jq '[.data_view[] | select(.id == "'"$VIEW_ID"'")] | length')
+[ "$count" -eq 1 ] || { echo "FAIL: data_views list — created view not found in list"; exit 1; }
+
+# ── delete ────────────────────────────────────────────────────────────
+
+$CLI stack kb data-views delete-data-view-default --view-id "$VIEW_ID" --json >/dev/null 2>/dev/null
+VIEW_ID=""
+
+output=$($CLI stack kb data-views get-all-data-views-default --json 2>/dev/null)
+count=$(echo "$output" | jq '[.data_view[] | select(.name == "cli-ft-dv")] | length')
+[ "$count" -eq 0 ] || { echo "FAIL: data_views delete — view still present after delete"; exit 1; }
+
+echo "PASS: kb/data_views.sh"

--- a/test/functional/kb/run.sh
+++ b/test/functional/kb/run.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Runner for Kibana functional tests.
+# Each test file is run in a subshell; failures are collected and reported.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PASSED=0
+FAILED=0
+ERRORS=""
+
+run_test() {
+  local name="$1"
+  local file="$SCRIPT_DIR/$2"
+  if OUTPUT=$(bash "$file" 2>&1); then
+    PASSED=$((PASSED + 1))
+    echo "PASS: $name"
+  else
+    FAILED=$((FAILED + 1))
+    ERRORS="$ERRORS\n  FAIL: $name"
+    echo "FAIL: $name"
+    echo "$OUTPUT" | tail -5
+  fi
+}
+
+run_test "data_views" "data_views.sh"
+run_test "spaces"     "spaces.sh"
+run_test "alerting"   "alerting.sh"
+run_test "connectors" "connectors.sh"
+
+echo ""
+echo "================================"
+echo "Results: $PASSED passed, $FAILED failed"
+if [ "$FAILED" -gt 0 ]; then
+  printf "Failures:%b\n" "$ERRORS"
+  exit 1
+fi
+echo "================================"

--- a/test/functional/kb/run.sh
+++ b/test/functional/kb/run.sh
@@ -26,10 +26,11 @@ run_test() {
   fi
 }
 
-run_test "data_views" "data_views.sh"
-run_test "spaces"     "spaces.sh"
-run_test "alerting"   "alerting.sh"
-run_test "connectors" "connectors.sh"
+run_test "data_views"   "data_views.sh"
+run_test "spaces"       "spaces.sh"
+run_test "alerting"     "alerting.sh"
+run_test "connectors"   "connectors.sh"
+run_test "saved_objects" "saved_objects.sh"
 
 echo ""
 echo "================================"

--- a/test/functional/kb/saved_objects.sh
+++ b/test/functional/kb/saved_objects.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Functional tests for the Kibana saved-objects API namespace.
+# Exercises export (ndjson response) and import (multipart/form-data request)
+# using the built-in 'config' saved-object type which is always present.
+
+set -euo pipefail
+exec < /dev/null
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CLI="node $REPO_ROOT/dist/cli.js"
+
+EXPORT_FILE="/tmp/cli-ft-so-export-$$.ndjson"
+
+teardown() {
+  rm -f "$EXPORT_FILE"
+}
+trap teardown EXIT
+
+# ── export ────────────────────────────────────────────────────────────
+# Export returns application/x-ndjson; the CLI parses it into a JSON array.
+
+output=$($CLI stack kb saved-objects post-saved-objects-export \
+  --type "config" --exclude-export-details true --json 2>/dev/null)
+
+# Response must be a non-empty JSON array.
+arr_type=$(echo "$output" | jq -r 'type')
+[ "$arr_type" = "array" ] || { echo "FAIL: saved_objects export — response is not an array (got $arr_type)"; exit 1; }
+
+count=$(echo "$output" | jq 'length')
+[ "$count" -gt 0 ] || { echo "FAIL: saved_objects export — empty array"; exit 1; }
+
+# Each element must have a type field.
+first_type=$(echo "$output" | jq -r '.[0].type')
+[ -n "$first_type" ] || { echo "FAIL: saved_objects export — first element missing type field"; exit 1; }
+
+# ── import ────────────────────────────────────────────────────────────
+# Re-serialise the JSON array back to ndjson (one compact object per line)
+# then send as multipart/form-data via --file.
+
+echo "$output" | jq -c '.[]' > "$EXPORT_FILE"
+ndjson_lines=$(wc -l < "$EXPORT_FILE" | tr -d ' ')
+[ "$ndjson_lines" -gt 0 ] || { echo "FAIL: saved_objects import — ndjson file is empty"; exit 1; }
+
+import_result=$($CLI stack kb saved-objects post-saved-objects-import \
+  --overwrite true --file "$EXPORT_FILE" --json 2>/dev/null)
+success=$(echo "$import_result" | jq -r '.success')
+[ "$success" = "true" ] || { echo "FAIL: saved_objects import — success != true (got $success)"; exit 1; }
+
+success_count=$(echo "$import_result" | jq -r '.successCount')
+[ "$success_count" -gt 0 ] || { echo "FAIL: saved_objects import — successCount = 0"; exit 1; }
+
+echo "PASS: kb/saved_objects.sh"

--- a/test/functional/kb/spaces.sh
+++ b/test/functional/kb/spaces.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Functional tests for the Kibana spaces API namespace.
+# Exercises create / get / list / delete for a non-default space.
+
+set -euo pipefail
+exec < /dev/null
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CLI="node $REPO_ROOT/dist/cli.js"
+
+SPACE_ID="cli-ft-space"
+
+teardown() {
+  $CLI stack kb spaces delete-spaces-space-id --id "$SPACE_ID" --json >/dev/null 2>&1 || true
+}
+trap teardown EXIT
+
+# ── create ────────────────────────────────────────────────────────────
+
+output=$($CLI stack kb spaces post-spaces-space \
+  --id "$SPACE_ID" --name "CLI FT Space" --description "Created by functional test" \
+  --json 2>/dev/null)
+[ "$(echo "$output" | jq -r '.id')" = "$SPACE_ID" ] \
+  || { echo "FAIL: spaces create — id mismatch"; exit 1; }
+[ "$(echo "$output" | jq -r '.name')" = "CLI FT Space" ] \
+  || { echo "FAIL: spaces create — name mismatch"; exit 1; }
+
+# ── get ───────────────────────────────────────────────────────────────
+
+output=$($CLI stack kb spaces get-spaces-space-id --id "$SPACE_ID" --json 2>/dev/null)
+[ "$(echo "$output" | jq -r '.id')" = "$SPACE_ID" ] \
+  || { echo "FAIL: spaces get — id mismatch"; exit 1; }
+[ "$(echo "$output" | jq -r '.description')" = "Created by functional test" ] \
+  || { echo "FAIL: spaces get — description mismatch"; exit 1; }
+
+# ── list ──────────────────────────────────────────────────────────────
+
+# include_authorized_purposes is required by the generated schema even though
+# the Kibana docs treat it as optional; pass false to satisfy validation.
+output=$($CLI stack kb spaces get-spaces-space --include-authorized-purposes false --json 2>/dev/null)
+count=$(echo "$output" | jq '[.[] | select(.id == "'"$SPACE_ID"'")] | length')
+[ "$count" -eq 1 ] || { echo "FAIL: spaces list — created space not found"; exit 1; }
+
+# Default space must always be present.
+default_count=$(echo "$output" | jq '[.[] | select(.id == "default")] | length')
+[ "$default_count" -eq 1 ] || { echo "FAIL: spaces list — default space missing"; exit 1; }
+
+# ── delete ────────────────────────────────────────────────────────────
+
+$CLI stack kb spaces delete-spaces-space-id --id "$SPACE_ID" --json >/dev/null 2>/dev/null
+
+output=$($CLI stack kb spaces get-spaces-space --include-authorized-purposes false --json 2>/dev/null)
+count=$(echo "$output" | jq '[.[] | select(.id == "'"$SPACE_ID"'")] | length')
+[ "$count" -eq 0 ] || { echo "FAIL: spaces delete — space still present after delete"; exit 1; }
+
+echo "PASS: kb/spaces.sh"

--- a/test/kb/kibana-client.test.ts
+++ b/test/kb/kibana-client.test.ts
@@ -52,6 +52,16 @@ function makeCapturingFetch (status = 200, body = '{}'): {
 // Constructor / auth header
 // ---------------------------------------------------------------------------
 
+describe('KibanaClient — no auth', () => {
+  it('omits Authorization header when no auth is provided', async () => {
+    const { fetch, calls } = makeCapturingFetch()
+    const client = new KibanaClient('https://kb.example.com')
+    client._testSetFetch(fetch)
+    await client.request({ method: 'GET', path: '/api/status' })
+    assert.equal((calls[0]!.init.headers as Record<string, string>)['Authorization'], undefined)
+  })
+})
+
 describe('KibanaClient — API key auth', () => {
   it('sets Authorization header to ApiKey <key>', async () => {
     const { fetch, calls } = makeCapturingFetch()
@@ -222,15 +232,11 @@ describe('getKibanaClient', () => {
     )
   })
 
-  it('throws missing_config when auth is missing api_key and credentials', () => {
+  it('returns an unauthenticated client when auth block is empty or absent', () => {
     setResolvedConfig(makeConfig({ kibana: { url: 'https://kb.example.com', auth: {} as never } }))
-    assert.throws(
-      () => getKibanaClient(),
-      (err: Error) => {
-        assert.ok(err.message.includes('missing_config'))
-        return true
-      }
-    )
+    const client = getKibanaClient()
+    assert.ok(client instanceof KibanaClient)
+    assert.equal(client.baseUrl, 'https://kb.example.com')
   })
 
   it('returns a KibanaClient instance configured with api_key auth', () => {


### PR DESCRIPTION
## Summary

Closes #219

- Adds hand-authored functional tests for 5 Kibana API namespaces: `data-views`, `spaces`, `alerting`, `connectors`, `saved-objects`
- Each test exercises the full CRUD lifecycle (create, get, list, delete / export, import) using the same `set -euo pipefail` + `elastic --json` + `jq` assertion pattern as ES functional tests
- Fixes two pre-existing bugs in `kibana-client.ts` (introduced in #195) required to make saved-objects work:
  - `application/x-ndjson` responses are now parsed line-by-line into a JSON array instead of throwing a JSON parse error
  - `multipart/form-data` requests are now sent via `FormData` (file upload) instead of `application/json`, fixing the `415 Unsupported Media Type` error from Kibana
- Adds `requestType` and `responseType` fields to `KbApiDefinition` so the request builder and client know which transport mode to use (depends on elastic/elastic-client-generator-js feat/kb-ndjson-multipart)
- Adds a Buildkite CI step (`run-kb-tests.sh`) that starts ES + Kibana Docker containers and runs the suite on Node 22 and 24
- Adds `test:functional:kb` npm script for local execution

Future optimization: https://github.com/elastic/cli/issues/280

## Test plan

- [x] All 5 tests pass locally against a live Kibana 9.3.0 (`npm run test:functional:kb`: 5 passed, 0 failed)
- [x] Generator PR (elastic-client-generator-js feat/kb-ndjson-multipart) merged first
- [ ] Buildkite KB functional tests step passes in CI