### PR TITLE
feat: namespace restructure per UX proposal (#229)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,15 +107,15 @@ For agent/LLM workflows, `serverless projects create` and `reset-credentials`
 accept `--save-as <context>` to avoid leaking admin credentials through stdout:
 
 ```bash
-elastic cloud serverless es projects create --wait --save-as scratch \
+elastic cloud serverless projects search create --wait --save-as scratch \
   --name scratch-es --region-id aws-us-east-1
 
 # stdout has endpoints + a `savedAs: scratch` marker, password is redacted.
 # The keychain now holds scratch:elasticsearch.auth.password etc.
-elastic --use-context scratch stack es indices list
+elastic --use-context scratch es indices list
 
 # Rotate creds; URL stays, only the password moves.
-elastic cloud serverless es projects reset-credentials --id <id> \
+elastic cloud serverless projects search reset-credentials --id <id> \
   --save-as scratch --force
 ```
 
@@ -235,22 +235,24 @@ elastic version
 elastic --json version
 ```
 
-### `stack` - Elastic Stack
+### `stack` / `es` / `kb` - Elastic Stack
 
-Interact with Elastic Stack components. Both `stack es` (Elasticsearch) and
-`stack kb` (Kibana) are available. Full-name aliases also work:
+Interact with Elastic Stack components. `es` and `kb` work as top-level
+shortcuts alongside the full `stack es` / `stack kb` paths:
 
 ```bash
+elastic es --help                # same as: elastic stack es --help
+elastic kb --help                # same as: elastic stack kb --help
 elastic stack --help
 elastic stack es --help          # or: elastic stack elasticsearch --help
 elastic stack kb --help          # or: elastic stack kibana --help
 ```
 
-#### `stack es` - Elasticsearch API
+#### `es` - Elasticsearch API
 
 Run Elasticsearch API calls. Commands map directly to Elasticsearch API endpoints.
 
-All `stack es` subcommands support:
+All `es` subcommands support:
 
 | Option | Description |
 |---|---|
@@ -281,28 +283,28 @@ All `stack es` subcommands support:
 - `tasks` - task management
 - `transform` - transforms
 
-**Top-level `stack es` commands** (examples):
+**Top-level `es` commands** (examples):
 
 ```bash
-elastic stack es search --index my-index
-elastic stack es get --index my-index --id abc123
-elastic stack es index --index my-index --id abc123
-elastic stack es delete --index my-index --id abc123
-elastic stack es count --index my-index
-elastic stack es info
-elastic stack es bulk
-elastic stack es reindex
-elastic stack es update --index my-index --id abc123
+elastic es search --index my-index
+elastic es get --index my-index --id abc123
+elastic es index --index my-index --id abc123
+elastic es delete --index my-index --id abc123
+elastic es count --index my-index
+elastic es info
+elastic es bulk
+elastic es reindex
+elastic es update --index my-index --id abc123
 ```
 
-Run `elastic stack es <command> --help` for all available options on any command.
+Run `elastic es <command> --help` for all available options on any command.
 
-#### `stack kb` - Kibana API
+#### `kb` - Kibana API
 
 Run Kibana API calls. Commands are organised by namespace (e.g. `data-views`,
 `cases`, `alerting`). Requires a `kibana` service block in the active context.
 
-All `stack kb` subcommands support:
+All `kb` subcommands support:
 
 | Option | Description |
 |---|---|
@@ -310,13 +312,13 @@ All `stack kb` subcommands support:
 | `--input-file <path>` | Load command input from a JSON file instead of CLI flags |
 
 ```bash
-elastic stack kb data-views list
-elastic stack kb data-views get --data-view-id <id>
-elastic stack kb cases list
-elastic stack kb alerting list-rule-types
+elastic kb data-views list
+elastic kb data-views get --data-view-id <id>
+elastic kb cases list
+elastic kb alerting list-rule-types
 ```
 
-Run `elastic stack kb <namespace> --help` for all available commands in a namespace.
+Run `elastic kb <namespace> --help` for all available commands in a namespace.
 
 ### `cloud` - Elastic Cloud
 
@@ -330,14 +332,15 @@ The tree has three kinds of children:
 - `cloud hosted …` for Hosted-Deployment APIs.
 - `cloud serverless …` for Serverless-Project APIs.
 
-#### Cross-cutting (account, auth, orgs, roles)
+#### Cross-cutting (trust, auth, orgs, users, billing)
 
 ```bash
-elastic cloud accounts get-current-account
-elastic cloud authentication get-api-keys
-elastic cloud organizations list-organizations
-elastic cloud organizations get-organization --organization-id <id>
-elastic cloud user-role-assignments add-role-assignments --user-id <id> <<< '{...}'
+elastic cloud trust get-current-account
+elastic cloud auth get-api-keys
+elastic cloud orgs list-organizations
+elastic cloud orgs get-organization --organization-id <id>
+elastic cloud users add-role-assignments --user-id <id> <<< '{...}'
+elastic cloud billing get-costs-overview
 ```
 
 #### `cloud hosted` - Hosted Deployments
@@ -348,32 +351,33 @@ elastic cloud hosted deployments get-deployment --id <id>
 elastic cloud hosted deployments shutdown-deployment --id <id>
 elastic cloud hosted deployments create-deployment <<< '{"name":"my-deployment",...}'
 elastic cloud hosted deployment-templates list-deployment-templates
+elastic cloud hosted traffic-filters get-traffic-filter-rulesets
 elastic cloud hosted extensions list-extensions
 elastic cloud hosted stack get-version-stacks
 ```
 
 Run `elastic cloud hosted --help` for all available namespace groups
-(billing-costs-analysis, deployment-templates, deployments, deployments-traffic-filter,
-extensions, stack, trusted-environments).
+(deployment-templates, deployments, traffic-filters, extensions, stack, trusted-environments).
 
 #### `cloud serverless` - Serverless Projects
 
 ```bash
-elastic cloud serverless es projects list
-elastic cloud serverless es projects create <<< '{"name":"demo","region_id":"aws-us-east-1"}'
-elastic cloud serverless es projects create --wait <<< '{"name":"demo","region_id":"aws-us-east-1"}'
-elastic cloud serverless es projects get --id <id>
-elastic cloud serverless es projects delete --id <id>
-elastic cloud serverless es projects get-status --id <id>
-elastic cloud serverless es projects get-roles --id <id>
-elastic cloud serverless es projects reset-credentials --id <id>
+elastic cloud serverless projects search list
+elastic cloud serverless projects search create <<< '{"name":"demo","region_id":"aws-us-east-1"}'
+elastic cloud serverless projects search create --wait <<< '{"name":"demo","region_id":"aws-us-east-1"}'
+elastic cloud serverless projects search get --id <id>
+elastic cloud serverless projects search delete --id <id>
+elastic cloud serverless projects search get-status --id <id>
+elastic cloud serverless projects search get-roles --id <id>
+elastic cloud serverless projects search reset-credentials --id <id>
 ```
 
-Same commands are available under `observability` and `security`:
+`search` also accepts `elasticsearch` as an alias. Same commands are available
+under `observability` and `security`:
 
 ```bash
-elastic cloud serverless observability projects list
-elastic cloud serverless security projects create --wait <<< '{"name":"demo","region_id":"aws-us-east-1"}'
+elastic cloud serverless projects observability list
+elastic cloud serverless projects security create --wait <<< '{"name":"demo","region_id":"aws-us-east-1"}'
 ```
 
 Other serverless resources:
@@ -381,6 +385,7 @@ Other serverless resources:
 ```bash
 elastic cloud serverless regions list-regions
 elastic cloud serverless traffic-filters list-traffic-filters
+elastic cloud serverless cross-project get-elasticsearch-project-link-candidates
 ```
 
 Run `elastic cloud serverless --help` for all available groups.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -80,11 +80,18 @@ program.addCommand(versionCmd)
 const { operands } = program.parseOptions(process.argv.slice(2))
 let firstArg = operands[0]
 
-// Deprecation redirect: `elastic kb ...` → `elastic stack kb ...`
-if (firstArg === 'kb') {
-  process.stderr.write('Warning: "elastic kb" is deprecated. Use "elastic stack kb" instead.\n')
-  const kbIdx = process.argv.indexOf('kb', 2)
-  if (kbIdx !== -1) process.argv.splice(kbIdx, 0, 'stack')
+// Transparent aliases: `elastic es ...` and `elastic kb ...` are first-class
+// shortcuts for `elastic stack es ...` and `elastic stack kb ...`.
+// argv is rewritten before Commander parses so all routing and dot-paths remain
+// consistent (e.g. policy entries still use `stack.es.*`).
+if (firstArg === 'es' || firstArg === 'elasticsearch') {
+  const idx = process.argv.indexOf(firstArg, 2)
+  if (idx !== -1) process.argv.splice(idx, 0, 'stack')
+  operands.splice(0, 0, 'stack')
+  firstArg = 'stack'
+} else if (firstArg === 'kb' || firstArg === 'kibana') {
+  const idx = process.argv.indexOf(firstArg, 2)
+  if (idx !== -1) process.argv.splice(idx, 0, 'stack')
   operands.splice(0, 0, 'stack')
   firstArg = 'stack'
 }
@@ -125,6 +132,17 @@ if (firstArg === 'stack') {
 } else {
   program.addCommand(defineGroup({ name: 'stack', description: 'Interact with Elastic Stack components (Elasticsearch, Kibana, Fleet)' }))
 }
+
+// Register top-level es|elasticsearch and kb|kibana stubs so they appear in
+// `elastic --help` as first-class aliases. When invoked, argv has already been
+// rewritten above so Commander routes through `stack es` / `stack kb`.
+const esAlias = defineGroup({ name: 'es', description: 'Interact with the Elasticsearch API' })
+esAlias.alias('elasticsearch')
+program.addCommand(esAlias)
+
+const kbAlias = defineGroup({ name: 'kb', description: 'Interact with the Kibana API' })
+kbAlias.alias('kibana')
+program.addCommand(kbAlias)
 
 if (firstArg === 'cloud') {
   const { registerCloudCommands } = await import('./cloud/register.ts')

--- a/src/cloud/register.ts
+++ b/src/cloud/register.ts
@@ -68,11 +68,12 @@ function queryParamToZod(q: CloudQueryParam): z.ZodType {
 
 /**
  * Maps project-type namespaces from codegen to short CLI group names.
- * E.g. `elasticsearch-projects` → `es`, used to build
- * `elastic cloud serverless es projects <action>`.
+ * E.g. `elasticsearch-projects` → `search`, used to build
+ * `elastic cloud serverless projects search <action>`.
+ * The elasticsearch type also gets an `elasticsearch` alias.
  */
 const PROJECT_NAMESPACES: Record<string, string> = {
-  'elasticsearch-projects': 'es',
+  'elasticsearch-projects': 'search',
   'observability-projects': 'observability',
   'security-projects': 'security',
 }
@@ -80,12 +81,30 @@ const PROJECT_NAMESPACES: Record<string, string> = {
 /**
  * Cross-cutting namespaces promoted to direct children of `cloud` because their APIs
  * apply to both Hosted deployments and Serverless projects.
+ * Values are the display names shown in the CLI tree.
  */
-const PROMOTED_NAMESPACES = new Set<string>([
-  'accounts',
-  'authentication',
-  'organizations',
-  'user-role-assignments',
+const PROMOTED_NAMESPACES = new Map<string, string>([
+  ['accounts',              'trust'],
+  ['authentication',        'auth'],
+  ['organizations',         'orgs'],
+  ['user-role-assignments', 'users'],
+  ['billing-costs-analysis','billing'],
+])
+
+/**
+ * Serverless namespaces whose commands are merged into a single `cross-project`
+ * group rather than exposed as two separate namespaces.
+ */
+const CROSS_PROJECT_NAMESPACES = new Set<string>([
+  'linked-projects',
+  'linked-candidate-projects',
+])
+
+/**
+ * Display name overrides for hosted namespaces.
+ */
+const HOSTED_NAMESPACE_RENAMES = new Map<string, string>([
+  ['deployments-traffic-filter', 'traffic-filters'],
 ])
 
 /**
@@ -153,22 +172,33 @@ function buildFlatLeaf (def: CloudApiDefinition): OpaqueCommandHandle {
   })
 }
 
+/**
+ * Builds flat namespace group handles.
+ * `renames` maps internal namespace keys to the display names used in the CLI tree;
+ * if a namespace is not in the map its key is used as-is.
+ */
 function buildFlatNamespaceGroups (
   defsByNamespace: Map<string, CloudApiDefinition[]>,
   descriptionPrefix: string,
+  renames: ReadonlyMap<string, string> = new Map(),
 ): OpaqueCommandHandle[] {
   const handles: OpaqueCommandHandle[] = []
   for (const [namespace, defs] of defsByNamespace) {
-    checkDuplicates(defs, namespace)
+    const displayName = renames.get(namespace) ?? namespace
+    checkDuplicates(defs, displayName)
     const leaves = defs.map(buildFlatLeaf)
     handles.push(
-      defineGroup({ name: namespace, description: `${descriptionPrefix} ${namespace} commands` }, ...leaves),
+      defineGroup({ name: displayName, description: `${descriptionPrefix} ${displayName} commands` }, ...leaves),
     )
   }
   return handles
 }
 
-function buildServerlessProjectGroup (
+/**
+ * Builds a single project-type subgroup for use inside `cloud serverless projects`.
+ * E.g. `elasticsearch-projects` → `search|elasticsearch` group with shortened action names.
+ */
+function buildServerlessTypeGroup (
   namespace: string,
   defs: CloudApiDefinition[],
 ): OpaqueCommandHandle {
@@ -201,19 +231,20 @@ function buildServerlessProjectGroup (
     return cmd
   })
 
-  const projectsGroup = defineGroup(
-    { name: 'projects', description: `Manage ${typeLabel} projects` },
+  const group = defineGroup(
+    { name: typeShort, description: `Manage ${typeLabel} projects` },
     ...leaves,
   )
-  return defineGroup(
-    { name: typeShort, description: `Elastic Serverless ${typeLabel} commands` },
-    projectsGroup,
-  )
+  // elasticsearch gets an explicit alias so both `search` and `elasticsearch` resolve
+  if (typeShort === 'search') {
+    ;(group as Command).alias('elasticsearch')
+  }
+  return group
 }
 
 function buildHostedGroup (defs: CloudApiDefinition[]): OpaqueCommandHandle {
   const byNamespace = groupByNamespace(defs)
-  const namespaceHandles = buildFlatNamespaceGroups(byNamespace, 'Cloud hosted')
+  const namespaceHandles = buildFlatNamespaceGroups(byNamespace, 'Cloud hosted', HOSTED_NAMESPACE_RENAMES)
   return defineGroup(
     { name: 'hosted', description: 'Manage Elastic Cloud Hosted deployments' },
     ...namespaceHandles,
@@ -222,22 +253,46 @@ function buildHostedGroup (defs: CloudApiDefinition[]): OpaqueCommandHandle {
 
 function buildServerlessGroup (defs: CloudApiDefinition[]): OpaqueCommandHandle {
   const projectDefs = new Map<string, CloudApiDefinition[]>()
+  const crossProjectDefs: CloudApiDefinition[] = []
   const otherDefs = new Map<string, CloudApiDefinition[]>()
 
   for (const def of defs) {
-    const target = PROJECT_NAMESPACES[def.namespace] != null ? projectDefs : otherDefs
-    let group = target.get(def.namespace)
-    if (group == null) {
-      group = []
-      target.set(def.namespace, group)
+    if (PROJECT_NAMESPACES[def.namespace] != null) {
+      let group = projectDefs.get(def.namespace)
+      if (group == null) { group = []; projectDefs.set(def.namespace, group) }
+      group.push(def)
+    } else if (CROSS_PROJECT_NAMESPACES.has(def.namespace)) {
+      crossProjectDefs.push(def)
+    } else {
+      let group = otherDefs.get(def.namespace)
+      if (group == null) { group = []; otherDefs.set(def.namespace, group) }
+      group.push(def)
     }
-    group.push(def)
   }
 
   const children: OpaqueCommandHandle[] = []
-  for (const [namespace, nsDefs] of projectDefs) {
-    children.push(buildServerlessProjectGroup(namespace, nsDefs))
+
+  // Inverted axis: cloud serverless projects <type> <action>
+  if (projectDefs.size > 0) {
+    const typeGroups: OpaqueCommandHandle[] = []
+    for (const [namespace, nsDefs] of projectDefs) {
+      typeGroups.push(buildServerlessTypeGroup(namespace, nsDefs))
+    }
+    children.push(defineGroup(
+      { name: 'projects', description: 'Manage Serverless projects' },
+      ...typeGroups,
+    ))
   }
+
+  // Merge linked-projects + linked-candidate-projects into cross-project
+  if (crossProjectDefs.length > 0) {
+    checkDuplicates(crossProjectDefs, 'cross-project')
+    children.push(defineGroup(
+      { name: 'cross-project', description: 'Serverless cross-project commands' },
+      ...crossProjectDefs.map(buildFlatLeaf),
+    ))
+  }
+
   children.push(...buildFlatNamespaceGroups(otherDefs, 'Serverless'))
 
   return defineGroup(
@@ -332,7 +387,7 @@ export function registerCloudCommands(
 
   const { promoted, hosted, serverless } = partitionDefinitions(definitions)
 
-  const promotedGroups = buildFlatNamespaceGroups(promoted, 'Cloud')
+  const promotedGroups = buildFlatNamespaceGroups(promoted, 'Cloud', PROMOTED_NAMESPACES)
   const hostedGroup = buildHostedGroup(hosted)
   const serverlessGroup = buildServerlessGroup(serverless)
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -267,13 +267,25 @@ describe('elastic CLI -- stack command tree', () => {
     }
   })
 
-  it('`elastic kb --help` redirects to stack kb with deprecation warning', async () => {
-    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-kb-deprecation-'))
+  it('`elastic kb --help` aliases to stack kb without a deprecation warning', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-kb-alias-'))
     try {
       const { code, stdout, stderr } = await runCli(['kb', '--help'], { cwd: dir, env: { HOME: dir } })
       assert.equal(code, 0, `expected exit code 0, got ${code}`)
-      assert.match(stderr, /deprecated.*elastic stack kb/i, 'expected deprecation warning on stderr')
+      assert.doesNotMatch(stderr, /deprecated/i, 'expected no deprecation warning on stderr')
       assert.match(stdout, /kb\|kibana/m, 'expected kb commands in output')
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
+  it('`elastic es --help` aliases to stack es', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-es-alias-'))
+    try {
+      const { code, stdout, stderr } = await runCli(['es', '--help'], { cwd: dir, env: { HOME: dir } })
+      assert.equal(code, 0, `expected exit code 0, got ${code}`)
+      assert.doesNotMatch(stderr, /deprecated/i, 'expected no deprecation warning on stderr')
+      assert.match(stdout, /es\|elasticsearch/m, 'expected es commands in output')
     } finally {
       await rm(dir, { recursive: true })
     }

--- a/test/cloud/register.test.ts
+++ b/test/cloud/register.test.ts
@@ -15,73 +15,91 @@ describe('registerCloudCommands', () => {
       assert.equal(group.name(), 'cloud')
     })
 
-    it('has promoted, hosted, and serverless subgroups with default definitions', () => {
+    it('has renamed promoted namespaces, hosted, and serverless subgroups', () => {
       const group = registerCloudCommands()
       const subcommands = group.commands.map((c) => c.name())
-      assert.ok(subcommands.includes('accounts'), 'should have promoted "accounts"')
-      assert.ok(subcommands.includes('authentication'), 'should have promoted "authentication"')
-      assert.ok(subcommands.includes('organizations'), 'should have promoted "organizations"')
-      assert.ok(subcommands.includes('user-role-assignments'), 'should have promoted "user-role-assignments"')
-      assert.ok(subcommands.includes('hosted'), 'should have "hosted" subgroup')
+      assert.ok(subcommands.includes('trust'),   'accounts → trust')
+      assert.ok(subcommands.includes('auth'),    'authentication → auth')
+      assert.ok(subcommands.includes('orgs'),    'organizations → orgs')
+      assert.ok(subcommands.includes('users'),   'user-role-assignments → users')
+      assert.ok(subcommands.includes('billing'), 'billing-costs-analysis promoted to billing')
+      assert.ok(subcommands.includes('hosted'),     'should have "hosted" subgroup')
       assert.ok(subcommands.includes('serverless'), 'should have "serverless" subgroup')
     })
 
     it('does not expose hosted or serverless namespaces at the top level', () => {
       const group = registerCloudCommands()
       const subcommands = group.commands.map((c) => c.name())
-      assert.ok(!subcommands.includes('deployments'), 'deployments must live under hosted')
-      assert.ok(!subcommands.includes('extensions'), 'extensions must live under hosted')
-      assert.ok(!subcommands.includes('stack'), 'stack must live under hosted')
-      assert.ok(!subcommands.includes('regions'), 'regions must live under serverless')
-      assert.ok(!subcommands.includes('traffic-filters'), 'traffic-filters must live under serverless')
-      assert.ok(!subcommands.includes('elasticsearch-projects'), 'elasticsearch-projects must live under serverless es')
+      assert.ok(!subcommands.includes('deployments'),          'deployments must live under hosted')
+      assert.ok(!subcommands.includes('extensions'),           'extensions must live under hosted')
+      assert.ok(!subcommands.includes('stack'),                'stack must live under hosted')
+      assert.ok(!subcommands.includes('regions'),              'regions must live under serverless')
+      assert.ok(!subcommands.includes('traffic-filters'),      'traffic-filters must live under serverless')
+      assert.ok(!subcommands.includes('elasticsearch-projects'),'elasticsearch-projects must live under serverless')
+      // old names must not appear
+      assert.ok(!subcommands.includes('accounts'),             'old name accounts must not appear')
+      assert.ok(!subcommands.includes('authentication'),       'old name authentication must not appear')
+      assert.ok(!subcommands.includes('organizations'),        'old name organizations must not appear')
+      assert.ok(!subcommands.includes('user-role-assignments'),'old name user-role-assignments must not appear')
+      assert.ok(!subcommands.includes('billing-costs-analysis'),'raw billing-costs-analysis must not appear')
     })
   })
 
   describe('promoted namespaces (cloud level)', () => {
-    it('accounts has its codegen command names preserved', () => {
+    it('trust (was: accounts) has its codegen command names preserved', () => {
       const group = registerCloudCommands()
-      const accountsGroup = group.commands.find((c) => c.name() === 'accounts')!
-      const leafNames = accountsGroup.commands.map((c) => c.name())
+      const trustGroup = group.commands.find((c) => c.name() === 'trust')!
+      const leafNames = trustGroup.commands.map((c) => c.name())
       assert.ok(leafNames.includes('get-current-account'))
       assert.ok(leafNames.includes('update-current-account'))
     })
 
-    it('organizations has its codegen command names preserved', () => {
+    it('orgs (was: organizations) has its codegen command names preserved', () => {
       const group = registerCloudCommands()
-      const orgsGroup = group.commands.find((c) => c.name() === 'organizations')!
+      const orgsGroup = group.commands.find((c) => c.name() === 'orgs')!
       const leafNames = orgsGroup.commands.map((c) => c.name())
       assert.ok(leafNames.includes('list-organizations'))
       assert.ok(leafNames.includes('get-organization'))
     })
 
-    it('promoted synthetic defs are lifted out of hosted', () => {
+    it('billing (was: billing-costs-analysis) is promoted to top-level cloud', () => {
+      const group = registerCloudCommands()
+      const billing = group.commands.find((c) => c.name() === 'billing')!
+      assert.ok(billing != null, 'billing must exist at top level')
+      const leafNames = billing.commands.map((c) => c.name())
+      assert.ok(leafNames.length > 0, 'billing must have commands')
+    })
+
+    it('promoted synthetic defs are lifted out of hosted with new display names', () => {
       const defs: CloudApiDefinition[] = [
         { name: 'get-current-account', namespace: 'accounts', description: 'Get', method: 'GET', path: '/api/v1/account' },
         { name: 'list-deployments', namespace: 'deployments', description: 'List', method: 'GET', path: '/api/v1/deployments' },
       ]
       const group = registerCloudCommands(defs)
       const top = group.commands.map((c) => c.name())
-      assert.ok(top.includes('accounts'))
+      assert.ok(top.includes('trust'))
       assert.ok(top.includes('hosted'))
       const hostedChildren = group.commands.find((c) => c.name() === 'hosted')!.commands.map((c) => c.name())
+      assert.ok(!hostedChildren.includes('trust'),    'trust must not appear under hosted')
       assert.ok(!hostedChildren.includes('accounts'), 'accounts must not appear under hosted')
       assert.ok(hostedChildren.includes('deployments'))
     })
   })
 
   describe('hosted subgroup', () => {
-    it('contains hosted-specific namespaces', () => {
+    it('contains hosted-specific namespaces with renames applied', () => {
       const group = registerCloudCommands()
       const hosted = group.commands.find((c) => c.name() === 'hosted')!
       const namespaces = hosted.commands.map((c) => c.name())
       assert.ok(namespaces.includes('deployments'))
       assert.ok(namespaces.includes('deployment-templates'))
-      assert.ok(namespaces.includes('deployments-traffic-filter'))
+      assert.ok(namespaces.includes('traffic-filters'),      'deployments-traffic-filter → traffic-filters')
+      assert.ok(!namespaces.includes('deployments-traffic-filter'), 'old name must not appear')
       assert.ok(namespaces.includes('extensions'))
       assert.ok(namespaces.includes('stack'))
       assert.ok(namespaces.includes('trusted-environments'))
-      assert.ok(namespaces.includes('billing-costs-analysis'))
+      assert.ok(!namespaces.includes('billing-costs-analysis'), 'billing promoted to top-level cloud')
+      assert.ok(!namespaces.includes('billing'),               'billing must not appear under hosted')
     })
 
     it('does not contain promoted namespaces', () => {
@@ -89,9 +107,13 @@ describe('registerCloudCommands', () => {
       const hosted = group.commands.find((c) => c.name() === 'hosted')!
       const namespaces = hosted.commands.map((c) => c.name())
       assert.ok(!namespaces.includes('accounts'))
+      assert.ok(!namespaces.includes('trust'))
       assert.ok(!namespaces.includes('authentication'))
+      assert.ok(!namespaces.includes('auth'))
       assert.ok(!namespaces.includes('organizations'))
+      assert.ok(!namespaces.includes('orgs'))
       assert.ok(!namespaces.includes('user-role-assignments'))
+      assert.ok(!namespaces.includes('users'))
     })
 
     it('deployments namespace has list, get, and shutdown commands', () => {
@@ -106,44 +128,84 @@ describe('registerCloudCommands', () => {
   })
 
   describe('serverless subgroup', () => {
-    it('contains project-type groups and flat serverless namespaces', () => {
+    it('has inverted axis: projects group containing search|elasticsearch, observability, security', () => {
       const group = registerCloudCommands()
       const serverless = group.commands.find((c) => c.name() === 'serverless')!
       const namespaces = serverless.commands.map((c) => c.name())
-      assert.ok(namespaces.includes('es'), 'should have "es" project-type group')
-      assert.ok(namespaces.includes('observability'))
-      assert.ok(namespaces.includes('security'))
+      assert.ok(namespaces.includes('projects'),       'should have top-level projects group')
+      assert.ok(namespaces.includes('cross-project'),  'should have cross-project group')
       assert.ok(namespaces.includes('regions'))
       assert.ok(namespaces.includes('traffic-filters'))
+      // old flat project-type groups must not exist at serverless level
+      assert.ok(!namespaces.includes('es'),            'es must be inside projects now')
+      assert.ok(!namespaces.includes('observability'), 'observability must be inside projects now')
+      assert.ok(!namespaces.includes('security'),      'security must be inside projects now')
+      assert.ok(!namespaces.includes('linked-projects'),           'merged into cross-project')
+      assert.ok(!namespaces.includes('linked-candidate-projects'), 'merged into cross-project')
     })
 
-    it('es projects has CRUD commands with short names', () => {
+    it('projects group has search|elasticsearch, observability, and security type groups', () => {
       const group = registerCloudCommands()
       const projects = group.commands.find((c) => c.name() === 'serverless')!
-        .commands.find((c) => c.name() === 'es')!
         .commands.find((c) => c.name() === 'projects')!
-      const leafNames = projects.commands.map((c) => c.name())
-      assert.ok(leafNames.includes('list'), 'should have list')
-      assert.ok(leafNames.includes('create'), 'should have create')
-      assert.ok(leafNames.includes('get'), 'should have get')
-      assert.ok(leafNames.includes('delete'), 'should have delete')
-      assert.ok(leafNames.includes('patch'), 'should have patch')
-      assert.ok(leafNames.includes('resume'), 'should have resume')
+      const typeNames = projects.commands.map((c) => c.name())
+      assert.ok(typeNames.includes('search'),       'should have search (was: es)')
+      assert.ok(typeNames.includes('observability'))
+      assert.ok(typeNames.includes('security'))
+    })
+
+    it('search type has elasticsearch alias', () => {
+      const group = registerCloudCommands()
+      const search = group.commands.find((c) => c.name() === 'serverless')!
+        .commands.find((c) => c.name() === 'projects')!
+        .commands.find((c) => c.name() === 'search')!
+      assert.ok((search as unknown as { aliases(): string[] }).aliases().includes('elasticsearch'))
+    })
+
+    it('search type has CRUD commands with short names', () => {
+      const group = registerCloudCommands()
+      const search = group.commands.find((c) => c.name() === 'serverless')!
+        .commands.find((c) => c.name() === 'projects')!
+        .commands.find((c) => c.name() === 'search')!
+      const leafNames = search.commands.map((c) => c.name())
+      assert.ok(leafNames.includes('list'))
+      assert.ok(leafNames.includes('create'))
+      assert.ok(leafNames.includes('get'))
+      assert.ok(leafNames.includes('delete'))
+      assert.ok(leafNames.includes('patch'))
+      assert.ok(leafNames.includes('resume'))
       assert.ok(leafNames.includes('get-status'))
       assert.ok(leafNames.includes('get-roles'))
       assert.ok(leafNames.includes('reset-credentials'))
     })
 
-    it('restructures synthetic project defs under serverless > <type> > projects', () => {
+    it('restructures synthetic project defs under serverless > projects > <type>', () => {
       const defs: CloudApiDefinition[] = [
         { name: 'list-observability-projects', namespace: 'observability-projects', description: 'List', method: 'GET', path: '/api/v1/serverless/projects/observability' },
         { name: 'get-observability-project', namespace: 'observability-projects', description: 'Get', method: 'GET', path: '/api/v1/serverless/projects/observability/{id}', pathParams: [{ name: 'id', description: 'ID', required: true }] },
       ]
       const group = registerCloudCommands(defs)
-      const projects = group.commands.find((c) => c.name() === 'serverless')!
-        .commands.find((c) => c.name() === 'observability')!
+      const observability = group.commands.find((c) => c.name() === 'serverless')!
         .commands.find((c) => c.name() === 'projects')!
-      assert.deepEqual(projects.commands.map((c) => c.name()), ['list', 'get'])
+        .commands.find((c) => c.name() === 'observability')!
+      assert.deepEqual(observability.commands.map((c) => c.name()), ['list', 'get'])
+    })
+
+    it('merges linked-projects and linked-candidate-projects into cross-project', () => {
+      const defs: CloudApiDefinition[] = [
+        { name: 'get-elasticsearch-project-can-delete', namespace: 'linked-projects', description: 'Can delete', method: 'GET', path: '/api/v1/serverless/projects/elasticsearch/{id}/can-delete', pathParams: [{ name: 'id', description: 'ID', required: true }] },
+        { name: 'get-elasticsearch-project-link-candidates', namespace: 'linked-candidate-projects', description: 'Candidates', method: 'GET', path: '/api/v1/serverless/link-candidates/elasticsearch' },
+      ]
+      const group = registerCloudCommands(defs)
+      const serverless = group.commands.find((c) => c.name() === 'serverless')!
+      const namespaces = serverless.commands.map((c) => c.name())
+      assert.ok(namespaces.includes('cross-project'), 'cross-project group must exist')
+      assert.ok(!namespaces.includes('linked-projects'))
+      assert.ok(!namespaces.includes('linked-candidate-projects'))
+      const crossProject = serverless.commands.find((c) => c.name() === 'cross-project')!
+      const leafNames = crossProject.commands.map((c) => c.name())
+      assert.ok(leafNames.includes('get-elasticsearch-project-can-delete'))
+      assert.ok(leafNames.includes('get-elasticsearch-project-link-candidates'))
     })
 
     it('keeps non-project serverless namespaces flat with codegen names', () => {
@@ -163,11 +225,11 @@ describe('registerCloudCommands', () => {
         { name: 'list-elasticsearch-projects', namespace: 'elasticsearch-projects', description: 'List', method: 'GET', path: '/api/v1/serverless/projects/elasticsearch' },
       ]
       const group = registerCloudCommands(defs)
-      const projects = group.commands.find((c) => c.name() === 'serverless')!
-        .commands.find((c) => c.name() === 'es')!
+      const search = group.commands.find((c) => c.name() === 'serverless')!
         .commands.find((c) => c.name() === 'projects')!
-      const createCmd = projects.commands.find((c) => c.name() === 'create')!
-      const listCmd = projects.commands.find((c) => c.name() === 'list')!
+        .commands.find((c) => c.name() === 'search')!
+      const createCmd = search.commands.find((c) => c.name() === 'create')!
+      const listCmd = search.commands.find((c) => c.name() === 'list')!
       assert.ok(createCmd.options.map((o) => o.long).includes('--wait'))
       assert.ok(!listCmd.options.map((o) => o.long).includes('--wait'))
     })
@@ -198,19 +260,31 @@ describe('registerCloudCommands', () => {
     })
   })
 
-  describe('default command aliases', () => {
-    it('no commands have aliases', () => {
+  describe('command aliases', () => {
+    it('search type group has elasticsearch alias, all others have no aliases', () => {
       const group = registerCloudCommands()
       interface CommandNode {
         name(): string
         aliases(): string[]
         commands: CommandNode[]
       }
-      const visit = (cmd: CommandNode): void => {
-        assert.deepEqual(cmd.aliases(), [], `${cmd.name()} should have no alias`)
-        for (const child of cmd.commands) visit(child)
+      const issues: string[] = []
+      const visit = (cmd: CommandNode, path: string): void => {
+        const aliases = cmd.aliases()
+        const isSearchGroup = path === 'cloud.serverless.projects.search'
+        if (isSearchGroup) {
+          if (!aliases.includes('elasticsearch')) {
+            issues.push(`${path} should have alias 'elasticsearch'`)
+          }
+        } else if (aliases.length > 0) {
+          issues.push(`${path} should have no alias but has: ${aliases.join(', ')}`)
+        }
+        for (const child of cmd.commands) visit(child, `${path}.${child.name()}`)
       }
-      for (const child of group.commands as unknown as CommandNode[]) visit(child)
+      for (const child of group.commands as unknown as CommandNode[]) {
+        visit(child, `cloud.${child.name()}`)
+      }
+      assert.deepEqual(issues, [])
     })
   })
 })


### PR DESCRIPTION
## Summary

Full implementation of the UX proposal from #229.

### `elastic es` / `elastic kb` top-level aliases

- `elastic es ...` and `elastic kb ...` are now first-class shortcuts — no deprecation warning
- Both appear in `elastic --help` as `es|elasticsearch` and `kb|kibana`
- `elastic stack es` / `elastic stack kb` continue to work unchanged
- `stack` is kept as a grouping concept for future `stack fleet`, `stack apm`, etc.

### Cloud namespace renames

| Old | New |
|---|---|
| `cloud accounts` | `cloud trust` |
| `cloud authentication` | `cloud auth` |
| `cloud organizations` | `cloud orgs` |
| `cloud user-role-assignments` | `cloud users` |
| `cloud hosted billing-costs-analysis` | `cloud billing` (promoted to top-level) |
| `cloud hosted deployments-traffic-filter` | `cloud hosted traffic-filters` |

### Cloud serverless restructure

Axis inverted from `cloud serverless <type> projects <action>` to `cloud serverless projects <type> <action>`:

```
cloud serverless projects
├── search|elasticsearch   (was: cloud serverless es projects)
├── observability          (was: cloud serverless observability projects)
└── security               (was: cloud serverless security projects)
```

`linked-projects` and `linked-candidate-projects` merged into `cloud serverless cross-project`.

## Test plan

- [x] `elastic --help` shows `es|elasticsearch`, `kb|kibana`, `stack`, `cloud` at top level
- [x] `elastic es search` routes correctly, no deprecation warning
- [x] `elastic cloud --help` shows `trust`, `auth`, `orgs`, `users`, `billing`, `hosted`, `serverless`
- [x] `elastic cloud hosted --help` shows `traffic-filters` (not `deployments-traffic-filter`), no `billing-costs-analysis`
- [x] `elastic cloud serverless --help` shows `projects`, `cross-project`, `regions`, `traffic-filters`
- [x] `elastic cloud serverless projects --help` shows `search|elasticsearch`, `observability`, `security`
- [x] All existing tests updated and passing (1090 pass)

Closes #229