### PR TITLE
fix: keep NOTICE.txt accurate in Renovate PRs and local dev (#252)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,10 @@
+#!/bin/sh
+# Regenerate NOTICE.txt whenever package.json or package-lock.json is staged.
+# This keeps the file accurate for both manual dependency bumps and automated
+# tool runs (e.g. `npm install`) that stage lockfile changes.
+
+if git diff --cached --name-only | grep -qE '^package(-lock)?\.json$'; then
+  echo "package.json or package-lock.json changed — regenerating NOTICE.txt..."
+  node scripts/generate-notice.mjs
+  git add NOTICE.txt
+fi

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "packages/*"
   ],
   "scripts": {
+    "prepare": "git config core.hooksPath .githooks || true",
     "build": "node --max-old-space-size=6144 node_modules/typescript/bin/tsc -b",
     "test": "npm run build && npm run test:unit && npm run test:license",
     "test:unit": "node --import tsx/esm --test --experimental-test-coverage --test-coverage-lines=90 --test-coverage-branches=90 --test-coverage-functions=90 --test-coverage-include='src/**/*.ts' --test-coverage-include='packages/*/src/**/*.ts' --test-coverage-exclude='src/cloud/apis/**' --test-coverage-exclude='src/es/apis.ts' --test-coverage-exclude='src/es/api-manifest.ts' --test-coverage-exclude='src/es/apis/**' --test-coverage-exclude='src/cloud/apis.ts' --test-coverage-exclude='src/cloud/serverless-apis.ts' --test-coverage-exclude='node_modules/**'",

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>elastic/renovate-config"
-  ]
+  ],
+  "postUpgradeTasks": {
+    "commands": ["node scripts/generate-notice.mjs"],
+    "fileFilters": ["NOTICE.txt"],
+    "executionMode": "branch"
+  }
 }


### PR DESCRIPTION
Renovate PRs were failing the notice-file CI check because NOTICE.txt was not regenerated when dependencies changed.

Three-part fix:
- renovate.json: add postUpgradeTasks so the Renovate bot runs `node scripts/generate-notice.mjs` after any dep update and includes the refreshed NOTICE.txt in the same PR commit.
- .githooks/pre-commit: regenerate NOTICE.txt automatically whenever package.json or package-lock.json is staged during a local commit.
- package.json `prepare` script: runs `git config core.hooksPath .githooks` after `npm install` so the hook is active without any manual setup.

closes https://github.com/elastic/cli/issues/252