### PR TITLE
feat(helpers): add watch command to stream new documents from an index

### DIFF
--- a/src/es/helpers/register.ts
+++ b/src/es/helpers/register.ts
@@ -8,11 +8,12 @@ import type { OpaqueCommandHandle } from '../../factory.ts'
 import { createScrollSearchCommand } from './scroll-search.ts'
 import { createBulkIngestCommand } from './bulk-ingest.ts'
 import { createMsearchCommand } from './msearch.ts'
+import { createWatchCommand } from './watch.ts'
 
 /**
  * Registers all high-level helper commands under a `helpers` group.
  * Helper commands provide convenience abstractions over common Elasticsearch
- * workflows (bulk ingestion, scroll search, multi-search batching).
+ * workflows (bulk ingestion, scroll search, multi-search batching, live watching).
  *
  * @returns an `OpaqueCommandHandle` for the `helpers` group
  */
@@ -21,6 +22,7 @@ export function registerHelperCommands (): OpaqueCommandHandle {
     { name: 'helpers', description: 'High-level helper commands for common Elasticsearch workflows' },
     createScrollSearchCommand(),
     createBulkIngestCommand(),
-    createMsearchCommand()
+    createMsearchCommand(),
+    createWatchCommand()
   )
 }

--- a/src/es/helpers/watch.ts
+++ b/src/es/helpers/watch.ts
@@ -1,0 +1,250 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from 'zod'
+import type { Transport } from '@elastic/transport'
+import { defineCommand } from '../../factory.ts'
+import type { OpaqueCommandHandle, JsonValue } from '../../factory.ts'
+import { getTransport } from '../../lib/transport.ts'
+import { missingConfigError, transportError } from '../errors.ts'
+import { readRawInput } from './shared.ts'
+
+interface SearchHit {
+  _source?: Record<string, unknown>
+  _id?: string
+  sort?: unknown[]
+}
+
+interface SearchResponse {
+  hits?: {
+    hits?: SearchHit[]
+  }
+}
+
+/** Dependencies injectable for testing. */
+export interface WatchDeps {
+  getTransport: () => Transport
+  stdout: { write: (chunk: string) => boolean }
+  stderr: { write: (chunk: string) => boolean }
+  sleep: (ms: number) => Promise<void>
+  onSignal: (signal: string, handler: () => void) => void
+  offSignal: (signal: string, handler: () => void) => void
+}
+
+const defaultDeps: WatchDeps = {
+  getTransport,
+  stdout: process.stdout,
+  stderr: process.stderr,
+  sleep: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  onSignal: (signal, handler) => process.on(signal, handler),
+  offSignal: (signal, handler) => process.off(signal, handler),
+}
+
+const inputSchema = z.object({
+  index: z.string().describe('Index or data stream to watch'),
+  query: z.string().optional().describe('Query DSL clause as JSON (wrapped under "query"), e.g. \'{"match":{"log.level":"error"}}\''),
+  query_file: z.string().optional().describe('Path to a file containing the full search body JSON'),
+  sort_field: z.string().default('@timestamp').describe('Field to use for ordering and detecting new documents'),
+  poll_interval: z.number().default(5000).describe('Polling interval in milliseconds'),
+  from: z.string().optional().describe('ISO 8601 timestamp to start from (e.g. "2024-01-01T00:00:00Z"). Defaults to the most recent document.'),
+  size: z.number().default(100).describe('Maximum documents to fetch per poll'),
+  format: z.string().optional().describe('Output template with {field} placeholders, e.g. "{@timestamp} {message}". Omit for NDJSON (_source as JSON).'),
+})
+
+/** Resolves a dotted field path against an object, e.g. "log.level" → obj.log.level. */
+function getNestedField (obj: Record<string, unknown>, path: string): unknown {
+  return path.split('.').reduce<unknown>((cur, key) => {
+    if (cur != null && typeof cur === 'object' && !Array.isArray(cur)) {
+      return (cur as Record<string, unknown>)[key]
+    }
+    return undefined
+  }, obj)
+}
+
+/** Render a `{field}` template against a document's _source. */
+export function applyTemplate (template: string, source: Record<string, unknown>): string {
+  return template.replace(/\{([^}]+)\}/g, (_, path: string) => {
+    const val = getNestedField(source, path.trim())
+    return val != null ? String(val) : `{${path}}`
+  })
+}
+
+/**
+ * Builds the search body for a watch poll.
+ *
+ * On the very first request (no searchAfter cursor yet) and when `--from` was given,
+ * a range filter is added so we skip documents older than the anchor timestamp.
+ * Once we have a cursor the sort+search_after mechanism prevents duplicates on its own.
+ */
+function buildSearchBody (
+  baseQueryBody: Record<string, unknown>,
+  sortField: string,
+  size: number,
+  searchAfter: unknown[] | undefined,
+  fromTimestamp: string | undefined,
+): Record<string, unknown> {
+  let queryClause: Record<string, unknown>
+
+  if (searchAfter == null && fromTimestamp != null) {
+    // Initial request with a --from anchor: wrap with a range filter.
+    const rangeFilter = { range: { [sortField]: { gt: fromTimestamp } } }
+    const existingQuery = baseQueryBody.query
+    if (existingQuery != null) {
+      queryClause = { query: { bool: { must: existingQuery, filter: rangeFilter } } }
+    } else {
+      queryClause = { query: rangeFilter }
+    }
+  } else {
+    queryClause = baseQueryBody.query != null ? { query: baseQueryBody.query } : {}
+  }
+
+  const body: Record<string, unknown> = {
+    ...baseQueryBody,
+    ...queryClause,
+    sort: [{ [sortField]: 'asc' }, { _id: 'asc' }],
+    size,
+  }
+
+  if (searchAfter != null) {
+    body.search_after = searchAfter
+  }
+
+  return body
+}
+
+function createWatchHandler (deps: WatchDeps = defaultDeps) {
+  return async (parsed: { input?: z.infer<typeof inputSchema>; options: Record<string, string | number | boolean> }): Promise<JsonValue> => {
+    const { index, query, query_file, sort_field, poll_interval, from, size, format } = parsed.input!
+
+    let transport: Transport
+    try {
+      transport = deps.getTransport()
+    } catch (err) {
+      return missingConfigError(err)
+    }
+
+    // Parse the base query body.
+    let baseQueryBody: Record<string, unknown> = {}
+    try {
+      if (query != null) {
+        baseQueryBody = { query: JSON.parse(query) as Record<string, unknown> }
+      } else if (query_file != null) {
+        const raw = readRawInput(query_file)
+        if (raw != null && raw.trim().length > 0) {
+          baseQueryBody = JSON.parse(raw) as Record<string, unknown>
+        }
+      }
+    } catch (err) {
+      return {
+        error: {
+          code: 'input_error',
+          message: `Failed to parse query: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      }
+    }
+
+    const encodedIndex = encodeURIComponent(index)
+
+    // Determine the starting cursor.
+    //   --from <ts>  → range-filter on the first request, then switch to search_after.
+    //   (default)    → find the most recent document and use its sort values as the cursor.
+    let searchAfter: unknown[] | undefined
+    let fromTimestamp: string | undefined
+
+    if (from != null) {
+      fromTimestamp = from
+      deps.stderr.write(`Watching ${index} from ${from}. Polling every ${poll_interval}ms...\n`)
+    } else {
+      // Anchor to the most recent document so we only see documents created after now.
+      try {
+        const anchorResult = await transport.request<SearchResponse>({
+          method: 'POST',
+          path: `/${encodedIndex}/_search`,
+          body: {
+            ...baseQueryBody,
+            sort: [{ [sort_field]: 'desc' }, { _id: 'desc' }],
+            size: 1,
+          },
+        })
+        const lastHit = anchorResult.hits?.hits?.[0]
+        if (lastHit?.sort != null) {
+          searchAfter = lastHit.sort
+          deps.stderr.write(`Watching ${index} from the most recent document. Polling every ${poll_interval}ms...\n`)
+        } else {
+          deps.stderr.write(`Watching ${index} from now (index is empty). Polling every ${poll_interval}ms...\n`)
+        }
+      } catch (err) {
+        return transportError(err)
+      }
+    }
+
+    deps.stderr.write('Press Ctrl+C to stop.\n')
+
+    let running = true
+    let totalDocs = 0
+    const startTime = Date.now()
+
+    const stopHandler = () => { running = false }
+    deps.onSignal('SIGINT', stopHandler)
+
+    try {
+      while (running) {
+        try {
+          const body = buildSearchBody(baseQueryBody, sort_field, size, searchAfter, fromTimestamp)
+          const result = await transport.request<SearchResponse>({
+            method: 'POST',
+            path: `/${encodedIndex}/_search`,
+            body,
+          })
+
+          const hits = result.hits?.hits ?? []
+
+          for (const hit of hits) {
+            if (!running) break
+            const source = (hit._source ?? {}) as Record<string, unknown>
+            if (format != null) {
+              deps.stdout.write(applyTemplate(format, source) + '\n')
+            } else {
+              deps.stdout.write(JSON.stringify(source) + '\n')
+            }
+            totalDocs++
+          }
+
+          // Advance the cursor to the last returned document.
+          const lastHit = hits[hits.length - 1]
+          if (lastHit?.sort != null) {
+            searchAfter = lastHit.sort
+            fromTimestamp = undefined // cursor takes over; range filter no longer needed
+          }
+
+          // If we got a full page there may be more waiting — skip the sleep and poll again.
+          if (running && hits.length < size) {
+            await deps.sleep(poll_interval)
+          }
+        } catch (err) {
+          if (!running) break
+          deps.stderr.write(`Poll error: ${err instanceof Error ? err.message : String(err)}\n`)
+          await deps.sleep(poll_interval)
+        }
+      }
+    } finally {
+      deps.offSignal('SIGINT', stopHandler)
+    }
+
+    const elapsed_ms = Date.now() - startTime
+    deps.stderr.write(`\nStreamed ${totalDocs} documents from ${index} in ${Math.round(elapsed_ms / 1000)}s.\n`)
+    return { total_docs: totalDocs, elapsed_ms }
+  }
+}
+
+export function createWatchCommand (deps?: WatchDeps): OpaqueCommandHandle {
+  return defineCommand({
+    name: 'watch',
+    description: 'Watch an index for new documents and stream them to stdout as NDJSON.',
+    input: inputSchema,
+    handler: createWatchHandler(deps),
+    formatOutput: () => '',
+  })
+}

--- a/test/es/helpers/watch.test.ts
+++ b/test/es/helpers/watch.test.ts
@@ -1,0 +1,430 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import type { Transport, TransportRequestParams } from '@elastic/transport'
+import { createWatchCommand, applyTemplate } from '../../../src/es/helpers/watch.ts'
+import type { WatchDeps } from '../../../src/es/helpers/watch.ts'
+import { Command } from 'commander'
+import { _testSetStdinReader } from '../../../src/factory.ts'
+
+// ---------------------------------------------------------------------------
+// Test infrastructure
+// ---------------------------------------------------------------------------
+
+interface MockHit {
+  _source: Record<string, unknown>
+  sort?: unknown[]
+}
+
+interface MockResponse {
+  hits?: { hits?: MockHit[] }
+}
+
+/**
+ * Builds a mock Transport from a queue of responses.  Each `request()` call
+ * dequeues the next item; after the queue is exhausted every call returns an
+ * empty hit list so polls stop producing results.
+ */
+function mockTransport (responses: MockResponse[]): {
+  transport: Transport
+  requests: Array<{ params: TransportRequestParams }>
+} {
+  const requests: Array<{ params: TransportRequestParams }> = []
+  let callIndex = 0
+  const transport = {
+    request: async (params: TransportRequestParams) => {
+      requests.push({ params })
+      const resp = responses[callIndex] ?? { hits: { hits: [] } }
+      callIndex++
+      return resp
+    },
+  } as unknown as Transport
+  return { transport, requests }
+}
+
+function captureOutput () {
+  const stdoutChunks: string[] = []
+  const stderrChunks: string[] = []
+  return {
+    stdout: {
+      chunks: stdoutChunks,
+      write: (s: string) => { stdoutChunks.push(s); return true },
+    },
+    stderr: {
+      chunks: stderrChunks,
+      write: (s: string) => { stderrChunks.push(s); return true },
+    },
+  }
+}
+
+/** Builds a WatchDeps where `sleep` resolves immediately and signals are controllable. */
+function makeDeps (
+  transport: Transport,
+  io = captureOutput(),
+  opts: { stopAfterPolls?: number } = {},
+): WatchDeps & { io: ReturnType<typeof captureOutput> } {
+  let pollCount = 0
+  const stopAfter = opts.stopAfterPolls ?? 1
+  const signalHandlers = new Map<string, (() => void)[]>()
+
+  return {
+    io,
+    getTransport: () => transport,
+    stdout: io.stdout,
+    stderr: io.stderr,
+    sleep: async () => {
+      pollCount++
+      if (pollCount >= stopAfter) {
+        // Trigger SIGINT to stop the watch loop after the configured number of sleeps.
+        for (const h of signalHandlers.get('SIGINT') ?? []) h()
+      }
+    },
+    onSignal: (signal, handler) => {
+      const list = signalHandlers.get(signal) ?? []
+      list.push(handler)
+      signalHandlers.set(signal, list)
+    },
+    offSignal: (signal, handler) => {
+      const list = (signalHandlers.get(signal) ?? []).filter((h) => h !== handler)
+      signalHandlers.set(signal, list)
+    },
+  }
+}
+
+async function runCommand (
+  args: string[],
+  deps: WatchDeps,
+): Promise<{ stdout: string[]; stderr: string[] }> {
+  const cmd = createWatchCommand(deps)
+  const program = new Command()
+  program.exitOverride()
+  program.addCommand(cmd)
+
+  const restoreStdin = _testSetStdinReader(() => '')
+  try {
+    await program.parseAsync(['node', 'test', 'watch', ...args])
+  } finally {
+    restoreStdin()
+    process.exitCode = 0
+  }
+
+  return {
+    stdout: (deps.stdout as { chunks: string[] }).chunks ?? [],
+    stderr: (deps.stderr as { chunks: string[] }).chunks ?? [],
+  }
+}
+
+// ---------------------------------------------------------------------------
+// applyTemplate unit tests
+// ---------------------------------------------------------------------------
+
+describe('applyTemplate', () => {
+  it('substitutes top-level fields', () => {
+    assert.equal(applyTemplate('{message}', { message: 'hello' }), 'hello')
+  })
+
+  it('substitutes nested fields using dot notation', () => {
+    assert.equal(
+      applyTemplate('{log.level}', { log: { level: 'error' } }),
+      'error',
+    )
+  })
+
+  it('leaves placeholder intact when field is missing', () => {
+    assert.equal(applyTemplate('{missing}', {}), '{missing}')
+  })
+
+  it('handles multiple placeholders in one template', () => {
+    assert.equal(
+      applyTemplate('{ts} [{level}] {msg}', { ts: '2024-01-01', level: 'info', msg: 'ok' }),
+      '2024-01-01 [info] ok',
+    )
+  })
+
+  it('coerces non-string values to string', () => {
+    assert.equal(applyTemplate('{count}', { count: 42 }), '42')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// createWatchCommand tests
+// ---------------------------------------------------------------------------
+
+describe('watch command', () => {
+  it('creates a command named watch', () => {
+    const { transport } = mockTransport([])
+    const cmd = createWatchCommand(makeDeps(transport))
+    assert.equal(cmd.name(), 'watch')
+  })
+
+  it('performs an anchor search before the first poll', async () => {
+    const io = captureOutput()
+    const { transport, requests } = mockTransport([
+      // Anchor: most recent doc
+      { hits: { hits: [{ _source: { id: 0 }, sort: ['2024-01-01T00:00:00Z', 'id0'] }] } },
+      // First poll: one new doc
+      { hits: { hits: [{ _source: { id: 1 }, sort: ['2024-01-02T00:00:00Z', 'id1'] }] } },
+    ])
+
+    const deps = makeDeps(transport, io, { stopAfterPolls: 1 })
+    await runCommand(['--index', 'my-index'], deps)
+
+    // First request is the anchor (sort desc, size 1)
+    const anchorReq = requests[0]!.params.body as Record<string, unknown>
+    const sortArr = anchorReq.sort as Array<Record<string, string>>
+    assert.equal(sortArr[0]!['@timestamp'], 'desc', 'anchor should sort descending')
+    assert.equal(anchorReq.size, 1)
+
+    // Second request is the poll (sort asc with search_after)
+    const pollReq = requests[1]!.params.body as Record<string, unknown>
+    assert.deepEqual(pollReq.search_after, ['2024-01-01T00:00:00Z', 'id0'])
+    const pollSort = pollReq.sort as Array<Record<string, string>>
+    assert.equal(pollSort[0]!['@timestamp'], 'asc')
+  })
+
+  it('streams new documents as NDJSON to stdout', async () => {
+    const io = captureOutput()
+    const { transport } = mockTransport([
+      // Anchor: empty index
+      { hits: { hits: [] } },
+      // First poll: two new docs
+      {
+        hits: {
+          hits: [
+            { _source: { msg: 'first' }, sort: ['t1', 'id1'] },
+            { _source: { msg: 'second' }, sort: ['t2', 'id2'] },
+          ],
+        },
+      },
+    ])
+
+    const deps = makeDeps(transport, io, { stopAfterPolls: 1 })
+    await runCommand(['--index', 'logs'], deps)
+
+    assert.equal(io.stdout.chunks.length, 2)
+    assert.deepEqual(JSON.parse(io.stdout.chunks[0]!), { msg: 'first' })
+    assert.deepEqual(JSON.parse(io.stdout.chunks[1]!), { msg: 'second' })
+  })
+
+  it('applies --format template to each document', async () => {
+    const io = captureOutput()
+    const { transport } = mockTransport([
+      { hits: { hits: [] } }, // anchor
+      {
+        hits: {
+          hits: [{ _source: { '@timestamp': '2024-01-01', message: 'hello' }, sort: ['t1', 'id1'] }],
+        },
+      },
+    ])
+
+    const deps = makeDeps(transport, io, { stopAfterPolls: 1 })
+    await runCommand(['--index', 'logs', '--format', '{@timestamp} {message}'], deps)
+
+    assert.equal(io.stdout.chunks.length, 1)
+    assert.equal(io.stdout.chunks[0]!.trim(), '2024-01-01 hello')
+  })
+
+  it('advances search_after cursor after each poll', async () => {
+    const io = captureOutput()
+    const { transport, requests } = mockTransport([
+      { hits: { hits: [] } }, // anchor (empty)
+      // First poll returns two docs
+      {
+        hits: {
+          hits: [
+            { _source: { n: 1 }, sort: ['t1', 'a'] },
+            { _source: { n: 2 }, sort: ['t2', 'b'] },
+          ],
+        },
+      },
+      // Second poll — stop after this
+      { hits: { hits: [{ _source: { n: 3 }, sort: ['t3', 'c'] }] } },
+    ])
+
+    const deps = makeDeps(transport, io, { stopAfterPolls: 2 })
+    await runCommand(['--index', 'logs'], deps)
+
+    // Second poll should use the sort value of doc #2
+    const secondPoll = requests[2]!.params.body as Record<string, unknown>
+    assert.deepEqual(secondPoll.search_after, ['t2', 'b'])
+  })
+
+  it('uses --from timestamp as range filter on first request', async () => {
+    const io = captureOutput()
+    const { transport, requests } = mockTransport([
+      // First (and only) poll
+      { hits: { hits: [{ _source: { msg: 'new' }, sort: ['t1', 'id1'] }] } },
+    ])
+
+    const deps = makeDeps(transport, io, { stopAfterPolls: 1 })
+    await runCommand(['--index', 'logs', '--from', '2024-06-01T00:00:00Z'], deps)
+
+    // Should not perform an anchor search; first request is the poll with range filter.
+    assert.equal(requests.length, 1)
+    const body = requests[0]!.params.body as Record<string, unknown>
+    const query = body.query as Record<string, unknown>
+    const range = query.range as Record<string, Record<string, string>>
+    assert.equal(range['@timestamp']!.gt, '2024-06-01T00:00:00Z')
+  })
+
+  it('does NOT add range filter on second poll once cursor is set', async () => {
+    const io = captureOutput()
+    const { transport, requests } = mockTransport([
+      // First poll with range filter
+      { hits: { hits: [{ _source: { n: 1 }, sort: ['t1', 'id1'] }] } },
+      // Second poll — cursor only, no range filter
+      { hits: { hits: [{ _source: { n: 2 }, sort: ['t2', 'id2'] }] } },
+    ])
+
+    const deps = makeDeps(transport, io, { stopAfterPolls: 2 })
+    await runCommand(['--index', 'logs', '--from', '2024-01-01T00:00:00Z'], deps)
+
+    const secondPoll = requests[1]!.params.body as Record<string, unknown>
+    // search_after is present, no range query
+    assert.ok(secondPoll.search_after != null)
+    const query = secondPoll.query as Record<string, unknown> | undefined
+    assert.ok(query?.range == null, 'second poll should not have a range filter')
+  })
+
+  it('immediately re-polls (no sleep) when a full page is returned', async () => {
+    const io = captureOutput()
+    let sleepCallCount = 0
+    const { transport } = mockTransport([
+      { hits: { hits: [] } }, // anchor
+      // Full page (size=2)
+      {
+        hits: {
+          hits: [
+            { _source: { n: 1 }, sort: ['t1', 'id1'] },
+            { _source: { n: 2 }, sort: ['t2', 'id2'] },
+          ],
+        },
+      },
+      // Partial page — triggers sleep → SIGINT → stop
+      { hits: { hits: [{ _source: { n: 3 }, sort: ['t3', 'id3'] }] } },
+    ])
+
+    const signalHandlers = new Map<string, (() => void)[]>()
+    const deps: WatchDeps & { io: ReturnType<typeof captureOutput> } = {
+      io,
+      getTransport: () => transport,
+      stdout: io.stdout,
+      stderr: io.stderr,
+      sleep: async () => {
+        sleepCallCount++
+        for (const h of signalHandlers.get('SIGINT') ?? []) h()
+      },
+      onSignal: (signal, handler) => {
+        const list = signalHandlers.get(signal) ?? []
+        list.push(handler)
+        signalHandlers.set(signal, list)
+      },
+      offSignal: (signal, handler) => {
+        const list = (signalHandlers.get(signal) ?? []).filter((h) => h !== handler)
+        signalHandlers.set(signal, list)
+      },
+    }
+
+    await runCommand(['--index', 'logs', '--size', '2'], deps)
+
+    // sleep should only be called once (after the partial second poll), not after the full page
+    assert.equal(sleepCallCount, 1)
+    assert.equal(io.stdout.chunks.length, 3)
+  })
+
+  it('uses the configured --sort-field for sorting', async () => {
+    const io = captureOutput()
+    const { transport, requests } = mockTransport([
+      { hits: { hits: [] } }, // anchor
+      { hits: { hits: [] } }, // poll
+    ])
+
+    const deps = makeDeps(transport, io, { stopAfterPolls: 1 })
+    await runCommand(['--index', 'logs', '--sort-field', 'created_at'], deps)
+
+    const anchorSort = (requests[0]!.params.body as Record<string, unknown>).sort as Array<Record<string, string>>
+    assert.ok('created_at' in anchorSort[0]!, 'anchor should use --sort-field')
+
+    const pollSort = (requests[1]!.params.body as Record<string, unknown>).sort as Array<Record<string, string>>
+    assert.ok('created_at' in pollSort[0]!, 'poll should use --sort-field')
+  })
+
+  it('filters using --query', async () => {
+    const io = captureOutput()
+    const { transport, requests } = mockTransport([
+      { hits: { hits: [] } }, // anchor
+      { hits: { hits: [] } }, // poll
+    ])
+
+    const deps = makeDeps(transport, io, { stopAfterPolls: 1 })
+    await runCommand(['--index', 'logs', '--query', '{"match":{"level":"error"}}'], deps)
+
+    const pollBody = requests[1]!.params.body as Record<string, unknown>
+    const query = pollBody.query as Record<string, unknown>
+    assert.deepEqual(query, { match: { level: 'error' } })
+  })
+
+  it('handles a transport error from the anchor gracefully', async () => {
+    const io = captureOutput()
+    const transport = {
+      request: async () => { throw new Error('connection refused') },
+    } as unknown as Transport
+
+    const deps = makeDeps(transport, io)
+    // Command should not throw — it returns a structured error.
+    await assert.doesNotReject(() => runCommand(['--index', 'logs'], deps))
+  })
+
+  it('writes a summary to stderr on stop', async () => {
+    const io = captureOutput()
+    const { transport } = mockTransport([
+      { hits: { hits: [] } }, // anchor
+      { hits: { hits: [{ _source: { n: 1 }, sort: ['t1', 'id1'] }] } },
+    ])
+
+    const deps = makeDeps(transport, io, { stopAfterPolls: 1 })
+    await runCommand(['--index', 'logs'], deps)
+
+    const stderr = io.stderr.chunks.join('')
+    assert.ok(stderr.includes('1 documents') || stderr.includes('Streamed 1'), `stderr: ${stderr}`)
+  })
+
+  it('returns missing_config error when transport is not configured', async () => {
+    const io = captureOutput()
+    const deps: WatchDeps & { io: ReturnType<typeof captureOutput> } = {
+      io,
+      getTransport: () => { throw new Error('no ES configured') },
+      stdout: io.stdout,
+      stderr: io.stderr,
+      sleep: async () => {},
+      onSignal: () => {},
+      offSignal: () => {},
+    }
+
+    const program = new Command()
+    program.exitOverride()
+    program.addCommand(createWatchCommand(deps))
+
+    let caughtOutput = ''
+    const origWrite = process.stderr.write.bind(process.stderr)
+    process.stderr.write = ((chunk: string) => {
+      caughtOutput += chunk
+      return true
+    }) as typeof process.stderr.write
+
+    const restoreStdin = _testSetStdinReader(() => '')
+    try {
+      await program.parseAsync(['node', 'test', 'watch', '--index', 'logs'])
+    } finally {
+      restoreStdin()
+      process.stderr.write = origWrite
+      process.exitCode = 0
+    }
+
+    assert.ok(caughtOutput.includes('missing_config') || caughtOutput.includes('no ES'), `output: ${caughtOutput}`)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #255.

Adds `elastic stack es helpers watch` — a polling helper that tails an Elasticsearch index or data stream and streams new documents to stdout as they arrive, similar in spirit to `tail -f` for Elasticsearch.

```
elastic stack es helpers watch --index logs-* --format "{@timestamp} [{log.level}] {message}"
```

## How it works

1. **Anchor search** — on startup, a `size=1` descending search finds the most recent document and captures its `sort` values as the starting cursor. This means `watch` only shows documents that arrive *after* it starts.
2. **Cursor-based polling** — every poll uses `search_after` with a stable sort of `[{sort_field: asc}, {_id: asc}]`. This prevents duplicates even when multiple documents share the same timestamp.
3. **`--from` mode** — if a timestamp is given, a range filter replaces the anchor for the first request; the cursor takes over once results arrive.
4. **Burst catch-up** — when a full page is returned the next poll fires immediately (no sleep) so the watcher catches up quickly after a gap.
5. **Clean exit** — stops on `SIGINT` (Ctrl+C) and prints a summary to stderr.

## Options

| Flag | Default | Description |
|---|---|---|
| `--index` | *(required)* | Index or data stream to watch |
| `--query` | — | Query DSL clause as JSON |
| `--query-file` | — | Path to file with full search body |
| `--sort-field` | `@timestamp` | Field for ordering / detecting new docs |
| `--poll-interval` | `5000` | Polling interval in ms |
| `--from` | most recent doc | ISO 8601 timestamp to start from |
| `--size` | `100` | Max docs per poll |
| `--format` | — | `{field}` template; default is NDJSON |

## Test plan

- [ ] `npm run test:unit` passes (1143 tests)
- [ ] `elastic stack es helpers watch --help` shows all options
- [ ] Manual smoke-test: `elastic stack es helpers watch --index <index>` streams new docs on arrival