### PR TITLE
feat(extension): add context env-var propagation for extensions

### DIFF
--- a/src/extension/context.ts
+++ b/src/extension/context.ts
@@ -11,6 +11,16 @@
  * Only variables with a defined value are included in the returned object.
  * Extensions must treat absent variables as "service not configured".
  *
+ * Security / trust model:
+ * - Credentials are passed as env vars, which is the standard approach for
+ *   CLI extension systems (same model as `gh`). On Linux, a process's env is
+ *   readable by root via /proc/<pid>/environ and by any process running as the
+ *   same user, so this offers no additional protection over the config file.
+ * - All child processes spawned by the extension inherit these env vars. Authors
+ *   should be aware and avoid leaking them into further subprocesses or logs.
+ * - The caller (runner) must NOT use `shell: true` when spawning extensions.
+ *   Use spawn with an explicit args array to avoid shell injection.
+ *
  * Exported variable names:
  *   ELASTIC_ES_URL              Elasticsearch URL
  *   ELASTIC_ES_API_KEY          Elasticsearch API key (api_key auth)

--- a/src/extension/context.ts
+++ b/src/extension/context.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Converts a resolved CLI config into a flat set of environment variables
+ * that extensions can read to connect to Elastic services without re-implementing
+ * config parsing.
+ *
+ * Only variables with a defined value are included in the returned object.
+ * Extensions must treat absent variables as "service not configured".
+ *
+ * Exported variable names:
+ *   ELASTIC_ES_URL              Elasticsearch URL
+ *   ELASTIC_ES_API_KEY          Elasticsearch API key (api_key auth)
+ *   ELASTIC_ES_USERNAME         Elasticsearch username (basic auth)
+ *   ELASTIC_ES_PASSWORD         Elasticsearch password (basic auth)
+ *   ELASTIC_KIBANA_URL          Kibana URL
+ *   ELASTIC_KIBANA_API_KEY      Kibana API key
+ *   ELASTIC_KIBANA_USERNAME     Kibana username (basic auth)
+ *   ELASTIC_KIBANA_PASSWORD     Kibana password (basic auth)
+ *   ELASTIC_CLOUD_URL           Elastic Cloud URL
+ *   ELASTIC_CLOUD_API_KEY       Elastic Cloud API key
+ */
+
+import type { ResolvedConfig, ServiceBlock } from '../config/types.ts'
+
+type EnvMap = Record<string, string>
+
+function serviceEnv (prefix: string, block: ServiceBlock): EnvMap {
+  const env: EnvMap = {}
+  env[`${prefix}_URL`] = block.url
+  if (block.auth == null) return env
+  if ('api_key' in block.auth) {
+    env[`${prefix}_API_KEY`] = block.auth.api_key
+  } else {
+    env[`${prefix}_USERNAME`] = block.auth.username
+    env[`${prefix}_PASSWORD`] = block.auth.password
+  }
+  return env
+}
+
+/**
+ * Returns a flat `Record<string, string>` of environment variables derived
+ * from the resolved config. Merge this into the child process `env` when
+ * spawning an extension.
+ */
+export function buildContextEnv (config: ResolvedConfig): EnvMap {
+  const env: EnvMap = {}
+  const { elasticsearch, kibana, cloud } = config.context
+  if (elasticsearch != null) Object.assign(env, serviceEnv('ELASTIC_ES', elasticsearch))
+  if (kibana != null) Object.assign(env, serviceEnv('ELASTIC_KIBANA', kibana))
+  if (cloud != null) Object.assign(env, serviceEnv('ELASTIC_CLOUD', cloud))
+  return env
+}

--- a/test/extension/context.test.ts
+++ b/test/extension/context.test.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { buildContextEnv } from '../../src/extension/context.ts'
+import type { ResolvedConfig } from '../../src/config/types.ts'
+
+describe('buildContextEnv', () => {
+  it('returns empty object when no services are configured', () => {
+    const config: ResolvedConfig = { context: {} }
+    assert.deepEqual(buildContextEnv(config), {})
+  })
+
+  it('sets ELASTIC_ES_URL and ELASTIC_ES_API_KEY for api_key auth', () => {
+    const config: ResolvedConfig = {
+      context: {
+        elasticsearch: { url: 'https://es.example.com:9200', auth: { api_key: 'abc123' } },
+      },
+    }
+    const env = buildContextEnv(config)
+    assert.equal(env['ELASTIC_ES_URL'], 'https://es.example.com:9200')
+    assert.equal(env['ELASTIC_ES_API_KEY'], 'abc123')
+    assert.equal('ELASTIC_ES_USERNAME' in env, false)
+    assert.equal('ELASTIC_ES_PASSWORD' in env, false)
+  })
+
+  it('sets ELASTIC_ES_USERNAME and ELASTIC_ES_PASSWORD for basic auth', () => {
+    const config: ResolvedConfig = {
+      context: {
+        elasticsearch: { url: 'http://localhost:9200', auth: { username: 'elastic', password: 'changeme' } },
+      },
+    }
+    const env = buildContextEnv(config)
+    assert.equal(env['ELASTIC_ES_URL'], 'http://localhost:9200')
+    assert.equal(env['ELASTIC_ES_USERNAME'], 'elastic')
+    assert.equal(env['ELASTIC_ES_PASSWORD'], 'changeme')
+    assert.equal('ELASTIC_ES_API_KEY' in env, false)
+  })
+
+  it('sets ELASTIC_ES_URL only when auth is absent', () => {
+    const config: ResolvedConfig = {
+      context: {
+        elasticsearch: { url: 'http://localhost:9200' },
+      },
+    }
+    const env = buildContextEnv(config)
+    assert.equal(env['ELASTIC_ES_URL'], 'http://localhost:9200')
+    assert.equal('ELASTIC_ES_API_KEY' in env, false)
+    assert.equal('ELASTIC_ES_USERNAME' in env, false)
+  })
+
+  it('sets Kibana env vars', () => {
+    const config: ResolvedConfig = {
+      context: {
+        kibana: { url: 'https://kb.example.com:5601', auth: { api_key: 'kb-key' } },
+      },
+    }
+    const env = buildContextEnv(config)
+    assert.equal(env['ELASTIC_KIBANA_URL'], 'https://kb.example.com:5601')
+    assert.equal(env['ELASTIC_KIBANA_API_KEY'], 'kb-key')
+    assert.equal('ELASTIC_ES_URL' in env, false)
+  })
+
+  it('sets Kibana basic auth env vars', () => {
+    const config: ResolvedConfig = {
+      context: {
+        kibana: { url: 'http://localhost:5601', auth: { username: 'kibana_system', password: 's3cr3t' } },
+      },
+    }
+    const env = buildContextEnv(config)
+    assert.equal(env['ELASTIC_KIBANA_USERNAME'], 'kibana_system')
+    assert.equal(env['ELASTIC_KIBANA_PASSWORD'], 's3cr3t')
+    assert.equal('ELASTIC_KIBANA_API_KEY' in env, false)
+  })
+
+  it('sets Cloud env vars', () => {
+    const config: ResolvedConfig = {
+      context: {
+        cloud: { url: 'https://cloud.elastic.co', auth: { api_key: 'cloud-key' } },
+      },
+    }
+    const env = buildContextEnv(config)
+    assert.equal(env['ELASTIC_CLOUD_URL'], 'https://cloud.elastic.co')
+    assert.equal(env['ELASTIC_CLOUD_API_KEY'], 'cloud-key')
+  })
+
+  it('sets env vars for all three services simultaneously', () => {
+    const config: ResolvedConfig = {
+      context: {
+        elasticsearch: { url: 'https://es:9200', auth: { api_key: 'es-key' } },
+        kibana: { url: 'https://kb:5601', auth: { api_key: 'kb-key' } },
+        cloud: { url: 'https://cloud.elastic.co', auth: { api_key: 'cloud-key' } },
+      },
+    }
+    const env = buildContextEnv(config)
+    assert.equal(env['ELASTIC_ES_URL'], 'https://es:9200')
+    assert.equal(env['ELASTIC_ES_API_KEY'], 'es-key')
+    assert.equal(env['ELASTIC_KIBANA_URL'], 'https://kb:5601')
+    assert.equal(env['ELASTIC_KIBANA_API_KEY'], 'kb-key')
+    assert.equal(env['ELASTIC_CLOUD_URL'], 'https://cloud.elastic.co')
+    assert.equal(env['ELASTIC_CLOUD_API_KEY'], 'cloud-key')
+  })
+
+  it('does not include undefined values in the returned object', () => {
+    const config: ResolvedConfig = {
+      context: {
+        elasticsearch: { url: 'https://es:9200', auth: { api_key: 'key' } },
+      },
+    }
+    const env = buildContextEnv(config)
+    for (const val of Object.values(env)) {
+      assert.notEqual(val, undefined)
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Closes #294. Part of #222.

- Adds `src/extension/context.ts` with a single `buildContextEnv(config: ResolvedConfig)` export
- Converts the active resolved config into a flat `Record<string, string>` to be merged into a child process `env` when spawning extensions
- Exposed variables (only set when the value is present):
  - `ELASTIC_ES_URL`, `ELASTIC_ES_API_KEY` / `ELASTIC_ES_USERNAME` + `ELASTIC_ES_PASSWORD`
  - `ELASTIC_KIBANA_URL`, `ELASTIC_KIBANA_API_KEY` / `ELASTIC_KIBANA_USERNAME` + `ELASTIC_KIBANA_PASSWORD`
  - `ELASTIC_CLOUD_URL`, `ELASTIC_CLOUD_API_KEY`
- 9 unit tests covering no-services, api_key auth, basic auth, auth-absent, each service independently, all three together, and no-undefined values guarantee

## Test plan

- [x] `npx tsc --noEmit` passes clean
- [x] `node --import tsx/esm --test test/extension/context.test.ts` -- 9/9 pass