### PR TITLE
feat(extension): add elastic extension command group (list, install, remove)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -45,6 +45,10 @@ program.hook('preAction', async (thisCommand, actionCommand) => {
   for (let c = actionCommand.parent; c != null; c = c.parent) {
     if (c.name() === 'config') return
   }
+  // `extension` commands manage the extension registry, not the Elastic stack
+  for (let c = actionCommand.parent; c != null; c = c.parent) {
+    if (c.name() === 'extension') return
+  }
   const { configFile: configPath, useContext: contextName, commandProfile: profileName } = thisCommand.opts()
   const typedProfileName = profileName as BuiltInProfile | undefined
 
@@ -176,11 +180,18 @@ if (firstArg === 'sanitize') {
   program.addCommand(defineGroup({ name: 'sanitize', description: 'Sanitize values for safe use in Elasticsearch' }))
 }
 
+if (firstArg === 'extension') {
+  const { registerExtensionCommands } = await import('./extension/register.ts')
+  program.addCommand(registerExtensionCommands())
+} else {
+  program.addCommand(defineGroup({ name: 'extension', description: 'Manage elastic CLI extensions' }))
+}
+
 // Load config early so --help can hide blocked commands. Skip for commands
 // that don't need config (e.g. `version`, `sanitize`, or `config` which authors the file)
 // to avoid unnecessary file I/O and a confusing "no config found" path.
 // The result is cached in earlyConfig so the preAction hook can reuse it.
-if (firstArg !== 'version' && firstArg !== 'config' && firstArg !== 'sanitize') {
+if (firstArg !== 'version' && firstArg !== 'config' && firstArg !== 'sanitize' && firstArg !== 'extension') {
   // Parse --profile early (before Commander's full parse) so the early config load
   // and hideBlockedCommands can apply the correct profile-based allow-list to --help.
   const profileArgIdx = process.argv.indexOf('--command-profile')

--- a/src/extension/register.ts
+++ b/src/extension/register.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * `elastic extension ...` command tree.
+ *
+ * Extension commands manage the locally installed extension registry. They do
+ * not require a resolved Elastic config (no preAction hook) because they
+ * operate on the extension registry at ~/.elastic/extensions.json, not on an
+ * Elasticsearch or Kibana cluster.
+ *
+ * Commands:
+ *   elastic extension list                  list installed extensions
+ *   elastic extension install <source>      install from github: or npm:
+ *   elastic extension remove <name>         uninstall by name
+ */
+
+import { defineCommand, defineGroup } from '../factory.ts'
+import type { JsonValue, OpaqueCommandHandle } from '../factory.ts'
+import { readExtensions } from './store.ts'
+import { installExtension, uninstallExtension } from './installer.ts'
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async function handleList (): Promise<JsonValue> {
+  const extensions = await readExtensions()
+  return extensions.map((e) => ({
+    name: e.name,
+    source: e.source,
+    path: e.path,
+    entrypoint: e.entrypoint,
+  })) as unknown as JsonValue
+}
+
+async function handleInstall (parsed: { arg?: string }): Promise<JsonValue> {
+  const source = parsed.arg?.trim()
+  if (source == null || source.length === 0) {
+    return { error: { code: 'missing_source', message: 'A source is required. Use github:owner/repo or npm:package-name.' } }
+  }
+  const entry = await installExtension(source)
+  return {
+    installed: true,
+    name: entry.name,
+    source: entry.source,
+    path: entry.path,
+    entrypoint: entry.entrypoint,
+  } as unknown as JsonValue
+}
+
+async function handleRemove (parsed: { arg?: string }): Promise<JsonValue> {
+  const name = parsed.arg?.trim()
+  if (name == null || name.length === 0) {
+    return { error: { code: 'missing_name', message: 'An extension name is required.' } }
+  }
+  await uninstallExtension(name)
+  return { removed: true, name } as unknown as JsonValue
+}
+
+// ---------------------------------------------------------------------------
+// Command tree
+// ---------------------------------------------------------------------------
+
+/**
+ * Builds the top-level `extension` command group.
+ */
+export function registerExtensionCommands (): OpaqueCommandHandle {
+  const listCmd = defineCommand({
+    name: 'list',
+    description: 'List all installed extensions',
+    handler: async () => handleList(),
+  })
+
+  const installCmd = defineCommand({
+    name: 'install',
+    description: 'Install an extension from a GitHub repo or npm package',
+    positionalArg: {
+      name: 'source',
+      description: 'Install source: github:owner/repo, owner/repo, or npm:package-name',
+      required: true,
+    },
+    handler: async (parsed) => handleInstall(parsed),
+  })
+
+  const removeCmd = defineCommand({
+    name: 'remove',
+    description: 'Uninstall an extension by name',
+    positionalArg: {
+      name: 'name',
+      description: 'Short extension name (e.g. "local" for elastic-local)',
+      required: true,
+    },
+    handler: async (parsed) => handleRemove(parsed),
+  })
+
+  return defineGroup(
+    { name: 'extension', description: 'Manage elastic CLI extensions' },
+    listCmd,
+    installCmd,
+    removeCmd,
+  )
+}


### PR DESCRIPTION
## Summary

Closes #296. Part of #222. Depends on #301.

- Adds `src/extension/register.ts` with `registerExtensionCommands()` building the `elastic extension` group
- Three subcommands: `list`, `install <source>`, `remove <name>`
- Extension commands bypass config loading (no Elastic cluster needed); handled by skipping the preAction hook for any command whose ancestor is `extension`
- `cli.ts`: lazy-loads `registerExtensionCommands()` when `firstArg === 'extension'`; excludes `extension` from the early config load path alongside `config`, `sanitize`, and `version`

## Test plan

- [x] `npx tsc --noEmit` passes clean
- [x] `elastic extension --help` shows list/install/remove subcommands
- [x] `elastic extension list` returns `[]` with no extensions installed
- [ ] `elastic extension install github:elastic/elastic-local` (functional, requires network)
- [ ] `elastic extension remove local` after install