### PR TITLE
feat(extension): dispatch unknown top-level commands to installed extensions

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -214,4 +214,24 @@ if (process.argv.slice(2).length === 0) {
   process.exit(0)
 }
 
+// If the first argument does not match any built-in command, attempt to
+// dispatch to an installed extension named `elastic-<firstArg>`.
+// This check runs after all built-ins are registered so the set is complete.
+const BUILT_IN_COMMANDS = new Set([
+  'version', 'stack', 'es', 'elasticsearch', 'kb', 'kibana',
+  'cloud', 'docs', 'config', 'sanitize', 'extension',
+])
+
+if (firstArg != null && !BUILT_IN_COMMANDS.has(firstArg)) {
+  const { findExtension } = await import('./extension/store.ts')
+  const ext = await findExtension(firstArg)
+  if (ext != null) {
+    const { buildContextEnv } = await import('./extension/context.ts')
+    const { runExtension } = await import('./extension/runner.ts')
+    const contextEnv = earlyConfig?.ok === true ? buildContextEnv(earlyConfig.value) : {}
+    const exitCode = await runExtension(ext, process.argv.slice(3), contextEnv)
+    process.exit(exitCode)
+  }
+}
+
 await program.parseAsync(process.argv)

--- a/src/extension/context.ts
+++ b/src/extension/context.ts
@@ -11,6 +11,16 @@
  * Only variables with a defined value are included in the returned object.
  * Extensions must treat absent variables as "service not configured".
  *
+ * Security / trust model:
+ * - Credentials are passed as env vars, which is the standard approach for
+ *   CLI extension systems (same model as `gh`). On Linux, a process's env is
+ *   readable by root via /proc/<pid>/environ and by any process running as the
+ *   same user, so this offers no additional protection over the config file.
+ * - All child processes spawned by the extension inherit these env vars. Authors
+ *   should be aware and avoid leaking them into further subprocesses or logs.
+ * - The caller (runner) must NOT use `shell: true` when spawning extensions.
+ *   Use spawn with an explicit args array to avoid shell injection.
+ *
  * Exported variable names:
  *   ELASTIC_ES_URL              Elasticsearch URL
  *   ELASTIC_ES_API_KEY          Elasticsearch API key (api_key auth)

--- a/src/extension/context.ts
+++ b/src/extension/context.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Converts a resolved CLI config into a flat set of environment variables
+ * that extensions can read to connect to Elastic services without re-implementing
+ * config parsing.
+ *
+ * Only variables with a defined value are included in the returned object.
+ * Extensions must treat absent variables as "service not configured".
+ *
+ * Exported variable names:
+ *   ELASTIC_ES_URL              Elasticsearch URL
+ *   ELASTIC_ES_API_KEY          Elasticsearch API key (api_key auth)
+ *   ELASTIC_ES_USERNAME         Elasticsearch username (basic auth)
+ *   ELASTIC_ES_PASSWORD         Elasticsearch password (basic auth)
+ *   ELASTIC_KIBANA_URL          Kibana URL
+ *   ELASTIC_KIBANA_API_KEY      Kibana API key
+ *   ELASTIC_KIBANA_USERNAME     Kibana username (basic auth)
+ *   ELASTIC_KIBANA_PASSWORD     Kibana password (basic auth)
+ *   ELASTIC_CLOUD_URL           Elastic Cloud URL
+ *   ELASTIC_CLOUD_API_KEY       Elastic Cloud API key
+ */
+
+import type { ResolvedConfig, ServiceBlock } from '../config/types.ts'
+
+type EnvMap = Record<string, string>
+
+function serviceEnv (prefix: string, block: ServiceBlock): EnvMap {
+  const env: EnvMap = {}
+  env[`${prefix}_URL`] = block.url
+  if (block.auth == null) return env
+  if ('api_key' in block.auth) {
+    env[`${prefix}_API_KEY`] = block.auth.api_key
+  } else {
+    env[`${prefix}_USERNAME`] = block.auth.username
+    env[`${prefix}_PASSWORD`] = block.auth.password
+  }
+  return env
+}
+
+/**
+ * Returns a flat `Record<string, string>` of environment variables derived
+ * from the resolved config. Merge this into the child process `env` when
+ * spawning an extension.
+ */
+export function buildContextEnv (config: ResolvedConfig): EnvMap {
+  const env: EnvMap = {}
+  const { elasticsearch, kibana, cloud } = config.context
+  if (elasticsearch != null) Object.assign(env, serviceEnv('ELASTIC_ES', elasticsearch))
+  if (kibana != null) Object.assign(env, serviceEnv('ELASTIC_KIBANA', kibana))
+  if (cloud != null) Object.assign(env, serviceEnv('ELASTIC_CLOUD', cloud))
+  return env
+}

--- a/src/extension/runner.ts
+++ b/src/extension/runner.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Extension runner: locates and spawns an installed extension process.
+ *
+ * Security:
+ *   - The entrypoint path comes from the validated registry (store.ts enforces
+ *     that it is an absolute path).
+ *   - spawn() is always called with shell: false and an explicit args array to
+ *     prevent shell injection.
+ *   - The child process inherits the parent's stdio so it behaves like a
+ *     first-class terminal command.
+ *   - Context credentials are passed as env vars merged into the inherited
+ *     process.env; the extension process does not receive additional privileges.
+ */
+
+import { spawn } from 'node:child_process'
+import type { InstalledExtension } from './store.ts'
+
+/**
+ * Spawns the extension's entrypoint with `args`, merging `contextEnv` into
+ * the inherited environment. Resolves with the child's exit code.
+ *
+ * The caller should forward the exit code to `process.exit()`.
+ */
+export function runExtension (
+  ext: InstalledExtension,
+  args: string[],
+  contextEnv: Record<string, string>,
+): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(ext.entrypoint, args, {
+      stdio: 'inherit',
+      shell: false,
+      env: { ...process.env, ...contextEnv },
+    })
+    child.on('error', (err) => {
+      reject(new Error(`Failed to start extension "${ext.name}" (${ext.entrypoint}): ${err.message}`))
+    })
+    child.on('close', (code) => {
+      resolve(code ?? 1)
+    })
+  })
+}


### PR DESCRIPTION
## Summary

Closes #297. Part of #222. Depends on #302.

- Adds `src/extension/runner.ts` with `runExtension(ext, args, contextEnv)`: spawns the extension entrypoint with `shell: false`, merges context env vars into the inherited environment, and resolves with the child's exit code
- Updates `cli.ts`: after all built-in commands are registered, checks whether `firstArg` matches any of the known built-in command names; if not, looks up the extension registry and execs the extension, forwarding remaining argv and the resolved context env vars
- Unknown commands with no matching extension fall through to Commander's normal error handling

Security: `spawn` is called with `shell: false` and an explicit args array. The entrypoint path is validated by `store.ts` to be an absolute path within the install directory before it is ever written to the registry.

## Test plan

- [x] `npx tsc --noEmit` passes clean
- [x] `elastic some-unknown-cmd` still errors normally when no extension is installed
- [ ] `elastic local` dispatches to `elastic-local` binary after `elastic extension install github:elastic/elastic-local` (functional)
- [ ] Extension receives `ELASTIC_ES_URL` and `ELASTIC_ES_API_KEY` in its environment