### PR TITLE
feat(extension): add search and upgrade commands

### DIFF
--- a/src/extension/installer.ts
+++ b/src/extension/installer.ts
@@ -66,10 +66,10 @@ function assertSafeName (name: string): void {
 }
 
 interface ParsedSource {
-  type: 'github' | 'npm' | 'local'
+  type: 'github' | 'npm'
   /** Full package name for npm sources, e.g. `@elastic/start-local`. */
   package?: string
-  /** Clone URL for github sources, or absolute local path for local sources. */
+  /** GitHub clone URL, e.g. `https://github.com/elastic/elastic-local`. */
   cloneUrl?: string
   /** Derived repo/package base name (without scope or owner), e.g. `elastic-local`. */
   baseName: string
@@ -88,24 +88,12 @@ function parseSource (source: string): ParsedSource {
     return { type: 'npm', package: pkg, baseName: base, name }
   }
 
-  // local:/abs/path/to/repo — for local development and e2e testing
-  if (source.startsWith('local:')) {
-    const localPath = source.slice('local:'.length).trim()
-    if (!localPath.startsWith('/')) {
-      throw new Error(`local: source must be an absolute path, e.g. local:/path/to/repo`)
-    }
-    const baseName = localPath.split('/').filter(Boolean).pop() ?? 'extension'
-    const name = deriveName(baseName)
-    assertSafeName(name)
-    return { type: 'local', cloneUrl: localPath, baseName, name }
-  }
-
   // github:owner/repo or bare owner/repo
   const slug = source.startsWith('github:') ? source.slice('github:'.length) : source
   const parts = slug.split('/')
   if (parts.length !== 2 || parts.some((p) => p.trim().length === 0)) {
     throw new Error(
-      `Invalid GitHub source "${source}". Use github:owner/repo, owner/repo, local:/path, or npm:package.`
+      `Invalid GitHub source "${source}". Use github:owner/repo or owner/repo.`
     )
   }
   const owner = parts[0]!.trim()
@@ -230,7 +218,7 @@ export async function installExtension (source: string): Promise<InstalledExtens
 
   let entrypoint: string
 
-  if (parsed.type === 'github' || parsed.type === 'local') {
+  if (parsed.type === 'github') {
     run('git', ['clone', '--depth', '1', parsed.cloneUrl!, installDir], extensionsDir())
 
     // Build if package.json present
@@ -297,7 +285,7 @@ export async function upgradeExtension (name: string): Promise<InstalledExtensio
 
   const parsed = parseSource(ext.source)
 
-  if (parsed.type === 'github' || parsed.type === 'local') {
+  if (parsed.type === 'github') {
     run('git', ['pull', '--ff-only'], ext.path)
     const hasPkg = await readFile(join(ext.path, 'package.json'), 'utf-8').then(() => true).catch(() => false)
     if (hasPkg) {

--- a/src/extension/installer.ts
+++ b/src/extension/installer.ts
@@ -66,10 +66,10 @@ function assertSafeName (name: string): void {
 }
 
 interface ParsedSource {
-  type: 'github' | 'npm'
+  type: 'github' | 'npm' | 'local'
   /** Full package name for npm sources, e.g. `@elastic/start-local`. */
   package?: string
-  /** GitHub clone URL, e.g. `https://github.com/elastic/elastic-local`. */
+  /** Clone URL for github sources, or absolute local path for local sources. */
   cloneUrl?: string
   /** Derived repo/package base name (without scope or owner), e.g. `elastic-local`. */
   baseName: string
@@ -88,12 +88,24 @@ function parseSource (source: string): ParsedSource {
     return { type: 'npm', package: pkg, baseName: base, name }
   }
 
+  // local:/abs/path/to/repo — for local development and e2e testing
+  if (source.startsWith('local:')) {
+    const localPath = source.slice('local:'.length).trim()
+    if (!localPath.startsWith('/')) {
+      throw new Error(`local: source must be an absolute path, e.g. local:/path/to/repo`)
+    }
+    const baseName = localPath.split('/').filter(Boolean).pop() ?? 'extension'
+    const name = deriveName(baseName)
+    assertSafeName(name)
+    return { type: 'local', cloneUrl: localPath, baseName, name }
+  }
+
   // github:owner/repo or bare owner/repo
   const slug = source.startsWith('github:') ? source.slice('github:'.length) : source
   const parts = slug.split('/')
   if (parts.length !== 2 || parts.some((p) => p.trim().length === 0)) {
     throw new Error(
-      `Invalid GitHub source "${source}". Use github:owner/repo or owner/repo.`
+      `Invalid GitHub source "${source}". Use github:owner/repo, owner/repo, local:/path, or npm:package.`
     )
   }
   const owner = parts[0]!.trim()
@@ -218,7 +230,7 @@ export async function installExtension (source: string): Promise<InstalledExtens
 
   let entrypoint: string
 
-  if (parsed.type === 'github') {
+  if (parsed.type === 'github' || parsed.type === 'local') {
     run('git', ['clone', '--depth', '1', parsed.cloneUrl!, installDir], extensionsDir())
 
     // Build if package.json present
@@ -285,7 +297,7 @@ export async function upgradeExtension (name: string): Promise<InstalledExtensio
 
   const parsed = parseSource(ext.source)
 
-  if (parsed.type === 'github') {
+  if (parsed.type === 'github' || parsed.type === 'local') {
     run('git', ['pull', '--ff-only'], ext.path)
     const hasPkg = await readFile(join(ext.path, 'package.json'), 'utf-8').then(() => true).catch(() => false)
     if (hasPkg) {

--- a/src/extension/installer.ts
+++ b/src/extension/installer.ts
@@ -26,7 +26,7 @@ import { access, constants, mkdir, readFile, rm } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join, isAbsolute, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
-import { upsertExtension, removeExtension as removeFromStore } from './store.ts'
+import { readExtensions, upsertExtension, findExtension, removeExtension as removeFromStore } from './store.ts'
 import type { InstalledExtension } from './store.ts'
 
 // ---------------------------------------------------------------------------
@@ -269,4 +269,56 @@ export async function uninstallExtension (name: string): Promise<void> {
   const installDir = join(extensionsDir(), `elastic-${name}`)
   await rm(installDir, { recursive: true, force: true })
   await removeFromStore(name)
+}
+
+/**
+ * Upgrades a single installed extension in-place:
+ *   - github: `git pull --ff-only`, then `npm install --production` if package.json is present
+ *   - npm: `npm update --prefix <dir>`
+ *
+ * Rediscovers the entrypoint after the upgrade and persists the updated entry.
+ * Throws if the extension is not installed.
+ */
+export async function upgradeExtension (name: string): Promise<InstalledExtension> {
+  const ext = await findExtension(name)
+  if (ext == null) throw new Error(`Extension "${name}" is not installed.`)
+
+  const parsed = parseSource(ext.source)
+
+  if (parsed.type === 'github') {
+    run('git', ['pull', '--ff-only'], ext.path)
+    const hasPkg = await readFile(join(ext.path, 'package.json'), 'utf-8').then(() => true).catch(() => false)
+    if (hasPkg) {
+      run('npm', ['install', '--production', '--no-fund', '--no-audit'], ext.path)
+    }
+    const entrypoint = await discoverGithubEntrypoint(ext.path, parsed.baseName)
+    const updated: InstalledExtension = { ...ext, entrypoint: resolve(entrypoint) }
+    await upsertExtension(updated)
+    return updated
+  } else {
+    run('npm', ['update', '--prefix', ext.path, '--no-fund', '--no-audit'], extensionsDir())
+    await upsertExtension(ext)
+    return ext
+  }
+}
+
+/**
+ * Upgrades all installed extensions. Returns each updated entry.
+ * Errors from individual upgrades are collected and re-thrown together at the end.
+ */
+export async function upgradeAllExtensions (): Promise<InstalledExtension[]> {
+  const extensions = await readExtensions()
+  const results: InstalledExtension[] = []
+  const errors: string[] = []
+  for (const ext of extensions) {
+    try {
+      results.push(await upgradeExtension(ext.name))
+    } catch (err: unknown) {
+      errors.push(`${ext.name}: ${err instanceof Error ? err.message : String(err)}`)
+    }
+  }
+  if (errors.length > 0) {
+    throw new Error(`Some extensions failed to upgrade:\n${errors.map((e) => `  ${e}`).join('\n')}`)
+  }
+  return results
 }

--- a/src/extension/register.ts
+++ b/src/extension/register.ts
@@ -15,12 +15,15 @@
  *   elastic extension list                  list installed extensions
  *   elastic extension install <source>      install from github: or npm:
  *   elastic extension remove <name>         uninstall by name
+ *   elastic extension upgrade [name]        upgrade one or all extensions
+ *   elastic extension search [query]        discover extensions via GitHub topic
  */
 
 import { defineCommand, defineGroup } from '../factory.ts'
 import type { JsonValue, OpaqueCommandHandle } from '../factory.ts'
 import { readExtensions } from './store.ts'
-import { installExtension, uninstallExtension } from './installer.ts'
+import { installExtension, uninstallExtension, upgradeExtension, upgradeAllExtensions } from './installer.ts'
+import { searchExtensions } from './search.ts'
 
 // ---------------------------------------------------------------------------
 // Handlers
@@ -60,6 +63,22 @@ async function handleRemove (parsed: { arg?: string }): Promise<JsonValue> {
   return { removed: true, name } as unknown as JsonValue
 }
 
+async function handleUpgrade (parsed: { arg?: string }): Promise<JsonValue> {
+  const name = parsed.arg?.trim()
+  if (name != null && name.length > 0) {
+    const updated = await upgradeExtension(name)
+    return { upgraded: true, name: updated.name, source: updated.source, entrypoint: updated.entrypoint } as unknown as JsonValue
+  }
+  const all = await upgradeAllExtensions()
+  return { upgraded: true, extensions: all.map((e) => ({ name: e.name, source: e.source })) } as unknown as JsonValue
+}
+
+async function handleSearch (parsed: { arg?: string }): Promise<JsonValue> {
+  const query = parsed.arg?.trim()
+  const results = await searchExtensions(query)
+  return results as unknown as JsonValue
+}
+
 // ---------------------------------------------------------------------------
 // Command tree
 // ---------------------------------------------------------------------------
@@ -96,10 +115,34 @@ export function registerExtensionCommands (): OpaqueCommandHandle {
     handler: async (parsed) => handleRemove(parsed),
   })
 
+  const upgradeCmd = defineCommand({
+    name: 'upgrade',
+    description: 'Upgrade an installed extension, or all extensions if no name is given',
+    positionalArg: {
+      name: 'name',
+      description: 'Short extension name to upgrade (omit to upgrade all)',
+      required: false,
+    },
+    handler: async (parsed) => handleUpgrade(parsed),
+  })
+
+  const searchCmd = defineCommand({
+    name: 'search',
+    description: 'Discover extensions tagged with the elastic-extension GitHub topic',
+    positionalArg: {
+      name: 'query',
+      description: 'Optional search terms to narrow results',
+      required: false,
+    },
+    handler: async (parsed) => handleSearch(parsed),
+  })
+
   return defineGroup(
     { name: 'extension', description: 'Manage elastic CLI extensions' },
     listCmd,
     installCmd,
     removeCmd,
+    upgradeCmd,
+    searchCmd,
   )
 }

--- a/src/extension/search.ts
+++ b/src/extension/search.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Extension discovery via the GitHub repository search API.
+ *
+ * Searches for repos tagged with the `elastic-extension` GitHub topic.
+ * An optional free-text query further filters results.
+ *
+ * Security:
+ *   - fetch() is called with redirect: 'error' to prevent credential leakage
+ *     on unexpected redirects.
+ *   - The query string is encoded with encodeURIComponent before interpolation.
+ *   - No credentials are sent; the call uses the public GitHub API rate limit
+ *     (10 requests/minute unauthenticated). Passing a GITHUB_TOKEN in the
+ *     environment raises this to 30 requests/minute.
+ */
+
+const GITHUB_TOPIC = 'elastic-extension'
+const GITHUB_API = 'https://api.github.com'
+
+export interface ExtensionSearchResult {
+  /** GitHub `owner/repo` slug. */
+  repo: string
+  /** Short human-readable description from the GitHub repo, or empty string. */
+  description: string
+  /** URL to the repository on GitHub. */
+  url: string
+  /** Ready-to-paste install command. */
+  installCommand: string
+}
+
+interface GitHubRepoItem {
+  full_name: string
+  description: string | null
+  html_url: string
+}
+
+interface GitHubSearchResponse {
+  items: GitHubRepoItem[]
+}
+
+/**
+ * Queries GitHub for repositories tagged with `elastic-extension`.
+ * An optional `query` string is appended to narrow results (e.g. a keyword).
+ *
+ * @param query  Optional free-text search terms to append to the topic filter.
+ * @returns      Array of matching extension metadata, sorted by GitHub stars (desc).
+ */
+export async function searchExtensions (query?: string): Promise<ExtensionSearchResult[]> {
+  const q = query != null && query.trim().length > 0
+    ? `topic:${GITHUB_TOPIC} ${query.trim()}`
+    : `topic:${GITHUB_TOPIC}`
+
+  const url = `${GITHUB_API}/search/repositories?q=${encodeURIComponent(q)}&sort=stars&order=desc&per_page=30`
+
+  const headers: Record<string, string> = {
+    'Accept': 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+  }
+  if (process.env.GITHUB_TOKEN) {
+    headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`
+  }
+
+  const resp = await fetch(url, { headers, redirect: 'error' })
+
+  if (resp.status === 403 || resp.status === 429) {
+    throw new Error(
+      'GitHub API rate limit reached. Set the GITHUB_TOKEN environment variable to increase the limit.'
+    )
+  }
+  if (!resp.ok) {
+    throw new Error(`GitHub API error: ${resp.status} ${resp.statusText}`)
+  }
+
+  const data = await resp.json() as GitHubSearchResponse
+
+  return data.items.map((item) => ({
+    repo: item.full_name,
+    description: item.description ?? '',
+    url: item.html_url,
+    installCommand: `elastic extension install github:${item.full_name}`,
+  }))
+}

--- a/test/extension/installer.test.ts
+++ b/test/extension/installer.test.ts
@@ -17,7 +17,7 @@ import assert from 'node:assert/strict'
 import { mkdtemp, rm, mkdir, writeFile, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { installExtension, uninstallExtension, _testSetExtensionsDir } from '../../src/extension/installer.ts'
+import { installExtension, uninstallExtension, upgradeExtension, upgradeAllExtensions, _testSetExtensionsDir } from '../../src/extension/installer.ts'
 import { readExtensions, writeExtensions, _testSetRegistryPath } from '../../src/extension/store.ts'
 import type { InstalledExtension } from '../../src/extension/store.ts'
 
@@ -104,6 +104,19 @@ describe('installer', () => {
 
       await uninstallExtension('gone')
       assert.deepEqual(await readExtensions(), [])
+    })
+  })
+
+  describe('upgradeExtension', () => {
+    it('throws when the extension is not installed', async () => {
+      await assert.rejects(upgradeExtension('nonexistent'), /not installed/)
+    })
+  })
+
+  describe('upgradeAllExtensions', () => {
+    it('returns empty array when no extensions are installed', async () => {
+      const results = await upgradeAllExtensions()
+      assert.deepEqual(results, [])
     })
   })
 })

--- a/test/extension/search.test.ts
+++ b/test/extension/search.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, before, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { searchExtensions } from '../../src/extension/search.ts'
+
+// ---------------------------------------------------------------------------
+// Fetch stub
+// ---------------------------------------------------------------------------
+
+type FetchFn = typeof globalThis.fetch
+let _originalFetch: FetchFn
+let _stubResponse: { ok: boolean; status: number; statusText: string; json: () => Promise<unknown> } | null = null
+
+function stubFetch (response: typeof _stubResponse): void {
+  _stubResponse = response
+  globalThis.fetch = async (_url: string | URL | Request, _init?: RequestInit) => {
+    if (_stubResponse == null) throw new Error('No stub response configured')
+    return {
+      ok: _stubResponse.ok,
+      status: _stubResponse.status,
+      statusText: _stubResponse.statusText,
+      json: _stubResponse.json,
+    } as Response
+  }
+}
+
+before(() => { _originalFetch = globalThis.fetch })
+after(() => { globalThis.fetch = _originalFetch })
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const SAMPLE_ITEMS = [
+  { full_name: 'elastic/elastic-local', description: 'Local stack lifecycle', html_url: 'https://github.com/elastic/elastic-local' },
+  { full_name: 'acme/elastic-diag', description: null, html_url: 'https://github.com/acme/elastic-diag' },
+]
+
+describe('searchExtensions', () => {
+  it('returns mapped results from the GitHub API', async () => {
+    stubFetch({ ok: true, status: 200, statusText: 'OK', json: async () => ({ items: SAMPLE_ITEMS }) })
+    const results = await searchExtensions()
+    assert.equal(results.length, 2)
+    assert.equal(results[0]!.repo, 'elastic/elastic-local')
+    assert.equal(results[0]!.description, 'Local stack lifecycle')
+    assert.equal(results[0]!.installCommand, 'elastic extension install github:elastic/elastic-local')
+    assert.equal(results[1]!.description, '', 'null description should become empty string')
+  })
+
+  it('returns empty array when no results found', async () => {
+    stubFetch({ ok: true, status: 200, statusText: 'OK', json: async () => ({ items: [] }) })
+    const results = await searchExtensions()
+    assert.deepEqual(results, [])
+  })
+
+  it('throws a rate-limit error on 403', async () => {
+    stubFetch({ ok: false, status: 403, statusText: 'Forbidden', json: async () => ({}) })
+    await assert.rejects(searchExtensions(), /rate limit/)
+  })
+
+  it('throws a rate-limit error on 429', async () => {
+    stubFetch({ ok: false, status: 429, statusText: 'Too Many Requests', json: async () => ({}) })
+    await assert.rejects(searchExtensions(), /rate limit/)
+  })
+
+  it('throws a generic API error on other non-ok responses', async () => {
+    stubFetch({ ok: false, status: 500, statusText: 'Internal Server Error', json: async () => ({}) })
+    await assert.rejects(searchExtensions(), /GitHub API error: 500/)
+  })
+
+  it('includes the install command with the correct github: prefix', async () => {
+    stubFetch({ ok: true, status: 200, statusText: 'OK', json: async () => ({ items: SAMPLE_ITEMS }) })
+    const results = await searchExtensions('local')
+    for (const r of results) {
+      assert.ok(r.installCommand.startsWith('elastic extension install github:'))
+    }
+  })
+})

--- a/test/extension/search.test.ts
+++ b/test/extension/search.test.ts
@@ -17,7 +17,7 @@ let _stubResponse: { ok: boolean; status: number; statusText: string; json: () =
 
 function stubFetch (response: typeof _stubResponse): void {
   _stubResponse = response
-  globalThis.fetch = async (_url: string | URL | Request, _init?: RequestInit) => {
+  globalThis.fetch = async () => {
     if (_stubResponse == null) throw new Error('No stub response configured')
     return {
       ok: _stubResponse.ok,


### PR DESCRIPTION
## Summary

Closes #298. Part of #222. Depends on #303.

**`elastic extension search [query]`**
- Queries the GitHub repository search API for repos tagged with `elastic-extension` topic
- Optional free-text query to narrow results
- Returns repo, description, url, and a ready-to-paste `installCommand` for each result
- Handles rate-limit (403/429) with a clear message suggesting `GITHUB_TOKEN`
- `fetch()` called with `redirect: 'error'` to prevent credential leakage on redirects
- New module `src/extension/search.ts`

**`elastic extension upgrade [name]`**
- With a name: upgrades one extension (`git pull --ff-only` for github, `npm update` for npm), rediscovers entrypoint, updates registry
- Without a name: upgrades all installed extensions; collects per-extension errors and reports them together rather than stopping on first failure
- Added to `src/extension/installer.ts` alongside the existing install/uninstall functions

## Test plan

- [x] `npx tsc --noEmit` passes clean
- [x] 16/16 tests pass (`upgradeExtension` error path, `upgradeAllExtensions` empty case, 6 search stub tests)
- [x] `~/.bun/bin/bun test test/extension/` -- all pass
- [ ] `elastic extension search` (functional, requires network)
- [ ] `elastic extension upgrade local` after install (functional, requires git)