### PR TITLE
fix: bundle workspace deps and add config-resolver to release-please

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{".":"0.1.0","packages/es-schemas":"1.0.0"}
+{".":"0.1.0","packages/config-resolver":"0.1.0","packages/es-schemas":"1.0.0"}

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -11,12 +11,19 @@
         ],
         "include-component-in-tag": false
     },
+    "packages/config-resolver": {
+        "component": "config-resolver",
+        "release-type": "node"
+    },
     "packages/es-schemas": {
         "component": "es-schemas",
         "release-type": "node"
     }
   },
   "plugins": [
+    {
+        "type": "node-workspace"
+    },
     {
         "type": "sentence-case"
     }

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -65,7 +65,7 @@ released to the public npm registry; depend on it through the workspace.
 
 ------------------------------------------------------------------------
 @elastic/es-schemas@1.0.0
-License: Apache-2.0
+License: UNLICENSED
 Repository: https://github.com/elastic/cli
 Publisher: Elastic Client Library Maintainers
 ------------------------------------------------------------------------

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,10 @@
     "": {
       "name": "@elastic/cli",
       "version": "0.1.0",
+      "bundleDependencies": [
+        "@elastic/config-resolver",
+        "@elastic/es-schemas"
+      ],
       "license": "Apache-2.0",
       "workspaces": [
         "packages/*"
@@ -8722,7 +8726,7 @@
     },
     "packages/es-schemas": {
       "name": "@elastic/es-schemas",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,10 @@
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
   },
+  "bundledDependencies": [
+    "@elastic/config-resolver",
+    "@elastic/es-schemas"
+  ],
   "devDependencies": {
     "@eslint/js": "10.0.1",
     "@types/marked-terminal": "6.1.1",

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -3,8 +3,7 @@
   "version": "0.1.0",
   "description": "Expression resolver for the Elastic CLI config pipeline. Resolves $(name:params) references from sources like env vars, files, and OS keychains.",
   "license": "Apache-2.0",
-  "private": true,
-  "type": "module",
+"type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "description": "Expression resolver for the Elastic CLI config pipeline. Resolves $(name:params) references from sources like env vars, files, and OS keychains.",
   "license": "Apache-2.0",
-"type": "module",
+  "private": true,
+  "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/packages/es-schemas/package.json
+++ b/packages/es-schemas/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "build": "tsc"
   },
+  "private": true,
   "license": "Apache-2.0",
   "author": {
     "name": "Elastic Client Library Maintainers",


### PR DESCRIPTION
## Summary

Fixes #308 — `npm install @elastic/cli` was failing with E404 because `@elastic/config-resolver` and `@elastic/es-schemas` are declared as runtime dependencies but were never published to npm.

- **Add `bundledDependencies`** for both workspace packages in the root `package.json`. npm will include them verbatim in the published tarball so consumers never need to fetch them from the registry.
- **Add `packages/config-resolver`** to `.github/release-please-config.json` so it gets its own changelog, tags, and version bumps tracked by release-please.
- **Add the `node-workspace` plugin** to release-please config so that when either workspace package is versioned, the CLI's dependency references in `package.json` are updated automatically in the release PR (and the CLI gets a patch bump if it has no other changes).

## What to verify

- `npm pack --dry-run` shows `@elastic/config-resolver` and `@elastic/es-schemas` in the tarball listing
- `.github/release-please-config.json` — all three packages tracked, `node-workspace` plugin present
- The publish step in `release.yml` (`npm publish` without `--workspaces`) continues to publish only `@elastic/cli`; workspace packages are not published separately
