### PR TITLE
fix(factory): handle EAGAIN/EBADF from stdin in non-blocking environments

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -435,7 +435,21 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
         }
         inputValue = parseJsonContent(fileContent, '--input-file', cmd)
       } else if (!process.stdin.isTTY) {
-        const raw = stdinReader()
+        // EAGAIN / EBADF can occur in IDE terminals (Cursor, VS Code integrated
+        // terminal) and some CI environments where stdin is set to non-blocking
+        // mode but no data is piped. Treat these as "no stdin data" rather than
+        // crashing with an unhandled exception.
+        let raw: string
+        try {
+          raw = stdinReader()
+        } catch (err: unknown) {
+          const code = (err as NodeJS.ErrnoException).code
+          if (code === 'EAGAIN' || code === 'EBADF') {
+            raw = ''
+          } else {
+            throw err
+          }
+        }
         if (raw.trim().length > 0) {
           inputValue = parseJsonContent(raw, 'stdin', cmd)
         }

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -1186,6 +1186,58 @@ describe('defineCommand', () => {
         restore()
       }
     })
+
+    it('treats EAGAIN from stdin as no input (non-blocking fd in IDE terminals)', async () => {
+      const eagainErr = Object.assign(new Error('EAGAIN'), { code: 'EAGAIN' })
+      const restore = _testSetStdinReader(() => { throw eagainErr })
+      try {
+        const received: unknown[] = []
+        const cmd = defineCommand({
+          name: 'search',
+          description: 'Run a search',
+          input: z.object({ q: z.string().optional() }),
+          handler: (p) => { received.push(p.input); return {} },
+        })
+        await invokeAsync(cmd, [])
+        assert.equal(received.length, 1)
+      } finally {
+        restore()
+      }
+    })
+
+    it('treats EBADF from stdin as no input', async () => {
+      const ebadfErr = Object.assign(new Error('EBADF'), { code: 'EBADF' })
+      const restore = _testSetStdinReader(() => { throw ebadfErr })
+      try {
+        const received: unknown[] = []
+        const cmd = defineCommand({
+          name: 'search',
+          description: 'Run a search',
+          input: z.object({ q: z.string().optional() }),
+          handler: (p) => { received.push(p.input); return {} },
+        })
+        await invokeAsync(cmd, [])
+        assert.equal(received.length, 1)
+      } finally {
+        restore()
+      }
+    })
+
+    it('re-throws unexpected stdin errors (not EAGAIN/EBADF)', async () => {
+      const ioErr = Object.assign(new Error('EIO'), { code: 'EIO' })
+      const restore = _testSetStdinReader(() => { throw ioErr })
+      try {
+        const cmd = defineCommand({
+          name: 'search',
+          description: 'Run a search',
+          input: z.object({ q: z.string().optional() }),
+          handler: () => ({}),
+        })
+        await assert.rejects(() => invokeAsync(cmd, []), { code: 'EIO' })
+      } finally {
+        restore()
+      }
+    })
   })
 
   describe('JSON input conflict resolution', () => {


### PR DESCRIPTION
## Summary

Fixes #311.

In IDE terminals (Cursor, VS Code integrated terminal) and some CI environments, `process.stdin.isTTY` is falsy even when no data is piped. Attempting a synchronous `readFileSync(0)` in those conditions fails with `EAGAIN` (non-blocking fd, no data ready) or `EBADF`, which produced an unhandled exception with a raw Node.js stack trace on any command with an `input` schema (the entire `es` namespace).

## Changes

- `src/factory.ts`: wrap the `stdinReader()` call site with a try-catch that converts `EAGAIN` / `EBADF` to empty string, consistent with the existing empty-string path. All other errors are re-thrown unchanged.
- `test/factory.test.ts`: three new tests covering EAGAIN, EBADF, and re-throw of unexpected errors.

## Test plan

- `treats EAGAIN from stdin as no input` -- new
- `treats EBADF from stdin as no input` -- new
- `re-throws unexpected stdin errors (not EAGAIN/EBADF)` -- new
- All 266 existing factory tests still pass