### PR TITLE
feat(cli): add root version flag

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,7 +21,7 @@ const program = new Command()
 program
   .name('elastic')
   .description('Interface with the Elastic Stack and Elastic Cloud from the command line.')
-  .version(VERSION, '-V, --version', 'Print the elastic CLI version')
+  .version(VERSION, '-V, --version', 'Print the Elastic CLI version')
   .option('--config-file <path>', 'path to a config file (default: ~/.elasticrc.yml)')
   .option('--use-context <name>', 'override the active context from the config file')
   .option(`--command-profile <name>`, `restrict available commands to a deployment profile (${BUILT_IN_PROFILES.join(', ')})`)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -21,6 +21,7 @@ const program = new Command()
 program
   .name('elastic')
   .description('Interface with the Elastic Stack and Elastic Cloud from the command line.')
+  .version(VERSION, '-V, --version', 'Print the elastic CLI version')
   .option('--config-file <path>', 'path to a config file (default: ~/.elasticrc.yml)')
   .option('--use-context <name>', 'override the active context from the config file')
   .option(`--command-profile <name>`, `restrict available commands to a deployment profile (${BUILT_IN_PROFILES.join(', ')})`)

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -21,6 +21,7 @@ import { Command } from 'commander'
 function makeProgram(): InstanceType<typeof Command> {
   const prog = new Command('elastic')
   prog.exitOverride()
+  prog.version('0.1.1', '-V, --version', 'Print the elastic CLI version')
   prog.option('--config-file <path>', 'path to a config file (default: ~/.elasticrc.yml)')
   prog.option('--use-context <name>', 'override the active context from the config file')
   prog.option('--json', 'output as JSON')
@@ -47,10 +48,12 @@ describe('elastic CLI -- global flags', () => {
     assert.ok(!opt.required, '--json should be a boolean flag (no required value)')
   })
 
-  it('does not register --version as a flag (version is a subcommand)', () => {
+  it('registers --version as a boolean flag', () => {
     const prog = makeProgram()
     const opt = prog.options.find((o) => o.long === '--version')
-    assert.ok(opt == null, '--version must not be a global flag; use `elastic version` subcommand')
+    assert.ok(opt != null, 'expected --version option')
+    assert.ok(!opt.required, '--version should be a boolean flag (no required value)')
+    assert.equal(opt.short, '-V')
   })
 
   it('does not register --format as a flag', () => {
@@ -193,6 +196,28 @@ describe('elastic CLI -- config caching (preAction reuse)', () => {
 })
 
 describe('elastic CLI -- config-free commands', () => {
+  it('`elastic --version` succeeds without a config file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-noconfig-'))
+    try {
+      const { code, stdout } = await runCli(['--version'], { cwd: dir, env: { HOME: dir } })
+      assert.equal(code, 0, `expected exit code 0, got ${code}`)
+      assert.match(stdout, /^0\.1\.1\s*$/)
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
+  it('`elastic -V` succeeds without a config file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-noconfig-'))
+    try {
+      const { code, stdout } = await runCli(['-V'], { cwd: dir, env: { HOME: dir } })
+      assert.equal(code, 0, `expected exit code 0, got ${code}`)
+      assert.match(stdout, /^0\.1\.1\s*$/)
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
   it('`elastic version` succeeds without a config file', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-noconfig-'))
     try {


### PR DESCRIPTION
## Summary

- Add Commander root `-V, --version` support using the existing CLI version constant.
- Keep the existing `elastic version` subcommand available for JSON output.
- Update CLI tests to cover the new root version flags without requiring a config file.

Closes #313

## Verification

- `npm run build`
- `node --max-old-space-size=8192 --import tsx/esm --test test/cli.test.ts`
- `npm run test:lint`
- `npm run test:license`
- `npm test`
- Manual: `node dist\cli.js --version`, `node dist\cli.js -V`, `node dist\cli.js version --json`

This was implemented with Codex assistance, with the final diff and verification reviewed manually.