### PR TITLE
fix(output): allow literal-dotted keys in --output-fields paths

### DIFF
--- a/src/lib/output-transform.ts
+++ b/src/lib/output-transform.ts
@@ -24,6 +24,12 @@ export function pickFields (value: JsonValue, fields: string[]): JsonValue {
 
   const result: Record<string, JsonValue> = {}
   for (const field of fields) {
+    // If the source has the literal dotted key (cat API style), preserve it
+    // verbatim in the result; otherwise descend the path nestedly.
+    if (Object.prototype.hasOwnProperty.call(value, field) && value[field] !== undefined) {
+      result[field] = value[field]
+      continue
+    }
     const val = getNestedValue(value, field)
     if (val !== undefined) {
       setNestedValue(result, field, val)
@@ -33,6 +39,12 @@ export function pickFields (value: JsonValue, fields: string[]): JsonValue {
 }
 
 function getNestedValue (obj: Record<string, JsonValue>, path: string): JsonValue | undefined {
+  // Literal-key fast path: cat APIs and similar return flat objects whose keys
+  // contain literal dots (e.g. "docs.count"). Prefer a literal match over splitting,
+  // so a literal key wins over an equivalent nested path when both exist.
+  if (obj !== null && typeof obj === 'object' && !Array.isArray(obj) && obj[path] !== undefined) {
+    return obj[path]
+  }
   const parts = path.split('.')
   let current: JsonValue = obj
   for (const part of parts) {

--- a/test/lib/output-transform.test.ts
+++ b/test/lib/output-transform.test.ts
@@ -71,6 +71,37 @@ describe('pickFields — dot-notation', () => {
 })
 
 // ---------------------------------------------------------------------------
+// pickFields — literal-dotted keys (cat API style)
+// ---------------------------------------------------------------------------
+
+describe('pickFields — literal-dotted keys', () => {
+  it('matches a literal-dotted key (cat-API case)', () => {
+    const input = { 'docs.count': '5', index: 'x' }
+    assert.deepEqual(pickFields(input, ['docs.count']), { 'docs.count': '5' })
+  })
+
+  it('still descends nested objects when no literal key exists', () => {
+    const input = { docs: { count: '5' } }
+    assert.deepEqual(pickFields(input, ['docs.count']), { docs: { count: '5' } })
+  })
+
+  it('prefers the literal key over a nested path when both exist', () => {
+    const input = { 'docs.count': '10', docs: { count: '5' } }
+    assert.deepEqual(pickFields(input, ['docs.count']), { 'docs.count': '10' })
+  })
+
+  it('preserves all fields on a cat-indices-shaped row', () => {
+    const input = [
+      { health: 'green', index: 'i', 'docs.count': '5', 'store.size': '31kb' },
+    ]
+    assert.deepEqual(
+      pickFields(input, ['index', 'docs.count', 'store.size']),
+      [{ index: 'i', 'docs.count': '5', 'store.size': '31kb' }],
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
 // pickFields — arrays
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Cat APIs return flat objects whose keys contain literal dots (`docs.count`, `store.size`), but `--output-fields` parsing split every dot as a nesting separator, silently dropping those fields.
- `getNestedValue` now prefers a literal-key match before falling back to dot-notation descent; `pickFields` preserves the literal key verbatim in the projected output.
- Existing nested-path behaviour for normal JSON responses is unchanged; a literal key wins over an equivalent nested path when both are present.

Closes #325