### PR TITLE
fix(factory): support '-' as stdin sentinel for --input-file

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -652,10 +652,14 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
       const filePath = cmd.getOptionValue('inputFile') as string | undefined
       if (filePath !== undefined) {
         let fileContent: string
-        try {
-          fileContent = readFileSync(filePath, 'utf-8')
-        } catch {
-          return cmd.error(`--input-file: file not found: ${filePath}`)
+        if (filePath === '-') {
+          fileContent = stdinReader()
+        } else {
+          try {
+            fileContent = readFileSync(filePath, 'utf-8')
+          } catch {
+            return cmd.error(`--input-file: file not found: ${filePath}`)
+          }
         }
         inputValue = parseJsonContent(fileContent, '--input-file', cmd)
       } else if (!process.stdin.isTTY) {

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -1073,6 +1073,56 @@ describe('defineCommand', () => {
       const err = await captureErrAsync(cmd, [])
       assert.match(err, /input validation failed/i)
     })
+
+    it('reads from stdin when --input-file is "-" (stdin sentinel)', async () => {
+      const restore = _testSetStdinReader(() => JSON.stringify({ cluster: 'test', shards: 5 }))
+      try {
+        const received: ParsedResult[] = []
+        const cmd = defineCommand({
+          name: 'query',
+          description: 'Run a query',
+          input: z.object({ cluster: z.string(), shards: z.number() }),
+          handler: (parsed) => { received.push(parsed); return {} },
+        })
+        await invokeAsync(cmd, ['--input-file', '-'])
+        assert.equal(received.length, 1)
+        assert.deepEqual(received[0].input, { cluster: 'test', shards: 5 })
+      } finally {
+        restore()
+      }
+    })
+
+    it('errors with --input-file source label when stdin (via "-") contains malformed JSON', async () => {
+      const restore = _testSetStdinReader(() => 'not { valid } json ][')
+      try {
+        const cmd = defineCommand({
+          name: 'query',
+          description: 'Run a query',
+          input: z.object({ q: z.string() }),
+          handler: () => ({}),
+        })
+        const err = await captureErrAsync(cmd, ['--input-file', '-'])
+        assert.match(err, /--input-file: invalid JSON:/)
+      } finally {
+        restore()
+      }
+    })
+
+    it('errors with "empty content" when --input-file is "-" and stdin is empty', async () => {
+      const restore = _testSetStdinReader(() => '')
+      try {
+        const cmd = defineCommand({
+          name: 'query',
+          description: 'Run a query',
+          input: z.object({ q: z.string() }),
+          handler: () => ({}),
+        })
+        const err = await captureErrAsync(cmd, ['--input-file', '-'])
+        assert.match(err, /--input-file: invalid JSON: empty content/)
+      } finally {
+        restore()
+      }
+    })
   })
 
   describe('JSON input via stdin', () => {


### PR DESCRIPTION
## Summary

- Treat `--input-file -` as a request to read JSON input from stdin, matching the Unix convention used by curl, kubectl, jq, and similar tools.
- Previously `elastic <cmd> --input-file -` failed with `Error: --input-file: file not found: -` because the resolver passed `-` to `readFileSync` unconditionally.
- The fix detects the `-` sentinel before the file-read branch and delegates to the existing module-level `stdinReader`; error messages continue to use the `--input-file` source label for consistency.

Closes #335