### PR TITLE
fix(output): project --output-fields across array nodes

### DIFF
--- a/src/lib/output-transform.ts
+++ b/src/lib/output-transform.ts
@@ -32,16 +32,22 @@ export function pickFields (value: JsonValue, fields: string[]): JsonValue {
   return result
 }
 
-function getNestedValue (obj: Record<string, JsonValue>, path: string): JsonValue | undefined {
-  const parts = path.split('.')
-  let current: JsonValue = obj
-  for (const part of parts) {
-    if (current === null || typeof current !== 'object' || Array.isArray(current)) return undefined
-    const next: JsonValue | undefined = (current as Record<string, JsonValue>)[part]
-    if (next === undefined) return undefined
-    current = next
+function getNestedValue (obj: JsonValue, path: string): JsonValue | undefined {
+  if (obj === null || typeof obj !== 'object') return undefined
+  if (Array.isArray(obj)) {
+    return obj
+      .map((el) => getNestedValue(el, path))
+      .filter((v): v is JsonValue => v !== undefined)
   }
-  return current
+  const dot = path.indexOf('.')
+  if (dot === -1) {
+    return (obj as Record<string, JsonValue>)[path]
+  }
+  const head = path.slice(0, dot)
+  const rest = path.slice(dot + 1)
+  const next = (obj as Record<string, JsonValue>)[head]
+  if (next === undefined) return undefined
+  return getNestedValue(next, rest)
 }
 
 function setNestedValue (obj: Record<string, JsonValue>, path: string, value: JsonValue): void {
@@ -86,7 +92,7 @@ export function applyTemplate (value: JsonValue, template: string): string {
 
   return template.replace(/\{\{\s*([^}]+?)\s*\}\}/g, (_match, field: string) => {
     if (field === '.') return JSON.stringify(value)
-    const val = getNestedValue(value as Record<string, JsonValue>, field)
+    const val = getNestedValue(value, field)
     if (val === undefined || val === null) return ''
     if (typeof val === 'object') return JSON.stringify(val)
     return String(val)

--- a/test/lib/output-transform.test.ts
+++ b/test/lib/output-transform.test.ts
@@ -93,6 +93,58 @@ describe('pickFields — arrays', () => {
 })
 
 // ---------------------------------------------------------------------------
+// pickFields — projection across arrays (mid-path)
+// ---------------------------------------------------------------------------
+
+describe('pickFields — projection across arrays', () => {
+  it('projects a leaf path across an inner array', () => {
+    const input = { hits: { hits: [{ _id: 'x' }, { _id: 'y' }] } }
+    assert.deepEqual(pickFields(input, ['hits.hits._id']), { hits: { hits: { _id: ['x', 'y'] } } })
+  })
+
+  it('projects multiple paths across an inner array', () => {
+    const input = {
+      hits: {
+        hits: [
+          { _id: '1', _source: { title: 'First' } },
+          { _id: '2', _source: { title: 'Second' } },
+        ],
+      },
+    }
+    assert.deepEqual(pickFields(input, ['hits.hits._id', 'hits.hits._source.title']), {
+      hits: {
+        hits: {
+          _id: ['1', '2'],
+          _source: { title: ['First', 'Second'] },
+        },
+      },
+    })
+  })
+
+  it('drops array elements where the projected path is missing', () => {
+    const input = { items: [{ a: 1 }, { b: 2 }, { a: 3 }] }
+    assert.deepEqual(pickFields(input, ['items.a']), { items: { a: [1, 3] } })
+  })
+
+  it('returns an empty array when no element matches the path', () => {
+    const input = { items: [{ a: 1 }, { a: 2 }] }
+    assert.deepEqual(pickFields(input, ['items.b']), { items: { b: [] } })
+  })
+
+  it('handles nested arrays in the middle of a path', () => {
+    const input = {
+      groups: [
+        { items: [{ id: 'a' }, { id: 'b' }] },
+        { items: [{ id: 'c' }] },
+      ],
+    }
+    assert.deepEqual(pickFields(input, ['groups.items.id']), {
+      groups: { items: { id: [['a', 'b'], ['c']] } },
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
 // pickFields — primitives (pass-through)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `--output-fields` returned `{}` whenever a projection path crossed an array (e.g. `hits.hits._id` on a search response) because `getNestedValue` bailed out on encountering an `Array`.
- `getNestedValue` now recurses into array elements and collects matched values, mirroring `jq '.path[].field'`. Missing leaves are filtered out.
- Tests cover leaf projection across an inner array, multi-path projection, missing-leaf filtering, all-missing leaves, and arrays-of-arrays in the middle of a path. Existing dot-notation and array tests still pass.

Closes #326.