### PR TITLE
fix(cli): bundle zod to fix `npm install -g` first-run failure

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -64,7 +64,7 @@ released to the public npm registry; depend on it through the workspace.
 
 
 ------------------------------------------------------------------------
-@elastic/es-schemas@1.0.0
+@elastic/es-schemas@1.0.1
 License: UNLICENSED
 Repository: https://github.com/elastic/cli
 Publisher: Elastic Client Library Maintainers

--- a/README.md
+++ b/README.md
@@ -4,17 +4,30 @@ Interact with the Elastic Stack and Elastic Cloud from the command line.
 
 ## Installation
 
-Install from npm:
+Install globally from npm so the `elastic` binary is available on your `PATH`:
 
 ```bash
-npm install @elastic/cli
-```
-
-Then you should be able to run `elastic` commands:
-
-```bash
+npm install -g @elastic/cli
 elastic --help
 ```
+
+If you don't want a global install, you can run a one-off invocation with
+`npx`, which downloads and runs the CLI without persisting it:
+
+```bash
+npx -y @elastic/cli --help
+```
+
+> If `npm install -g` fails with an `EACCES` permission error on Linux/macOS,
+> either re-run with `sudo` or (recommended) point npm's global prefix at a
+> user-owned directory:
+>
+> ```bash
+> mkdir -p ~/.npm-global
+> npm config set prefix ~/.npm-global
+> echo 'export PATH=~/.npm-global/bin:$PATH' >> ~/.bashrc
+> source ~/.bashrc
+> ```
 
 ## Configuration
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       ],
       "dependencies": {
         "@elastic/config-resolver": "*",
-        "@elastic/es-schemas": "*",
+        "@elastic/es-schemas": "1.0.1",
         "@elastic/transport": "^9.3.5",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
   },
   "bundledDependencies": [
     "@elastic/config-resolver",
-    "@elastic/es-schemas"
+    "@elastic/es-schemas",
+    "zod"
   ],
   "devDependencies": {
     "@eslint/js": "10.0.1",

--- a/test/packaging.test.ts
+++ b/test/packaging.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/**
+ * Guards against a recurrence of the broken-`npm install -g @elastic/cli`
+ * failure where the binary crashed with `Cannot find package 'zod'` because
+ * the global install left `node_modules/zod/` empty.
+ *
+ * Root cause: `@elastic/es-schemas` is shipped via `bundledDependencies`
+ * and declares `zod` as a peer dependency. During a global install npm
+ * cannot hoist `zod` to a parent `node_modules`, and the bundled-dep +
+ * peer-dep interaction makes its dependency resolver create an empty
+ * placeholder directory for `zod` without populating it. The simplest
+ * deterministic fix is to ship `zod` inside the published tarball by
+ * adding it to `bundledDependencies` as well.
+ *
+ * These invariants make sure nobody silently removes `zod` from the
+ * bundle or lets the version drift out of sync with the peer dep
+ * required by the bundled `@elastic/es-schemas` workspace package.
+ */
+
+interface PackageJsonShape {
+  dependencies?: Record<string, string>
+  bundledDependencies?: string[]
+  peerDependencies?: Record<string, string>
+}
+
+function readJson (relPath: string): PackageJsonShape {
+  const raw = readFileSync(resolve(process.cwd(), relPath), 'utf8')
+  return JSON.parse(raw) as PackageJsonShape
+}
+
+describe('package.json -- npm install invariants', () => {
+  const root = readJson('package.json')
+  const esSchemas = readJson('packages/es-schemas/package.json')
+
+  it('declares zod as a regular dependency', () => {
+    assert.ok(
+      root.dependencies?.['zod'] != null,
+      'zod must be listed under "dependencies" so it is recorded as a production dep'
+    )
+  })
+
+  it('bundles zod into the published tarball', () => {
+    assert.ok(
+      Array.isArray(root.bundledDependencies),
+      '"bundledDependencies" must be an array'
+    )
+    assert.ok(
+      root.bundledDependencies?.includes('zod') ?? false,
+      'zod must appear in "bundledDependencies" so `npm install -g` does not leave node_modules/zod/ empty'
+    )
+  })
+
+  it('bundles every workspace package that declares zod as a peer dependency', () => {
+    // If a bundled workspace package needs zod, the top-level zod must be
+    // bundled too -- otherwise npm tries to resolve the peer dep at install
+    // time and trips the empty-placeholder bug.
+    if (esSchemas.peerDependencies?.['zod'] != null) {
+      assert.ok(
+        root.bundledDependencies?.includes('zod') ?? false,
+        '@elastic/es-schemas declares a peer dep on zod, so the top-level zod must be bundled'
+      )
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `zod` to `bundledDependencies` so it ships inside the published tarball, fixing `npm install -g @elastic/cli` failing on first run with `Cannot find package 'zod'` from `dist/factory.js`.
- Adds a regression test (`test/packaging.test.ts`) that pins the invariants: `zod` must stay in both `dependencies` and `bundledDependencies`, and any bundled workspace package declaring a peer dep on `zod` must keep the top-level `zod` bundled.
- Updates the README install snippet to use `npm install -g`, documents `npx -y @elastic/cli` as a one-off alternative, and adds a short note about the common `EACCES` users hit on global installs.

Closes https://github.com/elastic/cli/issues/339

## Root cause

`@elastic/es-schemas` is shipped via `bundledDependencies` (since #309) and declares `zod` as a peer dependency. During a global install npm cannot hoist `zod` to a parent `node_modules`, and the bundled-dep + peer-dep interaction makes npm's resolver create an empty placeholder at `@elastic/cli/node_modules/zod/` without populating it. The binary then crashes with `ERR_MODULE_NOT_FOUND`. Re-running `npm install -g` happens to fix it because the broken on-disk state nudges the resolver onto a different code path.

Bundling `zod` removes the peer-resolution step at install time, so the install is deterministic on the first pass.

## Test plan

- [x] `npm test` passes (1159 tests, exit 0).
- [x] New regression test confirmed to fail on `main` and pass on this branch (TDD).
- [x] `npm pack` produces a tarball that contains a populated `package/node_modules/zod/` (including `package.json`, `index.js`, `index.cjs`).
- [x] Installing that tarball into an isolated `--prefix=/tmp/...` global root produces a working `elastic --help` on the first install (no need to re-run).
- [ ] CI green on Linux/macOS/Windows.
- [ ] Manual: try `npm install -g @elastic/cli@<this version>` once published and confirm first-run success.

## Related

- Builds on #309 which introduced the `bundledDependencies` for workspace packages.
- Fixes the symptom users hit when following the README install instructions; the README is also updated in this PR so the documented flow works end-to-end.

Made with [Cursor](https://cursor.com)