### PR TITLE
docs(sanitize): clarify index-name validation scope

### DIFF
--- a/src/sanitize/register.ts
+++ b/src/sanitize/register.ts
@@ -30,11 +30,17 @@ import {
 interface SanitizerEntry {
   name: string
   description: string
+  stderrNote?: string
   fn: (value: string) => SanitizeResult
 }
 
 const SANITIZERS: SanitizerEntry[] = [
-  { name: 'index-name', description: 'Sanitize an Elasticsearch index or alias name', fn: sanitizeIndexName },
+  {
+    name: 'index-name',
+    description: 'Apply local sanitization rules for an Elasticsearch index or alias name; full Elasticsearch validation still required',
+    stderrNote: 'full Elasticsearch validation still required',
+    fn: sanitizeIndexName,
+  },
   { name: 'snapshot-name', description: 'Sanitize an Elasticsearch snapshot name', fn: sanitizeSnapshotName },
   { name: 'data-stream-type', description: 'Sanitize a data stream type component', fn: sanitizeDataStreamType },
   { name: 'data-stream-dataset', description: 'Sanitize a data stream dataset component', fn: sanitizeDataStreamDataset },
@@ -49,7 +55,7 @@ const SANITIZERS: SanitizerEntry[] = [
  * value type.
  */
 export function registerSanitizeCommands (): OpaqueCommandHandle {
-  const commands = SANITIZERS.map(({ name, description, fn }) =>
+  const commands = SANITIZERS.map(({ name, description, stderrNote, fn }) =>
     defineCommand({
       name,
       description,
@@ -73,7 +79,8 @@ export function registerSanitizeCommands (): OpaqueCommandHandle {
       formatOutput: (result) => {
         const r = result as unknown as SanitizeResult
         if (r.changes.length > 0) {
-          process.stderr.write(`# changes: ${r.changes.join(', ')}\n`)
+          const note = stderrNote !== undefined ? `; note: ${stderrNote}` : ''
+          process.stderr.write(`# changes: ${r.changes.join(', ')}${note}\n`)
         }
         return r.sanitized + '\n'
       },

--- a/test/sanitize/register.test.ts
+++ b/test/sanitize/register.test.ts
@@ -82,6 +82,39 @@ describe('registerSanitizeCommands', () => {
     assert.ok(stderr.includes('stripped forbidden characters'), `stderr should list changes, got: ${stderr}`)
   })
 
+  it('index-name help documents local sanitization scope', () => {
+    const group = registerSanitizeCommands()
+    const indexCmd = (group.commands as Array<{ name: () => string }>).find(c => c.name() === 'index-name')!;
+
+    const help = (indexCmd as import('commander').Command).helpInformation()
+    assert.match(help, /local sanitization rules/i)
+    assert.match(help, /full\s+Elasticsearch\s+validation/i)
+  })
+
+  it('index-name stderr notes that full validation still applies', async () => {
+    const group = registerSanitizeCommands()
+    const indexCmd = (group.commands as Array<{ name: () => string }>).find(c => c.name() === 'index-name')!;
+
+    (indexCmd as import('commander').Command).exitOverride()
+    const stdoutChunks: string[] = []
+    const stderrChunks: string[] = []
+    const origStdout = process.stdout.write.bind(process.stdout)
+    const origStderr = process.stderr.write.bind(process.stderr)
+    process.stdout.write = ((chunk: string) => { stdoutChunks.push(chunk); return true }) as typeof process.stdout.write
+    process.stderr.write = ((chunk: string) => { stderrChunks.push(chunk); return true }) as typeof process.stderr.write
+    try {
+      await (indexCmd as import('commander').Command).parseAsync(['Foo Bar!'], { from: 'user' })
+    } finally {
+      process.stdout.write = origStdout
+      process.stderr.write = origStderr
+    }
+
+    assert.equal(stdoutChunks.join(''), 'foobar!\n')
+    const stderr = stderrChunks.join('')
+    assert.ok(stderr.includes('lowercased'), `stderr should list changes, got: ${stderr}`)
+    assert.ok(stderr.includes('full Elasticsearch validation still required'), `stderr should note validation scope, got: ${stderr}`)
+  })
+
   it('returns error result when value is empty after sanitization', async () => {
     const group = registerSanitizeCommands()
     const indexCmd = (group.commands as Array<{ name: () => string }>).find(c => c.name() === 'index-name')!;


### PR DESCRIPTION
## Summary

- clarify that `sanitize index-name` applies local sanitization rules and full Elasticsearch validation can still reject a result
- add the same validation-scope note to changed plain-text `index-name` output
- add regression coverage for the updated help/stderr wording

This follows the documentation fallback described in #324. I checked current `elastic/elasticsearch` `validateIndexOrAliasName`/`Strings.INVALID_CHARS`; `!` is not listed in the static invalid-character checks there, so this PR does not add `!` to the strip list.

## Validation

- `node --import tsx/esm --test test/lib/sanitize.test.ts test/sanitize/register.test.ts` -> 55 tests passed
- `npm run build` -> passed
- `node dist/cli.js sanitize index-name 'Foo Bar!'` -> prints `foobar!` with `note: full Elasticsearch validation still required`
- `node dist/cli.js sanitize index-name --help` -> documents local sanitization rules and full Elasticsearch validation
- `npm run test:lint` -> passed
- `npm test` -> passed
- `git diff --check HEAD~1 HEAD` -> passed
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30` -> no leaks found

Addresses #324.
