### PR TITLE
fix(factory): preserve optionality on JSON body field relaxation

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -770,9 +770,6 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
       if (jsonBodyFields.length > 0 && validationSchema instanceof z.ZodObject) {
         const overrides: Record<string, z.ZodType> = {}
         for (const f of jsonBodyFields) {
-          // Preserve the original field's optionality. Since Zod 4.4, `.extend()`
-          // drops `.optional()` from the replaced field, so an optional body field
-          // overridden with bare `z.any()` would suddenly become a required key.
           overrides[f.schemaKey] = f.required ? z.any() : z.any().optional()
         }
         validationSchema = (validationSchema as z.ZodObject<z.ZodRawShape>).extend(overrides)

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -770,7 +770,10 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
       if (jsonBodyFields.length > 0 && validationSchema instanceof z.ZodObject) {
         const overrides: Record<string, z.ZodType> = {}
         for (const f of jsonBodyFields) {
-          overrides[f.schemaKey] = z.any()
+          // Preserve the original field's optionality. Since Zod 4.4, `.extend()`
+          // drops `.optional()` from the replaced field, so an optional body field
+          // overridden with bare `z.any()` would suddenly become a required key.
+          overrides[f.schemaKey] = f.required ? z.any() : z.any().optional()
         }
         validationSchema = (validationSchema as z.ZodObject<z.ZodRawShape>).extend(overrides)
       }

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -1608,6 +1608,47 @@ describe('defineCommand', () => {
       const input = received[0] as Record<string, unknown>
       assert.deepEqual(input.operations, [{ index: {} }, { name: 'doc' }])
     })
+
+    // Regression: in Zod >=4.4, `.extend({ key: z.any() })` drops `.optional()`
+    // from the replaced field, turning previously-optional JSON body fields
+    // into required keys. The factory must re-apply `.optional()` on its
+    // body-field overrides so omitted optional fields still validate.
+    it('omitting an optional object body field still validates', async () => {
+      const schema = z.object({
+        index: z.string().meta({ found_in: 'path' }),
+        aliases: z.record(z.string(), z.any()).optional().meta({ found_in: 'body' }),
+        mappings: z.object({ properties: z.record(z.string(), z.any()) }).optional().meta({ found_in: 'body' }),
+      })
+      const received: unknown[] = []
+      const cmd = defineCommand({
+        name: 'create',
+        description: 'Create index',
+        input: schema,
+        handler: (parsed) => { received.push(parsed.input); return {} },
+      })
+      await invokeAsync(cmd, ['--index', 'foo'])
+      assert.equal(received.length, 1)
+      const input = received[0] as Record<string, unknown>
+      assert.equal(input.index, 'foo')
+    })
+
+    it('required object body fields remain required after relaxation', async () => {
+      const schema = z.object({
+        service: z.string().meta({ found_in: 'body' }),
+        service_settings: z.object({ api_key: z.string() }).meta({ found_in: 'body' }),
+      })
+      const cmd = defineCommand({
+        name: 'put',
+        description: 'Put inference',
+        input: schema,
+        handler: () => ({}),
+      })
+      // Missing required object body field should still fail validation.
+      await assert.rejects(
+        invokeAsync(cmd, ['--service', 'mistral']),
+        /input validation failed|service_settings/i,
+      )
+    })
   })
 
   describe('commands without input schema', () => {


### PR DESCRIPTION
## Summary

The Buildkite ES functional test suite has been failing (22 pass / 63 fail) since the bump to Zod 4.4.3 (#320). Most failures surface as a CLI process crash with `{ exitCode: 1 }` followed by Node's `Node.js v…` uncaught-exception trailer. The cause is in the factory's JSON-body relaxation, not in the generated schemas or the test codegen.

## Root cause

`src/factory.ts` relaxes object/array body fields to `z.any()` so the CLI can pass user-provided ES DSL through without strict client-side validation:

```ts
overrides[f.schemaKey] = z.any()
validationSchema = validationSchema.extend(overrides)
```

In Zod 4.4 (PR [colinhacks/zod#5661](https://github.com/colinhacks/zod/pull/5661)), `.extend()` drops `.optional()` from the replaced field. So every previously-optional JSON body field (`aliases`, `mappings`, `settings`, `query`, `doc`, …) became a **required key**. Any invocation that omitted one — e.g. `elastic stack es indices create --index foo` — failed with:

```json
{"error":{"code":"input_validation_failed","issues":[
  {"code":"invalid_type","expected":"nonoptional","path":["aliases"], …},
  {"code":"invalid_type","expected":"nonoptional","path":["mappings"], …},
  {"code":"invalid_type","expected":"nonoptional","path":["settings"], …}
]}}
```

The thrown `Error` bubbled out of `program.parseAsync` uncaught, which is why bash saw an empty `RESPONSE` and Node printed its crash trailer. Many of the 404 (`index_not_found_exception`) failures are downstream of this: setup steps run with `|| true` would silently swallow the validation crash, then the test step would hit a missing index.

## Fix

Preserve the original field's optionality when overriding:

```ts
overrides[f.schemaKey] = f.required ? z.any() : z.any().optional()
```

`schemaArgs[*].required` already reflects the source schema's optionality, so required body fields (e.g. `inference put-mistral`'s `service_settings`) continue to be enforced.

## Verification

- `npm run test:unit` — 1175/1175 pass (added 2 regression tests under "relaxed validation for JSON body fields").
- Local repro before fix: `elastic --json stack es indices create --index foo --dry-run` → `expected nonoptional` on `aliases`/`mappings`/`settings`.
- Local repro after fix: same command → `{"success":true}`.
- Spot-checked `bulk`, `search`, `count`, `update`, `inference put-mistral` (required body field still required) — all behave as expected.

## Test plan

- [ ] CI green on this PR (unit, lint, license)
- [ ] Re-run the Buildkite ES functional pipeline and confirm the 63 failures clear (or at least all Pattern 1 JS-exception failures)
