### PR TITLE
fix(es): parse --sort <field>:<direction> for body-routed Sort args

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -290,6 +290,32 @@ function camelCase (s: string): string {
 }
 
 /**
+ * Parses an ES `Sort` CLI value into the shape ES expects in a request body.
+ *
+ * The CLI help text advertises the URL-query grammar (`<field>:<direction>` pairs, comma-
+ * separated), but the request body needs explicit objects per pair. Bare field names (no
+ * colon) are kept as strings since ES accepts them directly.
+ *
+ * Examples:
+ *   "views"                       → "views"
+ *   "views:desc"                  → [{ views: "desc" }]
+ *   "views,timestamp"             → ["views", "timestamp"]
+ *   "views:desc,timestamp:asc"    → [{ views: "desc" }, { timestamp: "asc" }]
+ *   "views,timestamp:desc"        → ["views", { timestamp: "desc" }]
+ */
+function parseSortPairs (value: string): string | Array<string | Record<string, string>> {
+  const parts = parseFieldList(value)
+  if (parts.length === 0) return value
+  const transformed = parts.map((part): string | Record<string, string> => {
+    const colonIdx = part.indexOf(':')
+    if (colonIdx === -1) return part
+    return { [part.slice(0, colonIdx).trim()]: part.slice(colonIdx + 1).trim() }
+  })
+  if (transformed.length === 1 && typeof transformed[0] === 'string') return transformed[0]
+  return transformed
+}
+
+/**
  * Creates a parseArg function that accumulates repeated string flag values with comma separation.
  * Uses Commander's option value source tracking: first CLI occurrence replaces any default,
  * subsequent CLI occurrences append with a comma separator.
@@ -692,6 +718,15 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
             cliInput[arg.schemaKey] = raw
           }
         } else if (
+          arg.parseStyle === 'sort-pairs' &&
+          arg.foundIn === 'body' &&
+          typeof raw === 'string'
+        ) {
+          // ES `Sort` body fields: the help text advertises `<field>:<direction>` pairs
+          // (the URL query grammar), but in the request body ES expects
+          // `[{"field": "direction"}, ...]`. Parse the colon syntax into that shape.
+          cliInput[arg.schemaKey] = parseSortPairs(raw)
+        } else if (
           arg.type === 'string' &&
           arg.acceptsArrayForm === true &&
           arg.foundIn === 'body' &&
@@ -764,8 +799,13 @@ export function defineCommand<T extends z.ZodType> (config: CommandConfig<T>): O
       // JSON (e.g. --query, --mappings) whose full DSL (including shorthand forms)
       // is too complex for client-side Zod schemas. The CLI already validates that the
       // JSON is syntactically correct; Elasticsearch validates the semantics server-side.
+      //
+      // Also relax `sort-pairs` fields: the CLI rewrites `field:direction` strings into
+      // `[{field: 'direction'}]` objects, which the strict `Sort` schema (SortOptions has
+      // a fixed set of reserved keys like `_score`) would otherwise reject.
       const jsonBodyFields = schemaArgs.filter(
-        a => (a.type === 'object' || a.type === 'array') && a.foundIn === 'body'
+        a => a.foundIn === 'body' &&
+             (a.type === 'object' || a.type === 'array' || a.parseStyle === 'sort-pairs')
       )
       if (jsonBodyFields.length > 0 && validationSchema instanceof z.ZodObject) {
         const overrides: Record<string, z.ZodType> = {}

--- a/src/lib/schema-args.ts
+++ b/src/lib/schema-args.ts
@@ -36,6 +36,15 @@ export interface SchemaArgDefinition {
    * the destination demands it (e.g. JSON request bodies).
    */
   acceptsArrayForm?: boolean
+
+  /**
+   * Marks args whose CLI string value needs a non-trivial transformation before reaching the wire.
+   *
+   * - `'sort-pairs'`: ES `Sort` fields — the help text advertises `<field>:<direction>` pairs (the URL
+   *   query grammar), but the schema routes them through the request body, where ES expects
+   *   `[{"field": "direction"}, ...]`. The CLI parses the colon syntax into that shape.
+   */
+  parseStyle?: 'sort-pairs'
 }
 
 /** Valid routing destinations for a parameter derived from `found_in` Zod metadata. */
@@ -148,6 +157,7 @@ export function extractSchemaArgs (schema: unknown): SchemaArgDefinition[] {
 
     const foundIn = extractFoundIn(fieldSchema as z.ZodType)
     const acceptsArrayForm = type !== 'array' && schemaAcceptsArrayForm(fieldSchema as z.ZodType)
+    const parseStyle = schemaContainsId(fieldSchema as z.ZodType, 'Sort') ? 'sort-pairs' as const : undefined
     return {
       schemaKey: key,
       cliFlag: toKebabCase(key),
@@ -156,8 +166,50 @@ export function extractSchemaArgs (schema: unknown): SchemaArgDefinition[] {
       defaultValue,
       description,
       ...(foundIn !== undefined ? { foundIn } : {}),
-      ...(acceptsArrayForm ? { acceptsArrayForm: true } : {})
+      ...(acceptsArrayForm ? { acceptsArrayForm: true } : {}),
+      ...(parseStyle !== undefined ? { parseStyle } : {})
     }
+  })
+}
+
+/**
+ * Walks `field` through `optional`, `default`, `lazy`, and `union` wrappers, returning true
+ * if `predicate` matches any visited node. The `seen` set breaks cycles in self-referential
+ * lazy schemas (e.g. `z.lazy(() => Foo)` where `Foo` references itself).
+ *
+ * Note: evaluating `lazy.getter()` forces lazy-schema evaluation; the schemas this file
+ * inspects make that unavoidable for predicates that depend on a lazy's inner shape.
+ */
+function anyNode (field: z.ZodType, predicate: (node: z.ZodType) => boolean): boolean {
+  const seen = new Set<z.ZodType>()
+  function walk (node: z.ZodType): boolean {
+    if (seen.has(node)) return false
+    seen.add(node)
+    if (predicate(node)) return true
+    const def = node.def as ZodFieldDef
+    if (def.type === 'optional' || def.type === 'default') {
+      return def.innerType != null && walk(def.innerType as unknown as z.ZodType)
+    }
+    if (def.type === 'lazy' && typeof def.getter === 'function') {
+      return walk(def.getter())
+    }
+    if (def.type === 'union' && Array.isArray(def.options)) {
+      return def.options.some((o) => walk(o))
+    }
+    return false
+  }
+  return walk(field)
+}
+
+/**
+ * Returns true when `field`'s schema carries the given `id` in its Zod metadata anywhere
+ * in its wrapper chain. Used to identify named schema shapes like `Sort` that need
+ * destination-specific transformations.
+ */
+function schemaContainsId (field: z.ZodType, id: string): boolean {
+  return anyNode(field, (n) => {
+    const meta = n.meta() as Record<string, unknown> | null | undefined
+    return meta?.id === id
   })
 }
 
@@ -170,18 +222,7 @@ export function extractSchemaArgs (schema: unknown): SchemaArgDefinition[] {
  * bodies (only in querystrings and URL paths).
  */
 function schemaAcceptsArrayForm (field: z.ZodType): boolean {
-  const def = field.def as ZodFieldDef
-  if (def.type === 'array') return true
-  if ((def.type === 'optional' || def.type === 'default') && def.innerType != null) {
-    return schemaAcceptsArrayForm(def.innerType as unknown as z.ZodType)
-  }
-  if (def.type === 'lazy' && typeof def.getter === 'function') {
-    return schemaAcceptsArrayForm(def.getter())
-  }
-  if (def.type === 'union' && Array.isArray(def.options)) {
-    return def.options.some((o) => schemaAcceptsArrayForm(o))
-  }
-  return false
+  return anyNode(field, (n) => (n.def as ZodFieldDef).type === 'array')
 }
 
 /**

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -3199,6 +3199,70 @@ describe('repeated flags', () => {
     const help = cmd.helpInformation()
     assert.doesNotMatch(help, /--input-file with a JSON array/)
   })
+
+  describe('Sort body args (id="Sort") -- field:direction parsing (#330)', () => {
+    // Mirrors the ES `Sort` schema shape: union(union(Field, SortOptions), array(...)) tagged with id="Sort".
+    const SortOptions = z.object({ _score: z.string().optional() }).meta({ id: 'SortOptions' })
+    const SortCombinations = z.union([z.string(), SortOptions]).meta({ id: 'SortCombinations' })
+    const Sort = z.union([SortCombinations, z.array(SortCombinations)]).meta({ id: 'Sort' })
+
+    function makeCmd (captured: { value?: unknown }): OpaqueCommandHandle {
+      const schema = z.object({
+        sort: z.lazy(() => Sort).describe('A comma-separated list of <field>:<direction> pairs.').optional().meta({ found_in: 'body' }),
+      })
+      return defineCommand({
+        name: 'search',
+        description: 'Search',
+        input: schema,
+        handler: (parsed) => { captured.value = parsed.input; return {} },
+      })
+    }
+
+    it('single field:direction is sent as [{field: direction}]', async () => {
+      const captured: { value?: unknown } = {}
+      await invokeAsync(makeCmd(captured), ['--sort', 'views:desc'])
+      assert.deepEqual(captured.value, { sort: [{ views: 'desc' }] })
+    })
+
+    it('bare field name with no colon is preserved as a string', async () => {
+      const captured: { value?: unknown } = {}
+      await invokeAsync(makeCmd(captured), ['--sort', 'views'])
+      assert.deepEqual(captured.value, { sort: 'views' })
+    })
+
+    it('multiple field:direction pairs become an array of objects', async () => {
+      const captured: { value?: unknown } = {}
+      await invokeAsync(makeCmd(captured), ['--sort', 'views:desc,timestamp:asc'])
+      assert.deepEqual(captured.value, { sort: [{ views: 'desc' }, { timestamp: 'asc' }] })
+    })
+
+    it('mixed bare and pair entries are preserved per entry', async () => {
+      const captured: { value?: unknown } = {}
+      await invokeAsync(makeCmd(captured), ['--sort', 'views,timestamp:desc'])
+      assert.deepEqual(captured.value, { sort: ['views', { timestamp: 'desc' }] })
+    })
+
+    it('dotted field names are kept whole', async () => {
+      const captured: { value?: unknown } = {}
+      await invokeAsync(makeCmd(captured), ['--sort', 'user.name:asc'])
+      assert.deepEqual(captured.value, { sort: [{ 'user.name': 'asc' }] })
+    })
+
+    it('non-Sort string fields are unaffected by the colon transform', async () => {
+      let captured: unknown
+      const schema = z.object({
+        q: z.string().optional().describe('Query').meta({ found_in: 'query' }),
+      })
+      const cmd = defineCommand({
+        name: 'search',
+        description: 'Search',
+        input: schema,
+        handler: (parsed) => { captured = parsed.input; return {} },
+      })
+      await invokeAsync(cmd, ['--q', 'k:v'])
+      assert.deepEqual(captured, { q: 'k:v' })
+    })
+  })
 })
 
 describe('defineCommand schema input - passthrough validation', () => {


### PR DESCRIPTION
## Summary

Fixes #330. `elastic es search --sort views:desc` was sending `{"sort": "views:desc"}` in the request body, which Elasticsearch then rejected with `No mapping found for [views:desc]` because ES only parses the `field:direction` colon syntax in URL query strings, not in body sort fields.

The CLI help text advertises the URL-query grammar ("A comma-separated list of `<field>:<direction>` pairs.") but the schema routes the value through the body, where ES expects `[{"views": "desc"}, ...]` instead.

## What changed

- **`src/lib/schema-args.ts`**: Added a `parseStyle?: 'sort-pairs'` tag to `SchemaArgDefinition`. Any field whose Zod schema (walking through `optional`/`default`/`lazy`/`union` wrappers) carries `id: 'Sort'` in its metadata is tagged at registration time. To support this, extracted a shared `anyNode(field, predicate)` walker; `schemaContainsId` and the existing `schemaAcceptsArrayForm` now express their leaf condition as a one-line predicate against it (and `schemaAcceptsArrayForm` picks up cycle safety as a side effect).
- **`src/factory.ts`**: Added `parseSortPairs` (which reuses `parseFieldList` for the CSV split). In the schema-arg input collection, when `arg.parseStyle === 'sort-pairs'` and `foundIn === 'body'`, the CLI string is rewritten into the body shape ES expects. Bare field names round-trip as plain strings. The body-field Zod validation relaxation was extended to also cover `sort-pairs` fields, since the transformed `{field: 'direction'}` objects would otherwise fail the strict `SortOptions` schema (which only accepts reserved keys like `_score`).

### Examples

| Input | Output sent in body |
|---|---|
| `--sort views` | `"views"` |
| `--sort views:desc` | `[{"views": "desc"}]` |
| `--sort views,timestamp` | `["views", "timestamp"]` |
| `--sort views:desc,timestamp:asc` | `[{"views": "desc"}, {"timestamp": "asc"}]` |
| `--sort views,timestamp:desc` | `["views", {"timestamp": "desc"}]` |

## Verification

- `npm run build` — clean
- `npm run test:lint` — clean
- Full non-functional test suite (1068 tests) — pass, including 6 new tests under `Sort body args (id="Sort") -- field:direction parsing (#330)` covering single pair, bare field, multi-pair, mixed, dotted field names, and a negative control for non-Sort string fields.
- Verified the live `SearchRequest` schema produces `parseStyle: 'sort-pairs'` on the `sort` arg and that `buildRequestParams` emits `body: { sort: [{ views: "desc" }] }` for `--sort views:desc`.

## Notes for the reviewer

- The fix is scoped to body-routed Sort fields. Query-routed sort args (if any) are not touched, since ES parses the colon syntax natively there.
- Per-CLI-invocation cost is one `extractSchemaArgs` pass over the loaded command's top-level shape; the new `anyNode` walks are bounded by wrapper depth, not schema fan-out.
- `parseStyle` is a single-value string union today. If a second style appears (e.g. `'date-math'`), the shape scales; if not, this is a small amount of structure for one transform.
