### PR TITLE
fix(cloud): expose --name and --region-id flags on serverless project create commands

### DIFF
--- a/src/cloud/body-schemas.ts
+++ b/src/cloud/body-schemas.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { z } from 'zod'
+
+// Body Zod schemas for codegen-defined cloud APIs whose generated definition in
+// src/cloud/apis/*.ts omits the `body` field. Without these, the factory has no
+// fields to register as CLI flags. Keyed by the codegen command `name`.
+const projectCreateBody = z.object({
+  name: z.string()
+    .describe('Display name of the project')
+    .meta({ found_in: 'body' }),
+  region_id: z.string()
+    .describe('Region where the project is created (e.g. aws-us-east-1)')
+    .meta({ found_in: 'body' }),
+})
+
+export const cloudBodySchemas: ReadonlyMap<string, z.ZodObject<z.ZodRawShape>> = new Map([
+  ['create-elasticsearch-project', projectCreateBody],
+  ['create-observability-project', projectCreateBody],
+  ['create-security-project',      projectCreateBody],
+])

--- a/src/cloud/register.ts
+++ b/src/cloud/register.ts
@@ -11,6 +11,7 @@ import type { CloudApiDefinition, CloudPathParam, CloudQueryParam } from './type
 import { validateCloudApiDefinition } from './types.ts'
 import { allCloudApis } from './apis.ts'
 import { allServerlessApis } from './serverless-apis.ts'
+import { cloudBodySchemas } from './body-schemas.ts'
 import { createCloudHandler, isCreateProjectCommand } from './handler.ts'
 import {
   applyCredentialPolicy,
@@ -18,6 +19,12 @@ import {
   readCredentialPolicyOptions,
 } from './credentials.ts'
 import type { JsonValue, ParsedResult } from '../factory.ts'
+
+function applyBodyOverlay (def: CloudApiDefinition): CloudApiDefinition {
+  if (def.body != null) return def
+  const overlay = cloudBodySchemas.get(def.name)
+  return overlay != null ? { ...def, body: overlay } : def
+}
 
 /**
  * Builds the unified flat Zod schema for a Cloud API command.
@@ -381,11 +388,12 @@ async function wrapWithCredentialPolicy (
 export function registerCloudCommands(
   definitions: CloudApiDefinition[] = [...allCloudApis, ...allServerlessApis],
 ): OpaqueCommandHandle {
-  for (const def of definitions) {
+  const overlayed = definitions.map(applyBodyOverlay)
+  for (const def of overlayed) {
     validateCloudApiDefinition(def)
   }
 
-  const { promoted, hosted, serverless } = partitionDefinitions(definitions)
+  const { promoted, hosted, serverless } = partitionDefinitions(overlayed)
 
   const promotedGroups = buildFlatNamespaceGroups(promoted, 'Cloud', PROMOTED_NAMESPACES)
   const hostedGroup = buildHostedGroup(hosted)

--- a/src/cloud/request-builder.ts
+++ b/src/cloud/request-builder.ts
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { z } from 'zod'
 import type { CloudApiDefinition } from './types.ts'
 import type { CloudRequestParams } from '../lib/cloud-client.ts'
 import type { ParsedResult } from '../factory.ts'
@@ -81,20 +80,12 @@ function buildQuerystring(
 
 const BODY_METHODS: ReadonlySet<string> = new Set(['POST', 'PUT', 'PATCH'])
 
+// Forwards every input key not consumed by path or query routing, so declared
+// body fields and undeclared --input-file/stdin fields both flow through (#328, #86).
 function collectBody(
   def: CloudApiDefinition,
   input: Record<string, unknown>,
 ): Record<string, unknown> | undefined {
-  if (def.body instanceof z.ZodObject) {
-    const body: Record<string, unknown> = {}
-    for (const fieldName of Object.keys(def.body.shape as Record<string, unknown>)) {
-      if (input[fieldName] !== undefined) {
-        body[fieldName] = input[fieldName]
-      }
-    }
-    return Object.keys(body).length > 0 ? body : undefined
-  }
-
   if (!BODY_METHODS.has(def.method)) return undefined
 
   const reserved = new Set([

--- a/test/cloud/register.test.ts
+++ b/test/cloud/register.test.ts
@@ -233,6 +233,42 @@ describe('registerCloudCommands', () => {
       assert.ok(createCmd.options.map((o) => o.long).includes('--wait'))
       assert.ok(!listCmd.options.map((o) => o.long).includes('--wait'))
     })
+
+    it('exposes --name and --region-id flags on serverless project create commands (#328)', () => {
+      const defs: CloudApiDefinition[] = [
+        { name: 'create-elasticsearch-project',  namespace: 'elasticsearch-projects',  description: 'Create search project',        method: 'POST', path: '/api/v1/serverless/projects/elasticsearch' },
+        { name: 'create-observability-project',  namespace: 'observability-projects',  description: 'Create observability project', method: 'POST', path: '/api/v1/serverless/projects/observability' },
+        { name: 'create-security-project',       namespace: 'security-projects',       description: 'Create security project',      method: 'POST', path: '/api/v1/serverless/projects/security' },
+      ]
+      const group = registerCloudCommands(defs)
+      const projects = group.commands.find((c) => c.name() === 'serverless')!
+        .commands.find((c) => c.name() === 'projects')!
+      for (const typeName of ['search', 'observability', 'security']) {
+        const typeGroup = projects.commands.find((c) => c.name() === typeName)!
+        const createCmd = typeGroup.commands.find((c) => c.name() === 'create')!
+        const flags = createCmd.options.map((o) => o.long)
+        assert.ok(flags.includes('--name'),      `${typeName} create should expose --name`)
+        assert.ok(flags.includes('--region-id'), `${typeName} create should expose --region-id`)
+      }
+    })
+
+    it('does not add --name/--region-id flags to non-create project commands', () => {
+      const defs: CloudApiDefinition[] = [
+        { name: 'create-elasticsearch-project', namespace: 'elasticsearch-projects', description: 'Create', method: 'POST', path: '/api/v1/serverless/projects/elasticsearch' },
+        { name: 'list-elasticsearch-projects',  namespace: 'elasticsearch-projects', description: 'List',   method: 'GET',  path: '/api/v1/serverless/projects/elasticsearch' },
+        { name: 'get-elasticsearch-project',    namespace: 'elasticsearch-projects', description: 'Get',    method: 'GET',  path: '/api/v1/serverless/projects/elasticsearch/{id}', pathParams: [{ name: 'id', description: 'ID', required: true }] },
+      ]
+      const group = registerCloudCommands(defs)
+      const search = group.commands.find((c) => c.name() === 'serverless')!
+        .commands.find((c) => c.name() === 'projects')!
+        .commands.find((c) => c.name() === 'search')!
+      const listFlags = search.commands.find((c) => c.name() === 'list')!.options.map((o) => o.long)
+      const getFlags  = search.commands.find((c) => c.name() === 'get')!.options.map((o) => o.long)
+      assert.ok(!listFlags.includes('--name'),      'list must not expose --name')
+      assert.ok(!listFlags.includes('--region-id'), 'list must not expose --region-id')
+      assert.ok(!getFlags.includes('--name'),       'get must not expose --name')
+      assert.ok(!getFlags.includes('--region-id'),  'get must not expose --region-id')
+    })
   })
 
   describe('validation', () => {

--- a/test/cloud/request-builder.test.ts
+++ b/test/cloud/request-builder.test.ts
@@ -217,4 +217,27 @@ describe('buildCloudRequestParams', () => {
     const result = buildCloudRequestParams(def, parsed({ id: 'abc', extra: 'value' }))
     assert.equal(result.body, undefined)
   })
+
+  it('merges declared body schema with passthrough of additional input fields (#328)', () => {
+    const def: CloudApiDefinition = {
+      name: 'create-elasticsearch-project',
+      namespace: 'elasticsearch-projects',
+      description: 'Create',
+      method: 'POST',
+      path: '/api/v1/serverless/projects/elasticsearch',
+      body: z.object({ name: z.string(), region_id: z.string() }),
+    }
+    const result = buildCloudRequestParams(def, parsed({
+      name: 'demo',
+      region_id: 'aws-us-east-1',
+      alias: 'demo-alias',
+      metadata: { team: 'platform' },
+    }))
+    assert.deepEqual(result.body, {
+      name: 'demo',
+      region_id: 'aws-us-east-1',
+      alias: 'demo-alias',
+      metadata: { team: 'platform' },
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Adds `--name` and `--region-id` flags to the three serverless project create commands. Closes #328.

- `elastic cloud serverless projects search create`
- `elastic cloud serverless projects observability create`
- `elastic cloud serverless projects security create`

Before this change, those commands exposed only `--input-file`, `--wait`, `--save-as`, etc., so creating a project required writing a JSON file just to set two scalars. Now:

```
elastic cloud serverless projects search create \
  --name cli-demo --region-id aws-us-east-1 --wait --save-as cli-demo
```

## Why

`AGENTS.md` requires that every top-level body field have a kebab-case CLI flag. The upstream `elastic/elastic-client-generator-js` doesn't yet emit body schemas in `src/cloud/apis/*.ts`, so the factory had nothing to register. Editing those files isn't viable (they're wiped by `npm run codegen cloud`).

## How

- New `src/cloud/body-schemas.ts` — hand-maintained overlay mapping codegen command name → Zod body schema. Three entries (one per project type), each declaring `name` and `region_id` with `.describe()` + `.meta({ found_in: 'body' })`, matching the convention used in `src/es/apis/*`.
- `src/cloud/register.ts` — `applyBodyOverlay(def)` helper applied to every definition in `registerCloudCommands` before validation and command building.
- `src/cloud/request-builder.ts` — `collectBody` unified into a single passthrough path so declared body fields and undeclared `--input-file`/stdin keys both flow into the request body. Preserves the issue #86 passthrough behavior alongside the new declared schemas.

Scope is intentionally minimum (`name` + `region_id` only). Optional fields (`alias`, `metadata`, `optimized_for`, `product_types`) continue to flow through via `--input-file`/stdin. Broader systematic coverage of every POST/PUT/PATCH cloud endpoint should happen upstream in the generator.

## Test plan

- [x] `npm run test:unit` — 1178/1178 pass (added 2 register tests + 1 request-builder test for #328)
- [x] `npm run test:lint` — clean
- [x] `npm run build` — green
- [x] `node dist/cli.js cloud serverless projects search create --help` shows `--name <string>` (required) and `--region-id <string>` (required)
- [x] Same verified for `observability` and `security` aliases
- [x] `--help --json` JSON Schema includes `"required":["name","region_id"]`
- [x] Missing `--name`/`--region-id` produces a clean validation error
- [x] `echo '{"name":"demo","region_id":"aws-us-east-1","alias":"x","metadata":{"team":"y"}}' | … --dry-run` still validates (passthrough preserved)
