### PR TITLE
ci: drop obsolete --no-eslintrc megalinter override

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -22,13 +22,13 @@ PRE_COMMANDS:
   - command: "NODE_ENV=development npm ci --ignore-scripts"
     cwd: "workspace"
 
-# Use project's ESLint 10 (flat config, --no-eslintrc removed in v9+)
+# Use project's ESLint 10 (flat config). Megalinter v9.5+ EslintLinter strips
+# --no-eslintrc itself; declaring it under TYPESCRIPT_ES_COMMAND_REMOVE_ARGUMENTS
+# now crashes the run (ValueError: x not in list).
 TYPESCRIPT_ES_CLI_EXECUTABLE:
   - "node"
   - "node_modules/.bin/eslint"
 TYPESCRIPT_ES_CONFIG_FILE: eslint.config.js
-TYPESCRIPT_ES_COMMAND_REMOVE_ARGUMENTS:
-  - "--no-eslintrc"
 
 # Global exclusions
 FILTER_REGEX_EXCLUDE: "(node_modules/|dist/|build/|\\.git/)"


### PR DESCRIPTION
## Summary

Megalinter v9.5.0's `EslintLinter.build_lint_command` now strips `--no-eslintrc` itself for ESLint v10 compatibility. The parent `Linter.build_lint_command` then runs `TYPESCRIPT_ES_COMMAND_REMOVE_ARGUMENTS` through an **unguarded** `cmd.remove(arg)` loop ([Linter.py:1519](https://github.com/oxsecurity/megalinter/blob/v9.5.0/megalinter/Linter.py#L1519)), so the override that used to be a no-op now raises:

```
ValueError: list.remove(x): x not in list
```

…and the whole megalinter run crashes during init. Reproduces on every PR since [#347](https://github.com/elastic/cli/pull/347) bumped megalinter to v9.5.0.

## Fix

Drop `TYPESCRIPT_ES_COMMAND_REMOVE_ARGUMENTS: ["--no-eslintrc"]` from `.mega-linter.yml`. The arg is already removed by megalinter's own EslintLinter, so we don't need to re-strip it.

## Test plan

- [ ] CI passes (megalinter run completes without `ValueError`)

## Upstream note

The unguarded `cmd.remove` in megalinter is a latent bug — any repo with `TYPESCRIPT_ES_COMMAND_REMOVE_ARGUMENTS: ["--no-eslintrc"]` will hit this on v9.5.0+. Worth filing upstream as a follow-up.
