### PR TITLE
docs(agents): correct SPDX header opener to single-asterisk /*

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,11 +64,13 @@ All requirements below are non-negotiable and enforced at review time.
 All code files MUST start with:
 
 ```
-/**
+/*
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
 ```
+
+Note the single-asterisk `/*` opener — `scripts/check-spdx` rejects the JSDoc-style `/**` form.
 
 ### Standards
 


### PR DESCRIPTION
## Summary

- `AGENTS.md` documented the SPDX header with a JSDoc-style `/**` opener, but `scripts/check-spdx` only accepts the plain `/*` form, so contributors who follow the doc get failed CI runs.
- Flips the example to `/*` and adds a one-line pointer to `scripts/check-spdx` so the enforced convention is discoverable from the doc.

## Test plan

- [ ] `bash scripts/check-spdx` still exits 0 on `main` after merge.

Made with [Cursor](https://cursor.com)