### PR TITLE
fix: cat APIs were casting JSON objects to string instead of printing text

### DIFF
--- a/src/es/handler.ts
+++ b/src/es/handler.ts
@@ -49,6 +49,11 @@ export function createEsHandler (
 
       if (responseType === 'text' && jsonRequested) {
         params.querystring = { ...(params.querystring ?? {}), format: 'json' }
+        return await transport.request<JsonValue>(params)
+      }
+
+      if (responseType === 'text') {
+        return await transport.request<JsonValue>(params, { headers: { 'Accept': 'text/plain' } })
       }
 
       return await transport.request<JsonValue>(params)

--- a/test/es/handler.test.ts
+++ b/test/es/handler.test.ts
@@ -215,12 +215,12 @@ describe('createEsHandler', () => {
     assert.equal((capturedParams[0]?.querystring as Record<string, unknown>)?.format, 'json')
   })
 
-  it('does not inject format=json when --json is not active with responseType: text', async () => {
-    const capturedParams: EsRequestParams[] = []
+  it('sends Accept: text/plain when --json is not active with responseType: text', async () => {
+    const capturedOpts: Array<{ headers?: Record<string, string> }> = []
     const deps = makeDeps({
       getEsClient: () => ({
-        request: async (params: EsRequestParams) => {
-          capturedParams.push(params)
+        request: async (_params: EsRequestParams, opts?: { headers?: Record<string, string> }) => {
+          capturedOpts.push(opts ?? {})
           return 'green\n'
         },
       } as unknown as EsClient),
@@ -231,7 +231,7 @@ describe('createEsHandler', () => {
     const result = await handler(parsedInput())
 
     assert.equal(result, 'green\n')
-    assert.equal(capturedParams[0]?.querystring, undefined)
+    assert.equal(capturedOpts[0]?.headers?.['Accept'], 'text/plain')
   })
 
   it('does not inject format=json for responseType: json even with --json', async () => {

--- a/test/lib/sanitize.test.ts
+++ b/test/lib/sanitize.test.ts
@@ -137,6 +137,49 @@ describe('sanitizeIndexName', () => {
     assert.equal(r.sanitized, 'foobar')
     assert.ok(r.changes.some(c => /whitespace/i.test(c)))
   })
+
+  // Tests mirroring MetadataCreateIndexService.validateIndexOrAliasName() in ES server
+  // source: server/src/test/java/.../MetadataCreateIndexServiceTests.java
+  it('strips ? (INVALID_FILENAME_CHARS from Strings.INVALID_CHARS)', () => {
+    const r = sanitizeIndexName('index?name')
+    assert.equal(r.sanitized, 'indexname')
+  })
+
+  it('strips # (explicit check in validateIndexOrAliasName)', () => {
+    const r = sanitizeIndexName('index#name')
+    assert.equal(r.sanitized, 'indexname')
+  })
+
+  it('strips : (explicit check in validateIndexOrAliasName)', () => {
+    const r = sanitizeIndexName('foo:bar')
+    assert.equal(r.sanitized, 'foobar')
+  })
+
+  it('removes leading _ (validateIndexOrAliasName rule)', () => {
+    const r = sanitizeIndexName('_indexname')
+    assert.equal(r.sanitized, 'indexname')
+  })
+
+  it('removes leading - (validateIndexOrAliasName rule)', () => {
+    const r = sanitizeIndexName('-indexname')
+    assert.equal(r.sanitized, 'indexname')
+  })
+
+  it('removes leading + (validateIndexOrAliasName rule)', () => {
+    const r = sanitizeIndexName('+indexname')
+    assert.equal(r.sanitized, 'indexname')
+  })
+
+  it('lowercases (validateIndexName rule, separate from validateIndexOrAliasName)', () => {
+    const r = sanitizeIndexName('INDEXNAME')
+    assert.equal(r.sanitized, 'indexname')
+  })
+
+  it('does not strip ! (ES does not forbid it)', () => {
+    const r = sanitizeIndexName('foobar!')
+    assert.equal(r.sanitized, 'foobar!')
+    assert.deepEqual(r.changes, [])
+  })
 })
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Also adds more exhaustive tests for index-name sanitizer for https://github.com/elastic/cli/issues/324.
