### PR TITLE
fix: duplicate NDJSON content type in bulk ingest

### DIFF
--- a/src/es/helpers/bulk-ingest.ts
+++ b/src/es/helpers/bulk-ingest.ts
@@ -145,8 +145,7 @@ async function sendBatch (
 ): Promise<{ errors: number, total: number }> {
   const path = index != null ? `/${encodeURIComponent(index)}/_bulk` : '/_bulk'
   const result = await transport.request(
-    { method: 'POST', path, body: ndjsonBody, bulkBody: ndjsonBody },
-    { headers: { 'content-type': 'application/x-ndjson' } }
+    { method: 'POST', path, body: ndjsonBody, bulkBody: ndjsonBody }
   ) as { errors?: boolean, items?: Array<Record<string, { status?: number }>> }
 
   let errorCount = 0

--- a/test/es/helpers/bulk-ingest.test.ts
+++ b/test/es/helpers/bulk-ingest.test.ts
@@ -255,7 +255,7 @@ describe('bulk-ingest command', () => {
     assert.equal(error.code, 'missing_config')
   })
 
-  it('sends content-type application/x-ndjson header', async () => {
+  it('delegates the NDJSON content-type to EsClient bulkBody handling', async () => {
     const tmpDir = mkdtempSync(join(tmpdir(), 'bulk-test-'))
     writeFileSync(join(tmpDir, 'data.json'), '[{"a":1}]')
 
@@ -267,9 +267,8 @@ describe('bulk-ingest command', () => {
       '--json'
     ], makeDeps(transport))
 
-    const opts = requests[0]!.opts as Record<string, unknown>
-    const headers = opts.headers as Record<string, string>
-    assert.equal(headers['content-type'], 'application/x-ndjson')
+    assert.equal(requests[0]!.params.bulkBody, requests[0]!.params.body)
+    assert.equal(requests[0]!.opts, undefined)
   })
 
   it('returns empty summary for zero documents', async () => {


### PR DESCRIPTION
Summary:
- remove the explicit lowercase `content-type` header from `bulk-ingest` bulk requests
- keep using `bulkBody` so `EsClient` supplies `Content-Type: application/x-ndjson` once
- update the focused unit test to guard against passing helper-level header overrides

Verification:
- `node --import tsx/esm --test test\es\helpers\bulk-ingest.test.ts`
- `npm run test:lint`
- `npm run build`

Closes #361.

This was implemented with Codex assistance, with the patch kept focused and manually reviewed against the issue repro.