### PR TITLE
fix(config): dedupe inline secret warning

### DIFF
--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -45,6 +45,13 @@ const CONFIG_FILE_NAMES = ['.elasticrc', '.elasticrc.json', '.elasticrc.yaml', '
 /** Environment variable that overrides config file discovery with an explicit path. */
 const ENV_CONFIG_FILE = 'ELASTIC_CLI_CONFIG_FILE'
 
+let looseInlineSecretWarningEmitted = false
+
+/** @internal test seam */
+export function _testResetLooseInlineSecretWarning (): void {
+  looseInlineSecretWarningEmitted = false
+}
+
 /**
  * Searches a single directory for the first readable config file.
  *
@@ -190,6 +197,7 @@ export function resolveContext (config: ConfigFile, contextName: string, profile
  */
 async function warnOnLoosePermsIfInlineSecrets (path: string, raw: unknown): Promise<void> {
   if (process.platform === 'win32') return
+  if (looseInlineSecretWarningEmitted) return
   try {
     const st = await stat(path)
     const mode = st.mode & 0o777
@@ -199,6 +207,7 @@ async function warnOnLoosePermsIfInlineSecrets (path: string, raw: unknown): Pro
       `Warning: config file "${path}" has permissions ${mode.toString(8).padStart(3, '0')} and contains inline secrets. ` +
       'Run `chmod 0600 ' + path + '` to restrict access, or migrate secrets into the OS keychain via `elastic config context edit`.\n'
     )
+    looseInlineSecretWarningEmitted = true
   } catch {
     // ignore
   }

--- a/test/config/loader.test.ts
+++ b/test/config/loader.test.ts
@@ -5,10 +5,10 @@
 
 import { describe, it, before, after } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises'
+import { chmod, mkdtemp, writeFile, rm, mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { loadConfigFile, discoverConfigFile, resolveContext, resolveEffectiveCommands, loadConfig } from '../../src/config/loader.ts'
+import { loadConfigFile, discoverConfigFile, resolveContext, resolveEffectiveCommands, loadConfig, _testResetLooseInlineSecretWarning } from '../../src/config/loader.ts'
 import type { ConfigFile, ResolvedConfig } from '../../src/config/types.ts'
 
 // ---------------------------------------------------------------------------
@@ -198,6 +198,39 @@ describe('loadConfig -- default current_context', () => {
         kibana: { url: 'http://localhost:5601', auth: { api_key: 'kb-key-123' } },
       },
     } satisfies ResolvedConfig)
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('loadConfig -- inline secret permission warning', () => {
+  it('emits the loose-permission inline-secret warning once per process', { skip: process.platform === 'win32' }, async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'elastic-cli-warning-'))
+    const configPath = join(tmpDir, '.elasticrc.yml')
+    await writeFile(configPath, VALID_CONFIG_YAML)
+    await chmod(configPath, 0o644)
+
+    const originalWrite = process.stderr.write.bind(process.stderr)
+    const chunks: string[] = []
+    process.stderr.write = ((chunk: string | Uint8Array) => {
+      chunks.push(typeof chunk === 'string' ? chunk : chunk.toString())
+      return true
+    }) as typeof process.stderr.write
+
+    _testResetLooseInlineSecretWarning()
+    try {
+      const first = await loadConfig({ configPath })
+      const second = await loadConfig({ configPath })
+      assert.equal(first.ok, true)
+      assert.equal(second.ok, true)
+    } finally {
+      process.stderr.write = originalWrite
+      _testResetLooseInlineSecretWarning()
+      await rm(tmpDir, { recursive: true })
+    }
+
+    const warnings = chunks.join('').match(/contains inline secrets/g) ?? []
+    assert.equal(warnings.length, 1)
   })
 })
 


### PR DESCRIPTION
## Summary
- emit the inline-secrets loose-permission warning once per process
- preserve the existing warning when inline secrets are found in a config file with loose permissions
- add focused loader coverage for repeated `loadConfig` calls

Closes #314.

## Verification
- `npm run build`
- `npm run test:lint`
- `node --import tsx/esm --test test/config/loader.test.ts` (passes on Windows; the new POSIX permission assertion is skipped on Windows)
- `npm run test:license`
- `git diff --check`

I also ran `npm test`; it built successfully and reached 1256 passing tests, but one existing Windows-local bash generator test failed in `codegen/functional/test/generator.test.ts` while reading missing stderr from the bash parser process. That failure is outside this config loader change.

This was implemented with Codex assistance, with the patch kept focused and manually reviewed against the warning path.