### PR TITLE
fix(es): accept array _source in search bodies

### DIFF
--- a/packages/es-schemas/src/search.ts
+++ b/packages/es-schemas/src/search.ts
@@ -592,7 +592,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), Fields, SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface SearchInnerHitsShape {

--- a/test/es/search-schema.test.ts
+++ b/test/es/search-schema.test.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { SearchRequest } from '@elastic/es-schemas/search.js'
+
+describe('SearchRequest schema', () => {
+  it('accepts all Elasticsearch _source request body forms', () => {
+    for (const source of [
+      true,
+      'title',
+      ['title', 'author', 'views'],
+      { includes: ['title', 'author'], excludes: ['body'] },
+    ]) {
+      const result = SearchRequest.safeParse({ size: 3, _source: source })
+      assert.equal(result.success, true)
+    }
+  })
+})


### PR DESCRIPTION
Summary:
- allow the search request body `_source` schema to accept field-name strings/arrays, matching Elasticsearch's accepted request shape
- add a focused regression test for boolean, string, array, and object `_source` forms

Verification:
- `npm run build`
- `node --max-old-space-size=8192 --import tsx/esm --test test/es/search-schema.test.ts`
- `npx eslint packages/es-schemas/src/search.ts test/es/search-schema.test.ts` (schema file is ignored by the repo's lint config; new test had no errors)
- `git diff --check`
- dry-run repro with temp config: `node dist/cli.js --config-file <tmp> stack es search --index cli-demo-blog --input-file <tmp-body> --dry-run --json`

I also ran `npm test`; it reached 1407 passing tests and failed one existing Windows-environment check because `bash` is not available (`codegen/functional/test/generator.test.ts`, `bash -n` spawn result had no stderr). The focused build/test path above passed.

Note: `packages/es-schemas/src/search.ts` is generated in this repo, but the public generator repository referenced in CONTRIBUTING was not resolvable from GitHub while preparing this patch. If you prefer this to land through the generator/source pipeline instead, happy to redirect the change there.

Closes #331

This was implemented with Codex assistance, with the final patch and verification reviewed manually.