### PR TITLE
ci: add AI backport resolver and auto-pr workflows

### DIFF
--- a/.github/auto-pr-context.md
+++ b/.github/auto-pr-context.md
@@ -1,0 +1,19 @@
+# Auto PR context — elastic/cli
+
+This repo is the Elastic CLI tool. Source code lives under `packages/` with one package per CLI command group.
+
+## File layout
+
+- `packages/` — CLI command implementations (TypeScript)
+- `codegen/` — code generation utilities
+- `docs/` — documentation
+
+## Fix conventions
+
+- Only modify files under `packages/` unless the issue explicitly mentions another directory
+- Follow existing TypeScript patterns in the affected package
+- Do not modify generated files or `dist/`
+
+## Search hints
+
+Command names, flag names, or error messages in the issue body map to files in `packages/`.

--- a/.github/auto-pr-context.md
+++ b/.github/auto-pr-context.md
@@ -17,3 +17,7 @@ This repo is the Elastic CLI tool. Source code lives under `packages/` with one 
 ## Search hints
 
 Command names, flag names, or error messages in the issue body map to files in `packages/`.
+
+## Post-fix steps
+
+After making any changes that add, remove, or update npm dependencies (i.e. changes to `package.json`), run `node scripts/generate-notice.mjs` to regenerate `NOTICE.txt` and include it in the same commit.

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,0 +1,14 @@
+name: Auto PR
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  auto-pr:
+    if: startsWith(github.event.label.name, 'auto-pr')
+    uses: elastic/clients-team-automations/.github/workflows/auto-pr.yml@main
+    with:
+      issue_number: ${{ github.event.issue.number }}
+      search_directory: packages
+    secrets:
+      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}

--- a/.github/workflows/regenerate-notice.yml
+++ b/.github/workflows/regenerate-notice.yml
@@ -1,0 +1,47 @@
+name: Regenerate NOTICE.txt
+# Runs on PRs opened by bots (Renovate, Dependabot) that update dependencies.
+# Re-generates NOTICE.txt so it reflects the updated dependency tree.
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - package.json
+      - package-lock.json
+
+jobs:
+  regenerate:
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.event.pull_request.user.login, 'elastic-renovate') ||
+      startsWith(github.event.pull_request.user.login, 'renovate') ||
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ github.token }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Regenerate NOTICE.txt
+        run: node scripts/generate-notice.mjs
+
+      - name: Commit if changed
+        run: |
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          if git diff --quiet NOTICE.txt; then
+            echo "NOTICE.txt is already up to date."
+          else
+            git add NOTICE.txt
+            git commit -m "chore: regenerate NOTICE.txt"
+            git push
+          fi

--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -1,0 +1,14 @@
+name: AI Backport Resolver
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  resolve:
+    uses: elastic/clients-team-automations/.github/workflows/ai-backport-resolver.yml@main
+    with:
+      comment_body: ${{ github.event.comment.body }}
+      comment_user: ${{ github.event.comment.user.login }}
+      pr_number: ${{ github.event.issue.number }}
+    secrets:
+      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1133,7 +1133,7 @@ THIS SOFTWARE.
 
 
 ------------------------------------------------------------------------
-yaml@2.8.4
+yaml@2.9.0
 License: ISC
 Repository: https://github.com/eemeli/yaml
 Publisher: Eemeli Aro <eemeli@gmail.com>


### PR DESCRIPTION
Adds two AI automation workflows via `elastic/clients-team-automations`:

- **`resolve-conflicts.yml`** — AI backport conflict resolver. Triggers when the backport bot posts a failure comment; uses Claude to resolve cherry-pick conflicts and open a backport PR.
- **`auto-pr.yml`** — Issue-driven auto-fix. Triggers when an `auto-pr` label is added to an issue; uses Claude to find relevant files, implement the fix, and open a PR.

**Requires**: `LITELLM_API_KEY` secret in this repo.
**Companion PR**: https://github.com/elastic/clients-team-automations/pull/29